### PR TITLE
Improvement: Added Houdini, Master Impersonator, Counterfeiter, and Natural Thespian Unofficial SPAs

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -480,6 +480,13 @@
 
     <!-- Misc SPA -->
     <ability>
+        <lookupName>unofficial_houdini</lookupName>
+        <displayName>Houdini (Unofficial)</displayName>
+        <desc><![CDATA[Decreases the Target Number for all Escape Artist checks by 2.]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+    </ability>
+    <ability>
         <lookupName>flaw_in_for_life</lookupName>
         <displayName>In For Life (ATOW)</displayName>
         <desc><![CDATA[Roleplay only (for now)]]></desc>

--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -487,6 +487,27 @@
         <weight>1</weight>
     </ability>
     <ability>
+        <lookupName>unofficial_master_impersonator</lookupName>
+        <displayName>Master Impersonator (Unofficial)</displayName>
+        <desc><![CDATA[Decreases the Target Number for all Disguise checks by 2.]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+    </ability>
+    <ability>
+        <lookupName>unofficial_counterfeiter</lookupName>
+        <displayName>Counterfeiter (Unofficial)</displayName>
+        <desc><![CDATA[Decreases the Target Number for all Forgery checks by 2.]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+    </ability>
+    <ability>
+        <lookupName>unofficial_natural_thespian</lookupName>
+        <displayName>Natural Thespian (Unofficial)</displayName>
+        <desc><![CDATA[Decreases the Target Number for all Acting checks by 2.]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+    </ability>
+    <ability>
         <lookupName>flaw_in_for_life</lookupName>
         <displayName>In For Life (ATOW)</displayName>
         <desc><![CDATA[Roleplay only (for now)]]></desc>


### PR DESCRIPTION
## Houdini (Unofficial)
- Decreases the Target Number for all Escape Artist checks by 2.
- 100 xp

## Master Impersonator (Unofficial)
- Decreases the Target Number for all Disguise checks by 2.
- 100 xp

## Counterfeiter (Unofficial)
- Decreases the Target Number for all Forgery checks by 2.
- 100 xp

## Natural Thespian (Unofficial)
- Decreases the Target Number for all Acting checks by 2.
- 100 xp
