### PR TITLE
Rat name fixes

### DIFF
--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/FWL DropShips 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/FWL DropShips 3067 (FMU).txt
@@ -21,7 +21,7 @@ Intruder (3056),2
 Hamilcar (3054),3
 Fury (3056),4
 Leopard (3056),5
-Union (3065),6
+Union-X (3065),6
 Leopard CV (3054),5
 Condor (3054),4
 Gazelle (3055),3

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Heavy/FWL Heavy Aerospace Fighters 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Heavy/FWL Heavy Aerospace Fighters 3067 (FMU).txt
@@ -20,10 +20,10 @@ Thunderbird TRB-D36,1
 Chippewa CHP-W5,2
 Hammerhead HMR-HD,3
 Riever F-100,4
-Eagle EGL-R5,5
+Eagle EGL-R6,5
 Riever F-100,6
 Riever F-700,5
-Riever F-100B,4
-Transgressor TR-14,3
-Riever F-100A,2
-Riever F-100A,1
+Riever F-100b,4
+Transgressor TR-13,3
+Riever F-100a,2
+Riever F-100a,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Light/FWL Light Aerospace Fighters 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Light/FWL Light Aerospace Fighters 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Light Aerospace Fighters 3067 (FMU)
-SYD Z1 Seydlitz,1
+Seydlitz SYD-Z1,1
 Centurion CNT-1D,2
-Cheetah F11-R,3
+Cheetah F-11-R,3
 Thrush TR-7,4
-F12S Cheetah,5
-F11RR Cheetah,6
-F14S Cheetah,5
-F12S Cheetah,4
-F10 Cheetah,3
-F10 Cheetah,2
-Sabre S-27,1
+Cheetah F-12-S,5
+Cheetah F-11-RR,6
+Cheetah F-14-S,5
+Cheetah F-12-S,4
+Cheetah F-10,3
+Cheetah F-10,2
+Sabre SB-27,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Medium/FWL Medium Aerospace Fighters 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Medium/FWL Medium Aerospace Fighters 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Medium Aerospace Fighters 3067 (FMU)
-Corsair CSR-V12M,1
+Corsair CSR-V12M 'Regulus',1
 Hellcat HCT-213,2
-F92 Stingray,3
-F92 Stingray,4
-F90 Stingray,5
-F94 Stingray,6
-F94 Stingray,5
+Stingray F-92,3
+Stingray F-92,4
+Stingray F-90,5
+Stingray F-94,6
+Stingray F-94,5
 Ironsides IRN-SD1,4
 Lightning LTN-G15,3
-TR11 Transit,2
-TR10 Transit,1
+Transit TR-11,2
+Transit TR-10,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech A 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech A 3067 (FMU).txt
@@ -18,12 +18,12 @@
 FWL Assault Mech A 3067 (FMU)
 Albatross ALB-3U,1
 Grand Crusader GRN-D-01,2
-Sirrocco SRC-3C,3
+Sirocco SRC-3C,3
 Stalker STK-5M,4
 Awesome AWS-9M,5
 BattleMaster BLR-5M,6
 Longbow LGB-7Q,5
 Atlas AS7-K,4
 Grand Titan T-IT-N10M,3
-Sirrocco SRC-3C,2
-Cerebus MR-V2,1
+Sirocco SRC-3C,2
+Cerberus MR-V2,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech B 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech B 3067 (FMU).txt
@@ -18,12 +18,12 @@
 FWL Assault Mech B 3067 (FMU)
 Albatross ALB-3U,1
 Longbow LGB-7Q,2
-CP 11-A Cyclops,3
+Cyclops CP-11-A,3
 Victor VTR-9K,4
-CP 11-A Cyclops,5
+Cyclops CP-11-A,5
 Stalker STK-5M,6
 BattleMaster BLR-5M,5
 Awesome AWS-9M,4
-Sirrocco SRC-3C,3
+Sirocco SRC-3C,3
 Banshee BNC-5S,2
-Cerebus MR-V2,1
+Cerberus MR-V2,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech C 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech C 3067 (FMU).txt
@@ -18,7 +18,7 @@
 FWL Assault Mech C 3067 (FMU)
 Awesome AWS-8Q,1
 Awesome AWS-9M,2
-Cyclops CP-11A,3
+Cyclops CP-11-A,3
 Stalker STK-5M,4
 Stalker STK-3F,5
 BattleMaster BLR-1G,6

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech D 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech D 3067 (FMU).txt
@@ -22,7 +22,7 @@ Awesome AWS-8Q,3
 Goliath GOL-1H,4
 Stalker STK-3F,5
 BattleMaster BLR-1G,6
-Cyclops CP-10Z,5
+Cyclops CP-10-Z,5
 Stalker STK-5M,4
 Victor VTR-9B,3
 Banshee BNC-3E,2

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech F 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech F 3067 (FMU).txt
@@ -24,6 +24,6 @@ Stalker STK-3F,5
 BattleMaster BLR-1G,6
 Stalker STK-3F,5
 Victor VTR-9B,4
-Cyclops CP-10Z,3
+Cyclops CP-10-Z,3
 Banshee BNC-3E,2
 Awesome AWS-9M,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech A 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech A 3067 (FMU).txt
@@ -26,4 +26,4 @@ Archer ARC-8M,5
 Orion ON2-M,4
 Yeoman YMN-6Y,3
 Tempest TMP-3M,2
-P1 Perseus,1
+Perseus P1,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech B 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech B 3067 (FMU).txt
@@ -25,5 +25,5 @@ Thunderbolt TDR-9M,6
 Ostsol OTL-7M,5
 Guillotine GLT-5M,4
 Tempest TMP-3M,3
-P1 Perseus,2
+Perseus P1,2
 Orion ON1-M,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech C 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech C 3067 (FMU).txt
@@ -21,7 +21,7 @@ Quickdraw QKD-4G,2
 Archer ARC-4M,3
 Archer ARC-8M,4
 Thunderbolt TDR-5S,5
-Orion ON-1M,6
+Orion ON1-M,6
 Marauder MAD-5M,5
 Warhammer WHM-6R,4
 Tempest TMP-3M,3

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech D 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech D 3067 (FMU).txt
@@ -22,7 +22,7 @@ Warhammer WHM-6R,3
 Marauder MAD-5M,4
 Thunderbolt TDR-5S,5
 Archer ARC-4M,6
-Orion ON-1K,5
+Orion ON1-K,5
 Crusader CRD-3R,4
 Quickdraw QKD-4G,3
 Marauder MAD-3M,2

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech F 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech F 3067 (FMU).txt
@@ -21,7 +21,7 @@ Warhammer WHM-6R,2
 Marauder MAD-3M,3
 Thunderbolt TDR-5S,4
 Archer ARC-2R,5
-Orion ON-1K,6
+Orion ON1-K,6
 Crusader CRD-3R,5
 Quickdraw QKD-4G,4
 Rifleman RFL-3N,3

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech A 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech A 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Light Mech A 3067 (FMU)
-FireStarter FS9-0,1
+Firestarter FS9-O,1
 Falcon Hawk FNHK-9K,2
-Tarantula ZPH-1A,3
+Tarantula ZPH-1,3
 Eagle EGL-1M,4
 Locust LCT-5M,5
 Stinger STG-5M,6
 Hermes HER-3S,5
 Hammer HMR-3M,4
 Spider SDR-7M,3
-1532 Jackal JA-KL,2
+Jackal JA-KL-1532,2
 Owens OW-1,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech B 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech B 3067 (FMU).txt
@@ -17,7 +17,7 @@
 
 FWL Light Mech B 3067 (FMU)
 Raven RVN-3L,1
-Tarantula ZPH-1A,2
+Tarantula ZPH-1,2
 Wasp WSP-3M,3
 Stinger STG-5M,4
 Stinger STG-5M,5

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech C 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech C 3067 (FMU).txt
@@ -16,8 +16,8 @@
 # affiliated with Microsoft.
 
 FWL Light Mech C 3067 (FMU)
-Tarantula ZPH-1A,1
-OstScout OTT-7J,2
+Tarantula ZPH-1,1
+Ostscout OTT-7J,2
 Stinger STG-5M,3
 Javelin JVN-10P,4
 Stinger STG-3R,5

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech A 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech A 3067 (FMU).txt
@@ -23,7 +23,7 @@ Wolverine WVR-7M,4
 Hermes II HER-5S,5
 Trebuchet TBT-7M,6
 Griffin GRF-5M,5
-B1-HND Bloodhound,4
-Wraith TR-1,3
+Bloodhound B1-HND,4
+Wraith TR1,3
 Vulcan VT-5M,2
 Blackjack BJ2-O,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech B 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech B 3067 (FMU).txt
@@ -17,13 +17,13 @@
 
 FWL Medium Mech B 3067 (FMU)
 Apollo APL-1M,1
-Scorpion SCP-10,2
+Scorpion SCP-1O,2
 Cicada CDA-3M,3
 Shadow Hawk SHD-7M,4
 Hermes II HER-5S,5
 Trebuchet TBT-7M,6
 Griffin GRF-5M,5
-Wolverine WVR-7,4
+Wolverine WVR-7D,4
 Griffin GRF-3M,3
-Wraith TR-1,2
+Wraith TR1,2
 Blackjack BJ2-O,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech C 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech C 3067 (FMU).txt
@@ -16,7 +16,7 @@
 # affiliated with Microsoft.
 
 FWL Medium Mech C 3067 (FMU)
-Scorpion SCP-10,1
+Scorpion SCP-1O,1
 Hunchback HBK-5M,2
 Apollo APL-1M,3
 Griffin GRF-3M,4
@@ -24,6 +24,6 @@ Phoenix Hawk PXH-3M,5
 Shadow Hawk SHD-5M,6
 Trebuchet TBT-7M,5
 Hermes II HER-5S,4
-Wraith TR-1,3
+Wraith TR1,3
 Shadow Hawk SHD-2H,2
 Griffin GRF-5M,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech D 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech D 3067 (FMU).txt
@@ -18,7 +18,7 @@
 FWL Medium Mech D 3067 (FMU)
 Griffin GRF-3M,1
 Trebuchet TBT-5J,2
-Phoenix Hawk PCH-3M,3
+Phoenix Hawk PXH-3M,3
 Hunchback HBK-4G,4
 Shadow Hawk SHD-2H,5
 Phoenix Hawk PXH-1,6

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Assault/FWL Assault Vehicles 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Assault/FWL Assault Vehicles 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Assault Vehicles 3067 (FMU)
-Schiltron,1
-Behemoth,2
-Schrek,3
-Partisan,4
-Demolisher,5
-Ontos,6
-Schrek,5
-Ontos,4
+Schiltron Mobile Fire-Support Platform Prime,1
+Behemoth Heavy Tank,2
+Schrek PPC Carrier,3
+Partisan Heavy Tank,4
+Demolisher Heavy Tank (Mk. I),5
+Ontos Heavy Tank,6
+Schrek PPC Carrier,5
+Ontos Heavy Tank,4
 Partisan Air Defense Tank (XL),3
-Behemoth,2
-SturmFeur,1
+Behemoth Heavy Tank,2
+SturmFeur Heavy Tank,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Heavy/FWL Heavy Vehicles 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Heavy/FWL Heavy Vehicles 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Heavy Vehicles 3067 (FMU)
-Zhukov,1
-Patton,2
-Po,3
-Manticore,4
-Pike,5
+Zhukov Heavy Tank,1
+Patton Tank,2
+Po Heavy Tank,3
+Manticore Heavy Tank,4
+Pike Support Vehicle,5
 LRM Carrier,6
 SRM Carrier,5
-Bulldog,4
-Von Luckner,3
-Brutus,2
-Pike,1
+Bulldog Medium Tank,4
+Von Luckner Heavy Tank VNL-K75N,3
+Brutus Assault Tank,2
+Pike Support Vehicle,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Light/FWL Light Vehicles 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Light/FWL Light Vehicles 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Light Vehicles 3067 (FMU)
-Yellow Jacket,1
-Striker,2
-Mantis,3
-Plainsman (Streak),4
-Main Gauche,5
+Yellow Jacket Gunship,1
+Striker Light Tank,2
+Mantis Light Attack VTOL,3
+Plainsman Medium Hovertank (Streak),4
+Main Gauche Light Support Tank,5
 Saracen Medium Hover Tank (MRM),6
 Hawk Moth Gunship,5
 Pegasus Scout Hover Tank (3058 Upgrade),4
-Galleon,3
+Galleon Light Tank GAL-100,3
 Saladin Assault Hover Tank (LB-X),2
 Warrior Attack Helicopter H-8,1

--- a/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Medium/FWL Medium Vehicles 3067 (FMU).txt
+++ b/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Medium/FWL Medium Vehicles 3067 (FMU).txt
@@ -16,14 +16,14 @@
 # affiliated with Microsoft.
 
 FWL Medium Vehicles 3067 (FMU)
-Regulator,1
-Goblin,2
-Hetzer,3
-Drillson,4
-Maxim,5
-Vedette,6
-Hetzer,5
+Regulator Hovertank,1
+Goblin Medium Tank,2
+Hetzer Wheeled Assault Gun,3
+Drillson Heavy Hover Tank,4
+Maxim Heavy Hover Transport,5
+Vedette Medium Tank,6
+Hetzer Wheeled Assault Gun,5
 Condor Heavy Hover Tank,4
-Regulator,3
-Stygian,2
+Regulator Hovertank,3
+Stygian Strike Tank,2
 Condor Heavy Hover Tank,1


### PR DESCRIPTION
Fixes some recently changed rat files to use unit names that can actually be found. For some, I had to choose a model. The FM update source book is completely silent on models so I used the baseline model when possible.