### PR TITLE
Fix: Added Missing Loose Files on stageDataFiles Run

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,11 +8,14 @@
 var stagingFolder = File(project.layout.buildDirectory.get().toString(), "staging")
 
 tasks.register<Zip>("unitFilesZip") {
-    description = "Creates zip archives of all the unit file folders."
+    description = "Creates zip archives of all the unit file folders (excluding loose .txt and .xml files)."
     group = "build"
     destinationDirectory.set(File(stagingFolder, "mekfiles"))
     archiveFileName.set("unit_files.zip")
-    from("data/mekfiles")
+    from("data/mekfiles") {
+        exclude("*.txt")
+        exclude("*.xml")
+    }
 }
 
 tasks.register<Zip>("ratZip") {


### PR DESCRIPTION
A handful of loose files were being added to the unit_files archive and not included in the build for mhq.

This PR updates our grade build so that it adds the necessary loose files once unit_files has been built. Those files are also excluded from the constructed zip so we're not doubling up.