### PR TITLE
Improvement #68: Reduced Default Contract Search Radius

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -574,7 +574,7 @@
         <mothballUnitMarketDeliveries>true</mothballUnitMarketDeliveries>
         <unitMarketReportRefresh>true</unitMarketReportRefresh>
         <contractMarketMethod>ATB_MONTHLY</contractMarketMethod>
-        <contractSearchRadius>400</contractSearchRadius>
+        <contractSearchRadius>200</contractSearchRadius>
         <variableContractLength>true</variableContractLength>
         <useDynamicDifficulty>true</useDynamicDifficulty>
         <contractMarketReportRefresh>true</contractMarketReportRefresh>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -552,7 +552,7 @@
         <mothballUnitMarketDeliveries>true</mothballUnitMarketDeliveries>
         <unitMarketReportRefresh>true</unitMarketReportRefresh>
         <contractMarketMethod>ATB_MONTHLY</contractMarketMethod>
-        <contractSearchRadius>400</contractSearchRadius>
+        <contractSearchRadius>200</contractSearchRadius>
         <variableContractLength>true</variableContractLength>
         <useDynamicDifficulty>true</useDynamicDifficulty>
         <contractMarketReportRefresh>true</contractMarketReportRefresh>

--- a/data/campaignPresets/3 - Campaign Operations Preset.xml
+++ b/data/campaignPresets/3 - Campaign Operations Preset.xml
@@ -552,7 +552,7 @@
         <mothballUnitMarketDeliveries>false</mothballUnitMarketDeliveries>
         <unitMarketReportRefresh>true</unitMarketReportRefresh>
         <contractMarketMethod>NONE</contractMarketMethod>
-        <contractSearchRadius>400</contractSearchRadius>
+        <contractSearchRadius>200</contractSearchRadius>
         <variableContractLength>true</variableContractLength>
         <useDynamicDifficulty>true</useDynamicDifficulty>
         <contractMarketReportRefresh>true</contractMarketReportRefresh>


### PR DESCRIPTION
Close #68

The original search distance was settled on as it allowed players to get contracts from across the Inner Sphere. This was needed due to the static campaign start location - normally Galatea or Outreach.

Starting in 07 we introduced more dynamic start locations. That allows us to reduce search radius, helping flavor campaigns based on their start location.