### PR TITLE
Fix: Fixed Money Sink Options for Stock Presets

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -532,7 +532,7 @@
         <payForUnits>true</payForUnits>
         <payForSalaries>true</payForSalaries>
         <payForOverhead>false</payForOverhead>
-        <payForMaintain>true</payForMaintain>
+        <payForMaintain>false</payForMaintain>
         <payForTransport>true</payForTransport>
         <sellUnits>true</sellUnits>
         <sellParts>true</sellParts>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -473,7 +473,7 @@
         <payForRepairs>true</payForRepairs>
         <payForUnits>true</payForUnits>
         <payForSalaries>true</payForSalaries>
-        <payForOverhead>false</payForOverhead>
+        <payForOverhead>true</payForOverhead>
         <payForMaintain>true</payForMaintain>
         <payForTransport>true</payForTransport>
         <sellUnits>true</sellUnits>

--- a/data/campaignPresets/3 - Campaign Operations Preset.xml
+++ b/data/campaignPresets/3 - Campaign Operations Preset.xml
@@ -474,7 +474,7 @@
         <payForUnits>true</payForUnits>
         <payForSalaries>true</payForSalaries>
         <payForOverhead>false</payForOverhead>
-        <payForMaintain>true</payForMaintain>
+        <payForMaintain>false</payForMaintain>
         <payForTransport>true</payForTransport>
         <sellUnits>true</sellUnits>
         <sellParts>true</sellParts>


### PR DESCRIPTION
- Turned off maintenance costs for New Player Preset
- Turned off maintenance costs for Campaign Operations preset
- Turned _on_ overhead costs for Veteran preset