### PR TITLE
PR: include Sherpa (Mobile Canteen) model

### DIFF
--- a/data/forcegenerator/2398.xml
+++ b/data/forcegenerator/2398.xml
@@ -876,6 +876,10 @@
                 <roles>support</roles>
                 <availability>IS:4,Periphery:4,PIR:2</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Silverfin Coastal Cutter' unitType='Naval'>
             <availability>LA:6</availability>

--- a/data/forcegenerator/2440.xml
+++ b/data/forcegenerator/2440.xml
@@ -1055,6 +1055,10 @@
                 <roles>support</roles>
                 <availability>IS:4,Periphery:4,PIR:2</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Silverfin Coastal Cutter' unitType='Naval'>
             <availability>LA:6</availability>

--- a/data/forcegenerator/2460.xml
+++ b/data/forcegenerator/2460.xml
@@ -1139,6 +1139,10 @@
                 <roles>support</roles>
                 <availability>IS:4,Periphery:4,PIR:2</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Silverfin Coastal Cutter' unitType='Naval'>
             <availability>LA:6</availability>

--- a/data/forcegenerator/2470.xml
+++ b/data/forcegenerator/2470.xml
@@ -1344,6 +1344,10 @@
                 <roles>support</roles>
                 <availability>IS:4,Periphery:4,PIR:2</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Silverfin Coastal Cutter' unitType='Naval'>
             <availability>LA:6</availability>

--- a/data/forcegenerator/2490.xml
+++ b/data/forcegenerator/2490.xml
@@ -1663,6 +1663,10 @@
                 <roles>support</roles>
                 <availability>IS:4,Periphery:4,PIR:2</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Silverfin Coastal Cutter' unitType='Naval'>
             <availability>LA:6</availability>

--- a/data/forcegenerator/2520.xml
+++ b/data/forcegenerator/2520.xml
@@ -1922,6 +1922,10 @@
                 <roles>support</roles>
                 <availability>IS:2,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shuttle' unitType='Small Craft'>
             <availability>IS:8,Periphery:8</availability>

--- a/data/forcegenerator/2571.xml
+++ b/data/forcegenerator/2571.xml
@@ -2961,6 +2961,10 @@
                 <roles>support</roles>
                 <availability>IS:2,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shootist' unitType='Mek'>
             <availability>SL!A:1!B:1,SL.R:2+,TH:2+</availability>

--- a/data/forcegenerator/2650.xml
+++ b/data/forcegenerator/2650.xml
@@ -3188,6 +3188,10 @@
                 <roles>support</roles>
                 <availability>IS:2,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shootist' unitType='Mek'>
             <availability>SL:4,SL.R:5</availability>

--- a/data/forcegenerator/2700.xml
+++ b/data/forcegenerator/2700.xml
@@ -3836,6 +3836,10 @@
                 <roles>support</roles>
                 <availability>IS:2,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shootist' unitType='Mek'>
             <availability>LA:3+,SL:4,SL.R:6</availability>

--- a/data/forcegenerator/2765.xml
+++ b/data/forcegenerator/2765.xml
@@ -3969,6 +3969,10 @@
                 <roles>support</roles>
                 <availability>IS:2,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shogun' unitType='Mek'>
             <availability>SL:2</availability>

--- a/data/forcegenerator/2780.xml
+++ b/data/forcegenerator/2780.xml
@@ -4047,6 +4047,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shogun' unitType='Mek'>
             <availability>SL:3,FWL:2+</availability>

--- a/data/forcegenerator/2807.xml
+++ b/data/forcegenerator/2807.xml
@@ -4366,6 +4366,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2815.xml
+++ b/data/forcegenerator/2815.xml
@@ -4702,6 +4702,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2823.xml
+++ b/data/forcegenerator/2823.xml
@@ -4950,6 +4950,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2830.xml
+++ b/data/forcegenerator/2830.xml
@@ -5037,6 +5037,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2835.xml
+++ b/data/forcegenerator/2835.xml
@@ -5531,6 +5531,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2855.xml
+++ b/data/forcegenerator/2855.xml
@@ -5529,6 +5529,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2860.xml
+++ b/data/forcegenerator/2860.xml
@@ -5407,6 +5407,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2865.xml
+++ b/data/forcegenerator/2865.xml
@@ -5519,6 +5519,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2870.xml
+++ b/data/forcegenerator/2870.xml
@@ -5846,6 +5846,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2900.xml
+++ b/data/forcegenerator/2900.xml
@@ -6273,6 +6273,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/2950.xml
+++ b/data/forcegenerator/2950.xml
@@ -6679,6 +6679,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3019.xml
+++ b/data/forcegenerator/3019.xml
@@ -6956,6 +6956,10 @@
                 <roles>support</roles>
                 <availability>IS:2,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3028.xml
+++ b/data/forcegenerator/3028.xml
@@ -7356,6 +7356,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3039.xml
+++ b/data/forcegenerator/3039.xml
@@ -8325,6 +8325,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3049.xml
+++ b/data/forcegenerator/3049.xml
@@ -9629,6 +9629,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3055.xml
+++ b/data/forcegenerator/3055.xml
@@ -10587,6 +10587,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3058.xml
+++ b/data/forcegenerator/3058.xml
@@ -11564,6 +11564,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,CS:8,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>

--- a/data/forcegenerator/3060.xml
+++ b/data/forcegenerator/3060.xml
@@ -14222,6 +14222,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,WOB:0,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FRR:8,MERC:4,Periphery.OS:4,DC:8,Periphery:2</availability>

--- a/data/forcegenerator/3067.xml
+++ b/data/forcegenerator/3067.xml
@@ -17597,6 +17597,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>

--- a/data/forcegenerator/3075.xml
+++ b/data/forcegenerator/3075.xml
@@ -18697,6 +18697,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>

--- a/data/forcegenerator/3078.xml
+++ b/data/forcegenerator/3078.xml
@@ -19303,6 +19303,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,CEI:5+,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>

--- a/data/forcegenerator/3082.xml
+++ b/data/forcegenerator/3082.xml
@@ -17988,6 +17988,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,CEI:5+,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shilone' unitType='AeroSpaceFighter'>
             <availability>RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>

--- a/data/forcegenerator/3085.xml
+++ b/data/forcegenerator/3085.xml
@@ -18316,6 +18316,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,CEI:5+,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shillelagh Missile Tank' unitType='Tank'>
             <availability>DC:4-,LA:3-,ROS:3-,MERC:3-</availability>

--- a/data/forcegenerator/3100.xml
+++ b/data/forcegenerator/3100.xml
@@ -19270,6 +19270,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,CEI:5+,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shikra' unitType='AeroSpaceFighter'>
             <availability>RF:3,FWL:4,DA:4,MERC:3</availability>

--- a/data/forcegenerator/3131.xml
+++ b/data/forcegenerator/3131.xml
@@ -20423,6 +20423,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,CEI:5+,SE:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shikra' unitType='AeroSpaceFighter'>
             <availability>RF:4,FWL:5,DA:5,MERC:4,CP:5</availability>

--- a/data/forcegenerator/3145.xml
+++ b/data/forcegenerator/3145.xml
@@ -20615,6 +20615,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,SE:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shikra' unitType='AeroSpaceFighter'>
             <availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>

--- a/data/forcegenerator/3150.xml
+++ b/data/forcegenerator/3150.xml
@@ -20645,6 +20645,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,SE:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shikra' unitType='AeroSpaceFighter'>
             <availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>

--- a/data/forcegenerator/3160.xml
+++ b/data/forcegenerator/3160.xml
@@ -20127,6 +20127,10 @@
                 <roles>support</roles>
                 <availability>IS:2,FS:2-,LA:2-,Periphery:3,PIR:1</availability>
             </model>
+            <model name='(Mobile Canteen)'>
+                <roles>support</roles>
+                <availability>IS:6,Periphery:6,SE:6,PIR:5+</availability>
+            </model>
         </chassis>
         <chassis name='Shikra' unitType='AeroSpaceFighter'>
             <availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>


### PR DESCRIPTION
Adds the (Mobile Canteen) model of the Sherpa to the availability files, somewhat important given it is the only stock unit with Field Kitchen equipment for many eras.