### PR TITLE
Fix: Fixed the Key for the Piracy Success Index

### DIFF
--- a/data/universe/factions/PSI.yml
+++ b/data/universe/factions/PSI.yml
@@ -1,4 +1,4 @@
-key: PHI
+key: PSI
 name: Piracy Success Index
 capital: Terra
 tags:


### PR DESCRIPTION
`PHI` -> `PSI`