### PR TITLE
Fix #106: Fixed Gunnery/Missile, Gunnery/Laser, and Gunnery/Ballistic Appearing Outside of 'Gunnery Specialization' Multi-Option SPA

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -3537,29 +3537,6 @@
             <choiceValues></choiceValues>
         </ability>
         <ability>
-            <displayName>Gunnery/Ballistic (Unofficial)</displayName>
-            <lookupName>gunnery_ballistic</lookupName>
-            <desc>Pilot gets a -1 to-hit bonus on all ballistic weapons (MGs,
-                all ACs,
-                Gauss rifles).
-            </desc>
-            <xpCost>100</xpCost>
-            <weight>1</weight>
-            <prereqAbilities></prereqAbilities>
-            <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-            <removeAbilities></removeAbilities>
-            <choiceValues></choiceValues>
-            <skillPrereq>
-                <skill>Gunnery/Mek::Green</skill>
-                <skill>Gunnery/ProtoMek::Green</skill>
-                <skill>Gunnery/Aircraft::Green</skill>
-                <skill>Gunnery/Aerospace::Green</skill>
-                <skill>Gunnery/Spacecraft::Green</skill>
-                <skill>Gunnery/BattleArmor::Green</skill>
-                <skill>Gunnery/Vehicle::Green</skill>
-            </skillPrereq>
-        </ability>
-        <ability>
             <displayName>Natural Thespian (Unofficial)</displayName>
             <lookupName>unofficial_natural_thespian</lookupName>
             <desc>Decreases the Target Number for all Acting checks by 2.</desc>
@@ -3704,30 +3681,6 @@
             </skillPrereq>
         </ability>
         <ability>
-            <displayName>Gunnery/Missile (Unofficial)</displayName>
-            <lookupName>gunnery_missile</lookupName>
-            <desc>Pilot gets a -1 to-hit bonus on all missile weapons (LRM,
-                SRM,
-                MRM,
-                RL and ATM).
-            </desc>
-            <xpCost>100</xpCost>
-            <weight>1</weight>
-            <prereqAbilities></prereqAbilities>
-            <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-            <removeAbilities></removeAbilities>
-            <choiceValues></choiceValues>
-            <skillPrereq>
-                <skill>Gunnery/Mek::Green</skill>
-                <skill>Gunnery/ProtoMek::Green</skill>
-                <skill>Gunnery/Aircraft::Green</skill>
-                <skill>Gunnery/Aerospace::Green</skill>
-                <skill>Gunnery/Spacecraft::Green</skill>
-                <skill>Gunnery/BattleArmor::Green</skill>
-                <skill>Gunnery/Vehicle::Green</skill>
-            </skillPrereq>
-        </ability>
-        <ability>
             <displayName>Gremlins (ATOW)</displayName>
             <lookupName>flaw_gremlins</lookupName>
             <desc>The cost of purchasing and improving the Tech/Any, Computers, Communications, or Security Systems/Electronic skills is increased by 10% (rounded normally).
@@ -3850,30 +3803,6 @@
                 <skill>Piloting/VTOL::Veteran</skill>
                 <skill>Piloting/Aircraft::Veteran</skill>
                 <skill>Piloting/Mek::Veteran</skill>
-            </skillPrereq>
-        </ability>
-        <ability>
-            <displayName>Gunnery/Energy (Unofficial)</displayName>
-            <lookupName>gunnery_laser</lookupName>
-            <desc>NOTE: This is a unofficial rule.
-                Pilot gets a -1 to-hit bonus on all energy-based weapons (Laser,
-                PPC,
-                Plasma and Flamer).
-            </desc>
-            <xpCost>100</xpCost>
-            <weight>1</weight>
-            <prereqAbilities></prereqAbilities>
-            <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-            <removeAbilities></removeAbilities>
-            <choiceValues></choiceValues>
-            <skillPrereq>
-                <skill>Gunnery/Mek::Green</skill>
-                <skill>Gunnery/ProtoMek::Green</skill>
-                <skill>Gunnery/Aircraft::Green</skill>
-                <skill>Gunnery/Aerospace::Green</skill>
-                <skill>Gunnery/Spacecraft::Green</skill>
-                <skill>Gunnery/BattleArmor::Green</skill>
-                <skill>Gunnery/Vehicle::Green</skill>
             </skillPrereq>
         </ability>
         <ability>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -3479,29 +3479,6 @@
             <choiceValues></choiceValues>
         </ability>
         <ability>
-            <displayName>Gunnery/Ballistic (Unofficial)</displayName>
-            <lookupName>gunnery_ballistic</lookupName>
-            <desc>Pilot gets a -1 to-hit bonus on all ballistic weapons (MGs,
-                all ACs,
-                Gauss rifles).
-            </desc>
-            <xpCost>100</xpCost>
-            <weight>1</weight>
-            <prereqAbilities></prereqAbilities>
-            <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-            <removeAbilities></removeAbilities>
-            <choiceValues></choiceValues>
-            <skillPrereq>
-                <skill>Gunnery/Mek::Green</skill>
-                <skill>Gunnery/ProtoMek::Green</skill>
-                <skill>Gunnery/Aircraft::Green</skill>
-                <skill>Gunnery/Aerospace::Green</skill>
-                <skill>Gunnery/Spacecraft::Green</skill>
-                <skill>Gunnery/BattleArmor::Green</skill>
-                <skill>Gunnery/Vehicle::Green</skill>
-            </skillPrereq>
-        </ability>
-        <ability>
             <displayName>Natural Thespian (Unofficial)</displayName>
             <lookupName>unofficial_natural_thespian</lookupName>
             <desc>Decreases the Target Number for all Acting checks by 2.</desc>
@@ -3646,30 +3623,6 @@
             </skillPrereq>
         </ability>
         <ability>
-            <displayName>Gunnery/Missile (Unofficial)</displayName>
-            <lookupName>gunnery_missile</lookupName>
-            <desc>Pilot gets a -1 to-hit bonus on all missile weapons (LRM,
-                SRM,
-                MRM,
-                RL and ATM).
-            </desc>
-            <xpCost>100</xpCost>
-            <weight>1</weight>
-            <prereqAbilities></prereqAbilities>
-            <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-            <removeAbilities></removeAbilities>
-            <choiceValues></choiceValues>
-            <skillPrereq>
-                <skill>Gunnery/Mek::Green</skill>
-                <skill>Gunnery/ProtoMek::Green</skill>
-                <skill>Gunnery/Aircraft::Green</skill>
-                <skill>Gunnery/Aerospace::Green</skill>
-                <skill>Gunnery/Spacecraft::Green</skill>
-                <skill>Gunnery/BattleArmor::Green</skill>
-                <skill>Gunnery/Vehicle::Green</skill>
-            </skillPrereq>
-        </ability>
-        <ability>
             <displayName>Gremlins (ATOW)</displayName>
             <lookupName>flaw_gremlins</lookupName>
             <desc>The cost of purchasing and improving the Tech/Any, Computers, Communications, or Security Systems/Electronic skills is increased by 10% (rounded normally).
@@ -3792,30 +3745,6 @@
                 <skill>Piloting/VTOL::Veteran</skill>
                 <skill>Piloting/Aircraft::Veteran</skill>
                 <skill>Piloting/Mek::Veteran</skill>
-            </skillPrereq>
-        </ability>
-        <ability>
-            <displayName>Gunnery/Energy (Unofficial)</displayName>
-            <lookupName>gunnery_laser</lookupName>
-            <desc>NOTE: This is a unofficial rule.
-                Pilot gets a -1 to-hit bonus on all energy-based weapons (Laser,
-                PPC,
-                Plasma and Flamer).
-            </desc>
-            <xpCost>100</xpCost>
-            <weight>1</weight>
-            <prereqAbilities></prereqAbilities>
-            <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-            <removeAbilities></removeAbilities>
-            <choiceValues></choiceValues>
-            <skillPrereq>
-                <skill>Gunnery/Mek::Green</skill>
-                <skill>Gunnery/ProtoMek::Green</skill>
-                <skill>Gunnery/Aircraft::Green</skill>
-                <skill>Gunnery/Aerospace::Green</skill>
-                <skill>Gunnery/Spacecraft::Green</skill>
-                <skill>Gunnery/BattleArmor::Green</skill>
-                <skill>Gunnery/Vehicle::Green</skill>
             </skillPrereq>
         </ability>
         <ability>

--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -222,51 +222,52 @@
     </ability>
 
     <!-- GUNNERY SPA -->
-    <ability>
-        <lookupName>gunnery_ballistic</lookupName>
-        <xpCost>100</xpCost>
-        <weight>1</weight>
-        <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-        <skillPrereq>
-            <skill>Gunnery/Mek::Green</skill>
-            <skill>Gunnery/ProtoMek::Green</skill>
-            <skill>Gunnery/Aircraft::Green</skill>
-            <skill>Gunnery/Aerospace::Green</skill>
-            <skill>Gunnery/Spacecraft::Green</skill>
-            <skill>Gunnery/BattleArmor::Green</skill>
-            <skill>Gunnery/Vehicle::Green</skill>
-        </skillPrereq>
-    </ability>
-    <ability>
-        <lookupName>gunnery_missile</lookupName>
-        <xpCost>100</xpCost>
-        <weight>1</weight>
-        <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-        <skillPrereq>
-            <skill>Gunnery/Mek::Green</skill>
-            <skill>Gunnery/ProtoMek::Green</skill>
-            <skill>Gunnery/Aircraft::Green</skill>
-            <skill>Gunnery/Aerospace::Green</skill>
-            <skill>Gunnery/Spacecraft::Green</skill>
-            <skill>Gunnery/BattleArmor::Green</skill>
-            <skill>Gunnery/Vehicle::Green</skill>
-        </skillPrereq>
-    </ability>
-    <ability>
-        <lookupName>gunnery_laser</lookupName>
-        <xpCost>100</xpCost>
-        <weight>1</weight>
-        <invalidAbilities>weapon_specialist::specialist</invalidAbilities>
-        <skillPrereq>
-            <skill>Gunnery/Mek::Green</skill>
-            <skill>Gunnery/ProtoMek::Green</skill>
-            <skill>Gunnery/Aircraft::Green</skill>
-            <skill>Gunnery/Aerospace::Green</skill>
-            <skill>Gunnery/Spacecraft::Green</skill>
-            <skill>Gunnery/BattleArmor::Green</skill>
-            <skill>Gunnery/Vehicle::Green</skill>
-        </skillPrereq>
-    </ability>
+    <!-- the next three SPAs should not be enabled unless Gunnery Specialization is disabled first -->
+    <!--     <ability> -->
+    <!--         <lookupName>gunnery_ballistic</lookupName> -->
+    <!--         <xpCost>100</xpCost> -->
+    <!--         <weight>1</weight> -->
+    <!--         <invalidAbilities>weapon_specialist::specialist</invalidAbilities> -->
+    <!--         <skillPrereq> -->
+    <!--             <skill>Gunnery/Mek::Green</skill> -->
+    <!--             <skill>Gunnery/ProtoMek::Green</skill> -->
+    <!--             <skill>Gunnery/Aircraft::Green</skill> -->
+    <!--             <skill>Gunnery/Aerospace::Green</skill> -->
+    <!--             <skill>Gunnery/Spacecraft::Green</skill> -->
+    <!--             <skill>Gunnery/BattleArmor::Green</skill> -->
+    <!--             <skill>Gunnery/Vehicle::Green</skill> -->
+    <!--         </skillPrereq> -->
+    <!--     </ability> -->
+    <!--     <ability> -->
+    <!--         <lookupName>gunnery_missile</lookupName> -->
+    <!--         <xpCost>100</xpCost> -->
+    <!--         <weight>1</weight> -->
+    <!--         <invalidAbilities>weapon_specialist::specialist</invalidAbilities> -->
+    <!--         <skillPrereq> -->
+    <!--             <skill>Gunnery/Mek::Green</skill> -->
+    <!--             <skill>Gunnery/ProtoMek::Green</skill> -->
+    <!--             <skill>Gunnery/Aircraft::Green</skill> -->
+    <!--             <skill>Gunnery/Aerospace::Green</skill> -->
+    <!--             <skill>Gunnery/Spacecraft::Green</skill> -->
+    <!--             <skill>Gunnery/BattleArmor::Green</skill> -->
+    <!--             <skill>Gunnery/Vehicle::Green</skill> -->
+    <!--         </skillPrereq> -->
+    <!--     </ability> -->
+    <!--     <ability> -->
+    <!--         <lookupName>gunnery_laser</lookupName> -->
+    <!--         <xpCost>100</xpCost> -->
+    <!--         <weight>1</weight> -->
+    <!--         <invalidAbilities>weapon_specialist::specialist</invalidAbilities> -->
+    <!--         <skillPrereq> -->
+    <!--             <skill>Gunnery/Mek::Green</skill> -->
+    <!--             <skill>Gunnery/ProtoMek::Green</skill> -->
+    <!--             <skill>Gunnery/Aircraft::Green</skill> -->
+    <!--             <skill>Gunnery/Aerospace::Green</skill> -->
+    <!--             <skill>Gunnery/Spacecraft::Green</skill> -->
+    <!--             <skill>Gunnery/BattleArmor::Green</skill> -->
+    <!--             <skill>Gunnery/Vehicle::Green</skill> -->
+    <!--         </skillPrereq> -->
+    <!--     </ability> -->
     <ability>
         <lookupName>cluster_hitter</lookupName>
         <xpCost>100</xpCost>


### PR DESCRIPTION
Fix #106

Three SPAs were incorrectly enabled in defaultSPAs which resulted in those SPAs being able to be picked outside of their multi-option picker. Characters were not intended to be able to pick all three and doing so would likely have unintended consequences.