### PR TITLE
Improvement: Significantly Lowered the Rate of Princess Bringing Artillery Units to One-Shot Player DropShips

### DIFF
--- a/data/scenariotemplates/Deep Raid Defense.xml
+++ b/data/scenariotemplates/Deep Raid Defense.xml
@@ -110,6 +110,14 @@ We will control the battlefield at the end of the engagement, ensuring access to
                     <forceRole>ARTILLERY</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>

--- a/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -109,6 +109,14 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                     <forceRole>ARTILLERY</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>


### PR DESCRIPTION
Ok, this stopped being funny a couple of releases ago. While bringing artillery to swat grounded DropShips _is_ the optimum tactic, player feedback is clear: it's not fun.

This PR reduces the chance Princess will bring artillery units to anti-DropShip scenarios from 1:5 to 1:13. This should stop all-artillery forces, for the large part. Though that isn't impossible.