### PR TITLE
Fix: Removed Pokemon Names from Name Generator

### DIFF
--- a/data/names/femaleGivenNames.csv
+++ b/data/names/femaleGivenNames.csv
@@ -26969,7 +26969,6 @@ Ethnic Code,Name,Weight
 26,Peni,1
 26,Petora,1
 26,Pia,1
-26,Pikachu,1
 26,Pinko,1
 26,Pinoko,1
 26,Piyopiyo,1
@@ -26985,7 +26984,6 @@ Ethnic Code,Name,Weight
 26,Rabinia,1
 26,Rai,1
 26,Raicho,2
-26,Raichu,1
 26,Raiku,1
 26,Raina,1
 26,Raisa,1


### PR DESCRIPTION
Someone in the ancient past thought it would be funny to include Pikachu and Raichu in the female name generator.

This PR removes them, because I hate fun. But, also, because Pokemon are Trademarked.