### PR TITLE
Improvement: Updated XP Gains Based on Extensive Player Feedback

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -216,22 +216,22 @@
         <useUsefulAsTechs>true</useUsefulAsTechs>
         <useQuirks>true</useQuirks>
         <xpCostMultiplier>0.5</xpCostMultiplier>
-        <scenarioXP>0</scenarioXP>
-        <killsForXP>0</killsForXP>
-        <killXPAward>0</killXPAward>
+        <scenarioXP>1</scenarioXP>
+        <killsForXP>2</killsForXP>
+        <killXPAward>1</killXPAward>
         <nTasksXP>25</nTasksXP>
-        <tasksXP>0</tasksXP>
+        <tasksXP>1</tasksXP>
         <mistakeXP>0</mistakeXP>
         <successXP>0</successXP>
         <vocationalXP>2</vocationalXP>
         <vocationalXPTargetNumber>7</vocationalXPTargetNumber>
-        <vocationalXPCheckFrequency>1</vocationalXPCheckFrequency>
+        <vocationalXPCheckFrequency>3</vocationalXPCheckFrequency>
         <contractNegotiationXP>0</contractNegotiationXP>
         <adminWeeklyXP>0</adminWeeklyXP>
         <adminXPPeriod>1</adminXPPeriod>
         <missionXpFail>1</missionXpFail>
-        <missionXpSuccess>3</missionXpSuccess>
-        <missionXpOutstandingSuccess>5</missionXpOutstandingSuccess>
+        <missionXpSuccess>4</missionXpSuccess>
+        <missionXpOutstandingSuccess>7</missionXpOutstandingSuccess>
         <edgeCost>100</edgeCost>
         <limitByYear>true</limitByYear>
         <disallowExtinctStuff>false</disallowExtinctStuff>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -158,22 +158,22 @@
         <useUsefulAsTechs>true</useUsefulAsTechs>
         <useQuirks>true</useQuirks>
         <xpCostMultiplier>1.0</xpCostMultiplier>
-        <scenarioXP>0</scenarioXP>
-        <killsForXP>0</killsForXP>
-        <killXPAward>0</killXPAward>
+        <scenarioXP>1</scenarioXP>
+        <killsForXP>2</killsForXP>
+        <killXPAward>1</killXPAward>
         <nTasksXP>25</nTasksXP>
-        <tasksXP>0</tasksXP>
+        <tasksXP>1</tasksXP>
         <mistakeXP>0</mistakeXP>
         <successXP>0</successXP>
         <vocationalXP>2</vocationalXP>
         <vocationalXPTargetNumber>7</vocationalXPTargetNumber>
-        <vocationalXPCheckFrequency>1</vocationalXPCheckFrequency>
+        <vocationalXPCheckFrequency>3</vocationalXPCheckFrequency>
         <contractNegotiationXP>0</contractNegotiationXP>
         <adminWeeklyXP>0</adminWeeklyXP>
         <adminXPPeriod>1</adminXPPeriod>
         <missionXpFail>1</missionXpFail>
-        <missionXpSuccess>3</missionXpSuccess>
-        <missionXpOutstandingSuccess>5</missionXpOutstandingSuccess>
+        <missionXpSuccess>4</missionXpSuccess>
+        <missionXpOutstandingSuccess>7</missionXpOutstandingSuccess>
         <edgeCost>100</edgeCost>
         <limitByYear>true</limitByYear>
         <disallowExtinctStuff>false</disallowExtinctStuff>


### PR DESCRIPTION
This PR updates the mhq xp awards based on extensive player feedback that has been received since the major xp adjustments earlier in the year (late 2024?).

The key changes are that tasks award xp, as do scenario deployments, and kills. Albeit neither award significant gains keeping to our 'slow but steady' xp goal. To account for this change vocational xp has been nerfed.