### PR TITLE
Update mek data with TRO sources (3145)

### DIFF
--- a/data/mekfiles/meks/3145/Clans/Eyrie.mtf
+++ b/data/mekfiles/meks/3145/Clans/Eyrie.mtf
@@ -22,7 +22,7 @@ mul id:6263
 Config:Biped
 TechBase:Clan
 Era:3087
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1C.mtf
@@ -22,7 +22,7 @@ mul id:6265
 Config:Biped
 TechBase:Inner Sphere
 Era:3102
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1D.mtf
@@ -22,7 +22,7 @@ mul id:6264
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3105
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon 2.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon 2.mtf
@@ -22,7 +22,7 @@ mul id:6267
 Config:Biped
 TechBase:Clan
 Era:3112
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon 3.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon 3.mtf
@@ -22,7 +22,7 @@ mul id:6268
 Config:Biped
 TechBase:Clan
 Era:3112
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon 4.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon 4.mtf
@@ -22,7 +22,7 @@ mul id:6269
 Config:Biped
 techbase:Mixed (Clan Chassis)
 era:3112
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon.mtf
@@ -22,7 +22,7 @@ mul id:6266
 Config:Biped
 techbase:Clan
 era:3112
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Kodiak II 2.mtf
+++ b/data/mekfiles/meks/3145/Clans/Kodiak II 2.mtf
@@ -22,7 +22,7 @@ mul id:6296
 Config:Biped
 TechBase:Clan
 Era:3139
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:4
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Kodiak II.mtf
+++ b/data/mekfiles/meks/3145/Clans/Kodiak II.mtf
@@ -22,7 +22,7 @@ mul id:6295
 Config:Biped
 techbase:Clan
 era:3095
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) (Prime).mtf
@@ -23,7 +23,7 @@ mul id:6277
 Config:Biped Omnimech
 TechBase:Clan
 Era:3121
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) A.mtf
@@ -23,7 +23,7 @@ mul id:6278
 Config:Biped Omnimech
 TechBase:Clan
 Era:3121
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) B.mtf
@@ -23,7 +23,7 @@ mul id:6279
 Config:Biped Omnimech
 techbase:Clan
 era:3121
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Shrike 2.mtf
+++ b/data/mekfiles/meks/3145/Clans/Shrike 2.mtf
@@ -22,7 +22,7 @@ mul id:6293
 Config:Biped
 techbase:Clan
 era:3115
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Shrike 3.mtf
+++ b/data/mekfiles/meks/3145/Clans/Shrike 3.mtf
@@ -22,7 +22,7 @@ mul id:6294
 Config:Biped
 techbase:Clan
 era:3116
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Shrike.mtf
+++ b/data/mekfiles/meks/3145/Clans/Shrike.mtf
@@ -22,7 +22,7 @@ mul id:6292
 Config:Biped
 TechBase:Clan
 Era:3113
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) (Prime).mtf
@@ -23,7 +23,7 @@ mul id:6281
 Config:Biped Omnimech
 TechBase:Clan
 Era:3093
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) A.mtf
@@ -23,7 +23,7 @@ mul id:6282
 Config:Biped Omnimech
 TechBase:Clan
 Era:3093
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) B.mtf
@@ -23,7 +23,7 @@ mul id:6283
 Config:Biped Omnimech
 TechBase:Clan
 Era:3093
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) C.mtf
@@ -23,7 +23,7 @@ mul id:6284
 Config:Biped Omnimech
 TechBase:Clan
 Era:3093
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) D.mtf
@@ -23,7 +23,7 @@ mul id:6285
 Config:Biped Omnimech
 TechBase:Clan
 Era:3093
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk (Prime).mtf
@@ -22,7 +22,7 @@ mul id:6298
 Config:Biped Omnimech
 techbase:Clan
 era:3063
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk A.mtf
@@ -22,7 +22,7 @@ mul id:6299
 Config:Biped Omnimech
 TechBase:Clan
 Era:3063
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk B.mtf
@@ -22,7 +22,7 @@ mul id:6300
 Config:Biped Omnimech
 TechBase:Clan
 Era:3063
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk C.mtf
@@ -22,7 +22,7 @@ mul id:6301
 Config:Biped Omnimech
 TechBase:Clan
 Era:3063
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II (Prime).mtf
@@ -22,7 +22,7 @@ mul id:6303
 Config:Biped Omnimech
 techbase:Clan
 era:3088
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II A.mtf
@@ -22,7 +22,7 @@ mul id:6304
 Config:Biped Omnimech
 TechBase:Clan
 Era:3088
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II B.mtf
@@ -22,7 +22,7 @@ mul id:6305
 Config:Biped Omnimech
 TechBase:Clan
 Era:3088
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II C.mtf
@@ -22,7 +22,7 @@ mul id:6306
 Config:Biped Omnimech
 TechBase:Clan
 Era:3088
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III B.mtf
@@ -23,7 +23,7 @@ mul id:6273
 Config:Biped Omnimech
 TechBase:Clan
 Era:3109
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III C.mtf
@@ -23,7 +23,7 @@ mul id:6274
 Config:Biped Omnimech
 TechBase:Clan
 Era:3109
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III D.mtf
@@ -23,7 +23,7 @@ mul id:6275
 Config:Biped Omnimech
 TechBase:Clan
 Era:3109
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III Prime.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III Prime.mtf
@@ -24,7 +24,7 @@ mul id:6271
 Config:Biped OmniMek
 techbase:Clan
 era:3109
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Clans/Vulture Mk III (Mad Dog Mk III) A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture Mk III (Mad Dog Mk III) A.mtf
@@ -23,7 +23,7 @@ mul id:6272
 Config:Biped Omnimech
 TechBase:Clan
 Era:3109
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Warwolf (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf (Prime).mtf
@@ -22,7 +22,7 @@ mul id:6287
 Config:Biped Omnimech
 TechBase:Clan
 Era:3138
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Warwolf A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf A.mtf
@@ -22,7 +22,7 @@ mul id:6288
 Config:Biped Omnimech
 TechBase:Clan
 Era:3138
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Warwolf B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf B.mtf
@@ -22,7 +22,7 @@ mul id:6289
 Config:Biped Omnimech
 TechBase:Clan
 Era:3138
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Clans/Warwolf C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf C.mtf
@@ -22,7 +22,7 @@ mul id:6290
 Config:Biped Omnimech
 TechBase:Clan
 Era:3138
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Clans/Warwolf H.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf H.mtf
@@ -22,7 +22,7 @@ mul id:6291
 Config:Biped Omnimech
 TechBase:Clan
 Era:3138
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen (Prime).mtf
@@ -21,7 +21,7 @@ mul id:6256
 Config:Biped Omnimech
 techbase:Mixed (Clan Chassis)
 era:3137
-source:TRO: 3145 The Clans
+source:TR:3145:C
 rules level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen A.mtf
@@ -22,7 +22,7 @@ mul id:6257
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen B.mtf
@@ -22,7 +22,7 @@ mul id:6258
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 rules level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen C.mtf
@@ -22,7 +22,7 @@ mul id:6259
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen D.mtf
@@ -22,7 +22,7 @@ mul id:6260
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 rules level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen E.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen E.mtf
@@ -22,7 +22,7 @@ mul id:6261
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Clans/Wulfen H.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen H.mtf
@@ -22,7 +22,7 @@ mul id:6262
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Davion/Antlion LK-3D.mtf
+++ b/data/mekfiles/meks/3145/Davion/Antlion LK-3D.mtf
@@ -21,7 +21,7 @@ mul id:6338
 Config:Quad
 techbase:Mixed (IS Chassis)
 era:3117
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Davion/Atlas III AS7-D2.mtf
+++ b/data/mekfiles/meks/3145/Davion/Atlas III AS7-D2.mtf
@@ -22,7 +22,7 @@ mul id:6359
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3110
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Davion/Atlas III AS7-D3.mtf
+++ b/data/mekfiles/meks/3145/Davion/Atlas III AS7-D3.mtf
@@ -22,7 +22,7 @@ mul id:6358
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3137
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-2Y.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-2Y.mtf
@@ -22,7 +22,7 @@ mul id:6347
 Config:Biped
 TechBase:Inner Sphere
 Era:3091
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3A.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3A.mtf
@@ -22,7 +22,7 @@ mul id:6348
 Config:Biped
 TechBase:Inner Sphere
 Era:3095
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3B.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3B.mtf
@@ -22,7 +22,7 @@ mul id:6349
 Config:Biped
 TechBase:Inner Sphere
 Era:3100
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-4D.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-4D.mtf
@@ -22,7 +22,7 @@ mul id:6350
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3127
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-5H.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-5H.mtf
@@ -22,7 +22,7 @@ mul id:6351
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3138
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-O.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-O.mtf
@@ -22,7 +22,7 @@ mul id:6340
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3111
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OA.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OA.mtf
@@ -22,7 +22,7 @@ mul id:6341
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3111
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OB.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OB.mtf
@@ -22,7 +22,7 @@ mul id:6342
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3111
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OC.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OC.mtf
@@ -22,7 +22,7 @@ mul id:6343
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3111
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OD.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OD.mtf
@@ -22,7 +22,7 @@ mul id:6344
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3111
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OE.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OE.mtf
@@ -22,7 +22,7 @@ mul id:6345
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3111
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Davion/Gunsmith CH11-NG.mtf
+++ b/data/mekfiles/meks/3145/Davion/Gunsmith CH11-NG.mtf
@@ -23,7 +23,7 @@ mul id:6332
 Config:Biped
 techbase:Inner Sphere
 era:3131
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:4
 role:Striker
 

--- a/data/mekfiles/meks/3145/Davion/Hollander III BZK-D1.mtf
+++ b/data/mekfiles/meks/3145/Davion/Hollander III BZK-D1.mtf
@@ -22,7 +22,7 @@ mul id:6333
 Config:Biped
 TechBase:Inner Sphere
 Era:3114
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Davion/Hollander III BZK-D2.mtf
+++ b/data/mekfiles/meks/3145/Davion/Hollander III BZK-D2.mtf
@@ -23,7 +23,7 @@ mul id:6334
 Config:Biped
 TechBase:Inner Sphere
 Era:3115
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Davion/Hollander III BZK-D3.mtf
+++ b/data/mekfiles/meks/3145/Davion/Hollander III BZK-D3.mtf
@@ -22,7 +22,7 @@ mul id:6335
 Config:Biped
 TechBase:Inner Sphere
 Era:3118
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Davion/Prey Seeker PY-SR10.mtf
+++ b/data/mekfiles/meks/3145/Davion/Prey Seeker PY-SR10.mtf
@@ -21,7 +21,7 @@ mul id:6331
 Config:Biped
 techbase:Inner Sphere
 era:3136
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4 Hobbled Scarecrow.mtf
+++ b/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4 Hobbled Scarecrow.mtf
@@ -22,7 +22,7 @@ mul id:6337
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3122
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:4
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4.mtf
+++ b/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4.mtf
@@ -22,7 +22,7 @@ mul id:6336
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3099
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:4
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-O.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-O.mtf
@@ -21,7 +21,7 @@ mul id:6353
 Config:Biped Omnimech
 techbase:Inner Sphere
 era:3100
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OA.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OA.mtf
@@ -22,7 +22,7 @@ mul id:6354
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3100
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OB.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OB.mtf
@@ -22,7 +22,7 @@ mul id:6355
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3100
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OC.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OC.mtf
@@ -22,7 +22,7 @@ mul id:6356
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3120
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:4
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OD.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OD.mtf
@@ -21,7 +21,7 @@ mul id:6357
 Config:Biped Omnimech
 techbase:Mixed (IS Chassis)
 era:3120
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:4
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Davion/Vulpes VLP-1D.mtf
+++ b/data/mekfiles/meks/3145/Davion/Vulpes VLP-1D.mtf
@@ -22,7 +22,7 @@ mul id:6346
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3133
-Source:TRO: 3145 Federated Suns
+Source:TR:3145:FS
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1O.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1O.mtf
@@ -21,7 +21,7 @@ mul id:6396
 Config:Biped Omnimech
 techbase:Inner Sphere
 era:3133
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OA.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OA.mtf
@@ -22,7 +22,7 @@ mul id:6397
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3133
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OB.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OB.mtf
@@ -22,7 +22,7 @@ mul id:6398
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3133
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OC.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OC.mtf
@@ -22,7 +22,7 @@ mul id:6399
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3133
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1ON.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1ON.mtf
@@ -22,7 +22,7 @@ mul id:6400
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3133
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OR.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OR.mtf
@@ -22,7 +22,7 @@ mul id:6401
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3133
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11K.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11K.mtf
@@ -22,7 +22,7 @@ mul id:6414
 Config:Biped
 TechBase:Inner Sphere
 Era:3099
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11R.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11R.mtf
@@ -22,7 +22,7 @@ mul id:6415
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3102
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Exhumer EXR-2X.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Exhumer EXR-2X.mtf
@@ -22,7 +22,7 @@ mul id:6410
 Config:Biped
 TechBase:Inner Sphere
 Era:3129
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Kurita/Exhumer EXR-3P.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Exhumer EXR-3P.mtf
@@ -22,7 +22,7 @@ mul id:6411
 Config:Biped
 TechBase:Inner Sphere
 Era:3131
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Hatamoto-Godai HTM-30Z.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hatamoto-Godai HTM-30Z.mtf
@@ -22,7 +22,7 @@ mul id:6419
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3140
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Kurita/Hatamoto-Suna HTM-30S.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hatamoto-Suna HTM-30S.mtf
@@ -22,7 +22,7 @@ mul id:6418
 Config:Biped
 techbase:Inner Sphere
 era:3138
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1F.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1F.mtf
@@ -22,7 +22,7 @@ mul id:6412
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1P.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1P.mtf
@@ -22,7 +22,7 @@ mul id:6413
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K.mtf
@@ -22,7 +22,7 @@ mul id:6390
 Config:Biped
 TechBase:Inner Sphere
 Era:3116
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K2.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K2.mtf
@@ -22,7 +22,7 @@ mul id:6391
 Config:Biped
 TechBase:Inner Sphere
 Era:3116
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4K.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4K.mtf
@@ -22,7 +22,7 @@ mul id:6393
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4T.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4T.mtf
@@ -22,7 +22,7 @@ mul id:6392
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4X.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4X.mtf
@@ -22,7 +22,7 @@ mul id:6394
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3136
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Striker
 

--- a/data/mekfiles/meks/3145/Kurita/Shiro SH-1V.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Shiro SH-1V.mtf
@@ -22,7 +22,7 @@ mul id:6416
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3135
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Shiro SH-2P.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Shiro SH-2P.mtf
@@ -22,7 +22,7 @@ mul id:6417
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3135
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-O.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-O.mtf
@@ -22,7 +22,7 @@ mul id:6421
 Config:Biped Omnimech
 techbase:Inner Sphere
 era:3101
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OA.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OA.mtf
@@ -22,7 +22,7 @@ mul id:6422
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3101
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OB.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OB.mtf
@@ -22,7 +22,7 @@ mul id:6423
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3101
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OR.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OR.mtf
@@ -22,7 +22,7 @@ mul id:6424
 Config:Biped Omnimech
 techbase:Mixed (IS Chassis)
 era:3101
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Kurita/Wendigo (Prime).mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo (Prime).mtf
@@ -22,7 +22,7 @@ mul id:6402
 Config:Biped Omnimech
 TechBase:Clan
 Era:3135
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Wendigo A.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo A.mtf
@@ -22,7 +22,7 @@ mul id:6404
 Config:Biped Omnimech
 techbase:Clan
 era:3150
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Kurita/Wendigo B.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo B.mtf
@@ -22,7 +22,7 @@ mul id:6405
 Config:Biped Omnimech
 techbase:Clan
 era:3150
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Wendigo C.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo C.mtf
@@ -22,7 +22,7 @@ mul id:6406
 Config:Biped Omnimech
 techbase:Clan
 era:3150
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Wendigo-VP (Prime).mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo-VP (Prime).mtf
@@ -22,7 +22,7 @@ mul id:6408
 Config:Biped Omnimech
 TechBase:Clan
 Era:3134
-Source:TRO: 3145 Draconis Combine
+Source:TR:3145:DC
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Kurita/Wendigo-VP A.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo-VP A.mtf
@@ -22,7 +22,7 @@ mul id:6409
 Config:Biped Omnimech
 techbase:Clan
 era:3150
-source:TRO: 3145 Draconis Combine
+source:TR:3145:DC
 rules level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Anubis ABS-5Y.mtf
+++ b/data/mekfiles/meks/3145/Liao/Anubis ABS-5Y.mtf
@@ -22,7 +22,7 @@ mul id:6453
 Config:Biped
 TechBase:Inner Sphere
 Era:3121
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Liao/Anubis ABS-5Z.mtf
+++ b/data/mekfiles/meks/3145/Liao/Anubis ABS-5Z.mtf
@@ -22,7 +22,7 @@ mul id:6454
 Config:Biped
 TechBase:Inner Sphere
 Era:3124
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Liao/Calliope CAL-1MAF.mtf
+++ b/data/mekfiles/meks/3145/Liao/Calliope CAL-1MAF.mtf
@@ -22,7 +22,7 @@ mul id:6457
 Config:Biped
 TechBase:Inner Sphere
 Era:3127
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7.mtf
+++ b/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7.mtf
@@ -22,7 +22,7 @@ mul id:6464
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7L.mtf
+++ b/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7L.mtf
@@ -22,7 +22,7 @@ mul id:6465
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Gun GN-2O.mtf
+++ b/data/mekfiles/meks/3145/Liao/Gun GN-2O.mtf
@@ -22,7 +22,7 @@ mul id:6450
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3134
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Liao/Gun GN-2OA.mtf
+++ b/data/mekfiles/meks/3145/Liao/Gun GN-2OA.mtf
@@ -22,7 +22,7 @@ mul id:6451
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3134
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Liao/Gun GN-2OC.mtf
+++ b/data/mekfiles/meks/3145/Liao/Gun GN-2OC.mtf
@@ -22,7 +22,7 @@ mul id:6452
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3134
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Liao/Lu Wei Bing LN-4B.mtf
+++ b/data/mekfiles/meks/3145/Liao/Lu Wei Bing LN-4B.mtf
@@ -22,7 +22,7 @@ mul id:6471
 Config:Biped
 TechBase:Inner Sphere
 Era:3110
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Liao/Mortis MS-1A.mtf
+++ b/data/mekfiles/meks/3145/Liao/Mortis MS-1A.mtf
@@ -22,7 +22,7 @@ mul id:6466
 Config:Biped
 TechBase:Inner Sphere
 Era:3109
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Mortis MS-1P.mtf
+++ b/data/mekfiles/meks/3145/Liao/Mortis MS-1P.mtf
@@ -22,7 +22,7 @@ mul id:6467
 Config:Biped
 TechBase:Inner Sphere
 Era:3122
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Raven II RVN-5X.mtf
+++ b/data/mekfiles/meks/3145/Liao/Raven II RVN-5X.mtf
@@ -22,7 +22,7 @@ mul id:6458
 Config:Biped
 TechBase:Inner Sphere
 Era:3123
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N1.mtf
+++ b/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N1.mtf
@@ -22,7 +22,7 @@ mul id:6469
 Config:Biped
 TechBase:Inner Sphere
 Era:3090
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N2.mtf
+++ b/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N2.mtf
@@ -22,7 +22,7 @@ mul id:6470
 Config:Biped
 TechBase:Inner Sphere
 Era:3096
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N3.mtf
+++ b/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N3.mtf
@@ -22,7 +22,7 @@ mul id:6468
 Config:Biped
 TechBase:Inner Sphere
 Era:3140
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Liao/Vandal LI-O.mtf
+++ b/data/mekfiles/meks/3145/Liao/Vandal LI-O.mtf
@@ -22,7 +22,7 @@ mul id:6461
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3142
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Vandal LI-OA.mtf
+++ b/data/mekfiles/meks/3145/Liao/Vandal LI-OA.mtf
@@ -22,7 +22,7 @@ mul id:6462
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3142
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Vandal LI-OB.mtf
+++ b/data/mekfiles/meks/3145/Liao/Vandal LI-OB.mtf
@@ -22,7 +22,7 @@ mul id:6463
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3142
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3E.mtf
+++ b/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3E.mtf
@@ -22,7 +22,7 @@ mul id:6455
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3137
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:4
 role:Striker
 

--- a/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3Y.mtf
+++ b/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3Y.mtf
@@ -22,7 +22,7 @@ mul id:6456
 Config:Biped
 TechBase:Inner Sphere
 Era:3137
-Source:TRO: 3145 Capellan Confederation
+Source:TR:3145:CC
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Marik/Anzu ZU-G60.mtf
+++ b/data/mekfiles/meks/3145/Marik/Anzu ZU-G60.mtf
@@ -22,7 +22,7 @@ mul id:6510
 Config:Biped
 TechBase:Inner Sphere
 Era:3098
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Marik/Anzu ZU-J70.mtf
+++ b/data/mekfiles/meks/3145/Marik/Anzu ZU-J70.mtf
@@ -22,7 +22,7 @@ mul id:6511
 Config:Biped
 TechBase:Inner Sphere
 Era:3106
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Marik/Carronade CRN-7M.mtf
+++ b/data/mekfiles/meks/3145/Marik/Carronade CRN-7M.mtf
@@ -22,7 +22,7 @@ mul id:6512
 Config:Biped
 TechBase:Inner Sphere
 Era:3102
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Marik/Gambit GBT-1G.mtf
+++ b/data/mekfiles/meks/3145/Marik/Gambit GBT-1G.mtf
@@ -22,7 +22,7 @@ mul id:6500
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Marik/Gambit GBT-1L.mtf
+++ b/data/mekfiles/meks/3145/Marik/Gambit GBT-1L.mtf
@@ -22,7 +22,7 @@ mul id:6501
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Marik/Havoc HVC-P6.mtf
+++ b/data/mekfiles/meks/3145/Marik/Havoc HVC-P6.mtf
@@ -22,7 +22,7 @@ mul id:6502
 Config:Biped
 TechBase:Inner Sphere
 Era:3112
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Marik/Juliano JLN-5A.mtf
+++ b/data/mekfiles/meks/3145/Marik/Juliano JLN-5A.mtf
@@ -21,7 +21,7 @@ mul id:6516
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3116
-source:TRO: 3145 Free Worlds League
+source:TR:3145:FWL
 rules level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Marik/Neanderthal NTL-AG.mtf
+++ b/data/mekfiles/meks/3145/Marik/Neanderthal NTL-AG.mtf
@@ -22,7 +22,7 @@ mul id:6513
 Config:Biped
 TechBase:Inner Sphere
 Era:3128
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Marik/Neanderthal NTL-UG.mtf
+++ b/data/mekfiles/meks/3145/Marik/Neanderthal NTL-UG.mtf
@@ -22,7 +22,7 @@ mul id:6514
 Config:Biped
 TechBase:Inner Sphere
 Era:3124
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Marik/Quasimodo QSM-3D.mtf
+++ b/data/mekfiles/meks/3145/Marik/Quasimodo QSM-3D.mtf
@@ -22,7 +22,7 @@ mul id:6509
 Config:Biped
 TechBase:Inner Sphere
 Era:3140
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Marik/Sarath SRTH-1O.mtf
+++ b/data/mekfiles/meks/3145/Marik/Sarath SRTH-1O.mtf
@@ -22,7 +22,7 @@ mul id:6506
 Config:Quad Omnimech
 TechBase:Inner Sphere
 Era:3122
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OA.mtf
+++ b/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OA.mtf
@@ -22,7 +22,7 @@ mul id:6507
 Config:Quad Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3122
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:4
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OB.mtf
+++ b/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OB.mtf
@@ -22,7 +22,7 @@ mul id:6508
 Config:Quad Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3122
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Marik/Stalker II STK-9A.mtf
+++ b/data/mekfiles/meks/3145/Marik/Stalker II STK-9A.mtf
@@ -22,7 +22,7 @@ mul id:6515
 Config:Biped
 techbase:Inner Sphere
 era:3137
-source:TRO: 3145 Free Worlds League
+source:TR:3145:FWL
 rules level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Marik/Violator VT-U1.mtf
+++ b/data/mekfiles/meks/3145/Marik/Violator VT-U1.mtf
@@ -22,7 +22,7 @@ mul id:6503
 Config:Biped
 TechBase:Inner Sphere
 Era:3097
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Marik/Violator VT-U3.mtf
+++ b/data/mekfiles/meks/3145/Marik/Violator VT-U3.mtf
@@ -22,7 +22,7 @@ mul id:6504
 Config:Biped
 TechBase:Inner Sphere
 Era:3098
-Source:TRO: 3145 Free Worlds League
+Source:TR:3145:FWL
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 2.mtf
@@ -22,7 +22,7 @@ mul id:6555
 Config:Biped
 TechBase:Clan
 Era:3092
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 3.mtf
+++ b/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 3.mtf
@@ -22,7 +22,7 @@ mul id:6556
 Config:Biped
 TechBase:Clan
 Era:3092
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Black Hawk (Standard).mtf
+++ b/data/mekfiles/meks/3145/Merc/Black Hawk (Standard).mtf
@@ -22,7 +22,7 @@ mul id:6554
 Config:Biped
 techbase:Clan
 era:3073
-source:TRO: 3145 Mercenaries
+source:TR:3145:Merc
 rules level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Cadaver CVR-A1.mtf
+++ b/data/mekfiles/meks/3145/Merc/Cadaver CVR-A1.mtf
@@ -22,7 +22,7 @@ mul id:6550
 Config:Biped
 TechBase:Inner Sphere
 Era:3094
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Merc/Cadaver CVR-T1.mtf
+++ b/data/mekfiles/meks/3145/Merc/Cadaver CVR-T1.mtf
@@ -22,7 +22,7 @@ mul id:6551
 Config:Biped
 TechBase:Inner Sphere
 Era:3097
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Merc/HawkWolf HWK-4F.mtf
+++ b/data/mekfiles/meks/3145/Merc/HawkWolf HWK-4F.mtf
@@ -22,7 +22,7 @@ mul id:6576
 Config:Biped
 TechBase:Inner Sphere
 Era:3100
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Merc/Hound HD-2F.mtf
+++ b/data/mekfiles/meks/3145/Merc/Hound HD-2F.mtf
@@ -22,7 +22,7 @@ mul id:6563
 Config:Biped
 TechBase:Inner Sphere
 Era:3098
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk 2.mtf
@@ -22,7 +22,7 @@ mul id:6567
 Config:Biped
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk 3.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk 3.mtf
@@ -22,7 +22,7 @@ mul id:6568
 Config:Biped
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-03.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-03.mtf
@@ -22,7 +22,7 @@ mul id:6564
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3135
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-04.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-04.mtf
@@ -22,7 +22,7 @@ mul id:6565
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3135
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk.mtf
@@ -22,7 +22,7 @@ mul id:6566
 Config:Biped
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Koshi (Standard) 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Koshi (Standard) 2.mtf
@@ -22,7 +22,7 @@ mul id:6548
 Config:Biped
 TechBase:Clan
 Era:3095
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Merc/Koshi (Standard) 3.mtf
+++ b/data/mekfiles/meks/3145/Merc/Koshi (Standard) 3.mtf
@@ -22,7 +22,7 @@ mul id:6549
 Config:Biped
 TechBase:Clan
 Era:3095
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Merc/Koshi (Standard).mtf
+++ b/data/mekfiles/meks/3145/Merc/Koshi (Standard).mtf
@@ -21,7 +21,7 @@ mul id:6547
 Config:Biped
 TechBase:Clan
 Era:3091
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV (Prime).mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV (Prime).mtf
@@ -24,7 +24,7 @@ mul id:6570
 Config:Biped OmniMek
 techbase:Clan
 era:3136
-source:TRO: 3145 Mercenaries
+source:TR:3145:Merc
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV A.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV A.mtf
@@ -23,7 +23,7 @@ mul id:6571
 Config:Biped Omnimech
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV B.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV B.mtf
@@ -23,7 +23,7 @@ mul id:6572
 Config:Biped Omnimech
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV C.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV C.mtf
@@ -23,7 +23,7 @@ mul id:6573
 Config:Biped Omnimech
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR 2.mtf
@@ -24,7 +24,7 @@ mul id:6575
 Config:Biped
 techbase:Clan
 era:3131
-source:TRO: 3145 Mercenaries
+source:TR:3145:Merc
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR.mtf
@@ -24,7 +24,7 @@ mul id:6574
 Config:Biped
 techbase:Clan
 era:3130
-source:TRO: 3145 Mercenaries
+source:TR:3145:Merc
 rules level:3
 
 quirk:stable

--- a/data/mekfiles/meks/3145/Merc/Stalking Spider II.mtf
+++ b/data/mekfiles/meks/3145/Merc/Stalking Spider II.mtf
@@ -22,7 +22,7 @@ mul id:6553
 Config:Quad
 TechBase:Clan
 Era:3110
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Merc/Tiburon.mtf
+++ b/data/mekfiles/meks/3145/Merc/Tiburon.mtf
@@ -21,7 +21,7 @@ mul id:6552
 Config:Biped
 techbase:Clan
 era:3099
-source:TRO: 3145 Mercenaries
+source:TR:3145:Merc
 rules level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV A.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV A.mtf
@@ -23,7 +23,7 @@ mul id:6559
 Config:Biped Omnimech
 TechBase:Clan
 Era:3137
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV B.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV B.mtf
@@ -23,7 +23,7 @@ mul id:6560
 Config:Biped Omnimech
 techbase:Clan
 era:3137
-source:TRO: 3145 Mercenaries
+source:TR:3145:Merc
 rules level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV C.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV C.mtf
@@ -23,7 +23,7 @@ mul id:6561
 Config:Biped Omnimech
 TechBase:Clan
 Era:3137
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV D.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV D.mtf
@@ -23,7 +23,7 @@ mul id:6562
 Config:Biped Omnimech
 TechBase:Clan
 Era:3137
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV Prime.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV Prime.mtf
@@ -23,7 +23,7 @@ mul id:6558
 Config:Biped Omnimech
 TechBase:Clan
 Era:3137
-Source:TRO: 3145 Mercenaries
+Source:TR:3145:Merc
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Archer ARC-9KC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Archer ARC-9KC.mtf
@@ -22,7 +22,7 @@ mul id:6875
 Config:Biped
 TechBase:Inner Sphere
 Era:3089
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Atlas AS7-K4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Atlas AS7-K4.mtf
@@ -22,7 +22,7 @@ mul id:6832
 Config:Biped
 TechBase:Inner Sphere
 Era:3098
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Avatar AV1-OJ.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Avatar AV1-OJ.mtf
@@ -21,7 +21,7 @@ mul id:6874
 Config:Biped Omnimech
 techbase:Mixed (IS Chassis)
 era:3099
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Balius E.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Balius E.mtf
@@ -22,7 +22,7 @@ mul id:6883
 Config:Quad Omnimech
 TechBase:Clan
 Era:3127
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Banshee BNC-9S2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Banshee BNC-9S2.mtf
@@ -23,7 +23,7 @@ mul id:6844
 Config:Biped
 techbase:Inner Sphere
 era:3109
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Berserker BRZ-D4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Berserker BRZ-D4.mtf
@@ -22,7 +22,7 @@ mul id:6831
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3112
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Black Hawk (Nova) X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Black Hawk (Nova) X.mtf
@@ -23,7 +23,7 @@ mul id:6910
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3137
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Black Hawk-KU BHKU-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Black Hawk-KU BHKU-OG.mtf
@@ -22,7 +22,7 @@ mul id:6890
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3089
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ-2r.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ-2r.mtf
@@ -22,7 +22,7 @@ mul id:6914
 Config:Biped
 TechBase:Inner Sphere
 Era:3131
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ2-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ2-OG.mtf
@@ -22,7 +22,7 @@ mul id:6908
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Blade BLD-7R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Blade BLD-7R.mtf
@@ -22,7 +22,7 @@ mul id:6929
 Config:Biped
 TechBase:Inner Sphere
 Era:3094
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Commando COM-8S.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Commando COM-8S.mtf
@@ -22,7 +22,7 @@ mul id:6945
 Config:Biped
 TechBase:Inner Sphere
 Era:3108
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Cougar X 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cougar X 2.mtf
@@ -22,7 +22,7 @@ mul id:6952
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3089
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Cougar X 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cougar X 3.mtf
@@ -22,7 +22,7 @@ mul id:6953
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3093
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Cougar X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cougar X.mtf
@@ -22,7 +22,7 @@ mul id:6951
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3132
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2BC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2BC.mtf
@@ -22,7 +22,7 @@ mul id:6922
 Config:Biped
 TechBase:Inner Sphere
 Era:3119
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2X.mtf
@@ -22,7 +22,7 @@ mul id:6921
 Config:Biped
 TechBase:Inner Sphere
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Cygnus 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cygnus 4.mtf
@@ -22,7 +22,7 @@ mul id:6843
 Config:Biped
 techbase:Clan
 era:3090
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Dasher II 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Dasher II 3.mtf
@@ -22,7 +22,7 @@ mul id:6920
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3136
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Dasher II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Dasher II 4.mtf
@@ -22,7 +22,7 @@ mul id:6919
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3136
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Deimos D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Deimos D.mtf
@@ -22,7 +22,7 @@ mul id:6856
 Config:Biped Omnimech
 TechBase:Clan
 Era:3119
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Deimos E.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Deimos E.mtf
@@ -22,7 +22,7 @@ mul id:6855
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3140
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Diomede D-M3D-M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Diomede D-M3D-M.mtf
@@ -22,7 +22,7 @@ mul id:6823
 Config:Biped
 TechBase:Inner Sphere
 Era:3092
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-12.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-12.mtf
@@ -22,7 +22,7 @@ mul id:6942
 Config:Biped
 TechBase:Inner Sphere
 Era:3118
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-13.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-13.mtf
@@ -22,7 +22,7 @@ mul id:6943
 Config:Biped
 TechBase:Inner Sphere
 Era:3137
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Emperor EMP-8L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Emperor EMP-8L.mtf
@@ -22,7 +22,7 @@ mul id:6851
 Config:Biped
 TechBase:Inner Sphere
 Era:3127
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Fennec FEC-5CM.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Fennec FEC-5CM.mtf
@@ -22,7 +22,7 @@ mul id:6900
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3133
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Flamberge D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Flamberge D.mtf
@@ -22,7 +22,7 @@ mul id:6873
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3115
-Source:TRO: 3145
+Source:TR:3145
 Rules Level:4
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Gallant GLT-10-0.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Gallant GLT-10-0.mtf
@@ -22,7 +22,7 @@ mul id:6872
 Config:Biped
 TechBase:Inner Sphere
 Era:3130
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Ghost GST-50.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ghost GST-50.mtf
@@ -22,7 +22,7 @@ mul id:6907
 Config:Biped
 TechBase:Inner Sphere
 Era:3087
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Ghost GST-90.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ghost GST-90.mtf
@@ -22,7 +22,7 @@ mul id:6906
 Config:Biped
 TechBase:Inner Sphere
 Era:3133
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Grand Dragon DRG-10K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Grand Dragon DRG-10K.mtf
@@ -22,7 +22,7 @@ mul id:6889
 Config:Biped
 TechBase:Inner Sphere
 Era:3114
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Grand Titan T-IT-N13M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Grand Titan T-IT-N13M.mtf
@@ -22,7 +22,7 @@ mul id:6830
 Config:Biped
 TechBase:Inner Sphere
 Era:3091
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Griffin GRF-6S2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Griffin GRF-6S2.mtf
@@ -22,7 +22,7 @@ mul id:6899
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3123
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OF.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OF.mtf
@@ -22,7 +22,7 @@ mul id:6839
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3094
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OM.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OM.mtf
@@ -22,7 +22,7 @@ mul id:6838
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3120
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OT.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OT.mtf
@@ -22,7 +22,7 @@ mul id:6837
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3136
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Hellion G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hellion G.mtf
@@ -22,7 +22,7 @@ mul id:6939
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3119
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Javelin JVN-11P.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Javelin JVN-11P.mtf
@@ -22,7 +22,7 @@ mul id:6938
 Config:Biped
 TechBase:Inner Sphere
 Era:3101
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Jupiter 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Jupiter 4.mtf
@@ -22,7 +22,7 @@ mul id:6829
 Config:Biped
 TechBase:Clan
 Era:3093
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Karhu G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Karhu G.mtf
@@ -22,7 +22,7 @@ mul id:6882
 Config:Biped Omnimech
 TechBase:Clan
 Era:3099
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Koschei KSC-6L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Koschei KSC-6L.mtf
@@ -22,7 +22,7 @@ mul id:6881
 Config:Biped
 TechBase:Inner Sphere
 Era:3105
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Kuma 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Kuma 4.mtf
@@ -22,7 +22,7 @@ mul id:6888
 Config:Biped
 techbase:Clan
 era:3141
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Legionnaire LGN-2K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Legionnaire LGN-2K.mtf
@@ -22,7 +22,7 @@ mul id:6905
 Config:Biped
 TechBase:Inner Sphere
 Era:3128
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M2.mtf
@@ -22,7 +22,7 @@ mul id:6947
 Config:Biped
 TechBase:Inner Sphere
 Era:3087
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M3.mtf
@@ -22,7 +22,7 @@ mul id:6948
 Config:Biped
 TechBase:Inner Sphere
 Era:3088
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Loki (Hellbringer) G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Loki (Hellbringer) G.mtf
@@ -23,7 +23,7 @@ mul id:6879
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3112
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Longbow LGB-14C2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Longbow LGB-14C2.mtf
@@ -22,7 +22,7 @@ mul id:6854
 Config:Biped
 techbase:Inner Sphere
 era:3088
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 3.mtf
@@ -22,7 +22,7 @@ mul id:6896
 Config:Biped
 TechBase:Clan
 Era:3094
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 4.mtf
@@ -22,7 +22,7 @@ mul id:6897
 Config:Biped
 TechBase:Clan
 Era:3095
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 5.mtf
@@ -22,7 +22,7 @@ mul id:6898
 Config:Biped
 TechBase:Clan
 Era:3097
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 4.mtf
@@ -22,7 +22,7 @@ mul id:6850
 Config:Biped
 TechBase:Clan
 Era:3090
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 5.mtf
@@ -22,7 +22,7 @@ mul id:6849
 Config:Biped
 TechBase:Clan
 Era:3109
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 6.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 6.mtf
@@ -22,7 +22,7 @@ mul id:6848
 Config:Biped
 TechBase:Clan
 Era:3139
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Maelstrom MTR-7K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Maelstrom MTR-7K.mtf
@@ -22,7 +22,7 @@ mul id:6867
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3112
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Man O' War (Gargoyle) X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Man O' War (Gargoyle) X.mtf
@@ -24,7 +24,7 @@ mul id:6861
 Config:Biped Omnimech
 techbase:Mixed (Clan Chassis)
 era:3128
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Mangonel MNL-4S.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mangonel MNL-4S.mtf
@@ -21,7 +21,7 @@ mul id:6871
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3088
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Marauder II MAD-4L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Marauder II MAD-4L.mtf
@@ -22,7 +22,7 @@ mul id:6828
 Config:Biped
 TechBase:Inner Sphere
 Era:3084
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Marauder MAD-9D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Marauder MAD-9D.mtf
@@ -22,7 +22,7 @@ mul id:6866
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3125
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Marshal MHL-3MC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Marshal MHL-3MC.mtf
@@ -22,7 +22,7 @@ mul id:6895
 Config:Biped
 TechBase:Inner Sphere
 Era:3119	
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Men Shen MS1-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Men Shen MS1-OG.mtf
@@ -22,7 +22,7 @@ mul id:6894
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Morrigan 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Morrigan 4.mtf
@@ -22,7 +22,7 @@ mul id:6927
 Config:Biped
 techbase:Mixed (Clan Chassis)
 era:3111
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Morrigan 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Morrigan 5.mtf
@@ -22,7 +22,7 @@ mul id:6926
 Config:Biped
 techbase:Clan
 era:3124
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Nobori-nin (Huntsman) F.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nobori-nin (Huntsman) F.mtf
@@ -23,7 +23,7 @@ mul id:6904
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3132
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Nova Cat H.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nova Cat H.mtf
@@ -22,7 +22,7 @@ mul id:6869
 Config:Biped Omnimech
 TechBase:Clan
 Era:3099
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Nova Cat I.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nova Cat I.mtf
@@ -22,7 +22,7 @@ mul id:6870
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3132
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Nyx NX-100.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nyx NX-100.mtf
@@ -22,7 +22,7 @@ mul id:6937
 Config:Biped
 TechBase:Inner Sphere
 Era:3095
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Nyx NX-110.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nyx NX-110.mtf
@@ -22,7 +22,7 @@ mul id:6936
 Config:Biped
 TechBase:Inner Sphere
 Era:3141
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Ocelot 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ocelot 4.mtf
@@ -22,7 +22,7 @@ mul id:6925
 Config:Biped
 techbase:Clan
 era:3096
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Omen 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Omen 2.mtf
@@ -22,7 +22,7 @@ mul id:6853
 Config:Biped
 TechBase:Clan
 Era:3141
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Onager 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Onager 2.mtf
@@ -22,7 +22,7 @@ mul id:6847
 Config:Biped
 TechBase:Clan
 Era:3137
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Owens OW-1G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Owens OW-1G.mtf
@@ -22,7 +22,7 @@ mul id:6924
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3125
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Pack Hunter II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Pack Hunter II 4.mtf
@@ -22,7 +22,7 @@ mul id:6935
 Config:Biped
 techbase:Clan
 era:3093
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Panther PNT-12KC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Panther PNT-12KC.mtf
@@ -22,7 +22,7 @@ mul id:6923
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3139
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Peacekeeper PKP-2K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Peacekeeper PKP-2K.mtf
@@ -22,7 +22,7 @@ mul id:6836
 Config:Biped
 TechBase:Inner Sphere
 Era:3116
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Prefect PRF-3R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Prefect PRF-3R.mtf
@@ -22,7 +22,7 @@ mul id:6865
 Config:Biped
 TechBase:Inner Sphere
 Era:3110
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Quickdraw QKD-9M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Quickdraw QKD-9M.mtf
@@ -22,7 +22,7 @@ mul id:6887
 Config:Biped
 TechBase:Inner Sphere
 Era:3086
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Raptor II RPT-2X2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Raptor II RPT-2X2.mtf
@@ -22,7 +22,7 @@ mul id:6918
 Config:Biped
 TechBase:Inner Sphere
 Era:3109
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:4
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Sagittaire SGT-14D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sagittaire SGT-14D.mtf
@@ -22,7 +22,7 @@ mul id:6835
 Config:Biped
 TechBase:Inner Sphere
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Salamander PPR-7T.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Salamander PPR-7T.mtf
@@ -22,7 +22,7 @@ mul id:6860
 Config:Biped
 TechBase:Inner Sphere
 Era:3111
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Cat F.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Cat F.mtf
@@ -22,7 +22,7 @@ mul id:6912
 Config:Biped Omnimech
 TechBase:Mixed (Clan Chassis)
 Era:3131
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 3.mtf
@@ -22,7 +22,7 @@ mul id:6886
 Config:Biped
 TechBase:Clan
 Era:3089
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 4.mtf
@@ -22,7 +22,7 @@ mul id:6885
 Config:Biped
 TechBase:Clan
 Era:3092
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Hawk IIC 9.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Hawk IIC 9.mtf
@@ -22,7 +22,7 @@ mul id:6911
 Config:Biped
 TechBase:Clan
 Era:3134	
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shen Yi SHY-5B.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shen Yi SHY-5B.mtf
@@ -22,7 +22,7 @@ mul id:6878
 Config:Biped
 TechBase:Inner Sphere
 Era:3093
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-6H.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-6H.mtf
@@ -22,7 +22,7 @@ mul id:6903
 Config:Biped
 TechBase:Inner Sphere
 Era:3102
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-8X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-8X.mtf
@@ -22,7 +22,7 @@ mul id:6902
 Config:Biped
 TechBase:Inner Sphere
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Sphinx 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sphinx 3.mtf
@@ -22,7 +22,7 @@ mul id:6864
 Config:Biped
 TechBase:Clan
 Era:3091
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Sphinx 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sphinx 4.mtf
@@ -22,7 +22,7 @@ mul id:6863
 Config:Biped
 TechBase:Clan
 Era:3091
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Spider SDR-10K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Spider SDR-10K.mtf
@@ -22,7 +22,7 @@ mul id:6934
 Config:Biped
 TechBase:Inner Sphere
 Era:3143
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Spider SDR-8Xr.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Spider SDR-8Xr.mtf
@@ -22,7 +22,7 @@ mul id:6933
 Config:Biped
 TechBase:Inner Sphere
 Era:3103
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OH.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OH.mtf
@@ -22,7 +22,7 @@ mul id:6917
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3099
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OM.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OM.mtf
@@ -22,7 +22,7 @@ mul id:6916
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3135
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Sun Cobra 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sun Cobra 2.mtf
@@ -22,7 +22,7 @@ mul id:6893
 Config:Biped
 TechBase:Clan
 Era:3093
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OF.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OF.mtf
@@ -22,7 +22,7 @@ mul id:6846
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OG.mtf
@@ -22,7 +22,7 @@ mul id:6845
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3134
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Tarantula ZPH-5A.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Tarantula ZPH-5A.mtf
@@ -22,7 +22,7 @@ mul id:6941
 Config:Quad
 TechBase:Inner Sphere
 Era:3111	
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Targe TRG-3M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Targe TRG-3M.mtf
@@ -22,7 +22,7 @@ mul id:6915
 Config:Biped
 TechBase:Inner Sphere
 Era:3109
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/NTNU RS/Templar TLR1-OR.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Templar TLR1-OR.mtf
@@ -21,7 +21,7 @@ mul id:6852
 Config:Biped Omnimech
 techbase:Mixed (IS Chassis)
 era:3134
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Thunder Fox TFT-F11.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Thunder Fox TFT-F11.mtf
@@ -22,7 +22,7 @@ mul id:6892
 Config:Quad
 techbase:Mixed (IS Chassis)
 era:3119
-source:Record Sheets: 3145 New Tech New Upgrades
+source:RS:3145-NTNU
 rules level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Thunderbolt TDR-10S.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Thunderbolt TDR-10S.mtf
@@ -22,7 +22,7 @@ mul id:6877
 Config:Biped
 TechBase:Inner Sphere
 Era:3086
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Ti Ts'ang TSG-10L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ti Ts'ang TSG-10L.mtf
@@ -22,7 +22,7 @@ mul id:6884
 Config:Biped
 TechBase:Inner Sphere
 Era:3125
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Aj.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Aj.mtf
@@ -22,7 +22,7 @@ mul id:6827
 Config:Biped
 TechBase:Inner Sphere
 Era:3123
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Ar.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Ar.mtf
@@ -22,7 +22,7 @@ mul id:6826
 Config:Biped
 TechBase:Inner Sphere
 Era:3123
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Trebaruna TR-XH.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Trebaruna TR-XH.mtf
@@ -22,7 +22,7 @@ mul id:6834
 Config:Quad
 TechBase:Inner Sphere
 Era:3115
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Trebuchet TBT-9R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Trebuchet TBT-9R.mtf
@@ -22,7 +22,7 @@ mul id:6901
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3131
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Tundra Wolf 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Tundra Wolf 5.mtf
@@ -22,7 +22,7 @@ mul id:6862
 Config:Biped
 TechBase:Clan
 Era:3086
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Uller (Kit Fox) I.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Uller (Kit Fox) I.mtf
@@ -23,7 +23,7 @@ mul id:6932
 Config:Biped Omnimech
 TechBase:Clan
 Era:3101
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Valkyrie VLK-QD8.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Valkyrie VLK-QD8.mtf
@@ -22,7 +22,7 @@ mul id:6930
 Config:Biped
 TechBase:Inner Sphere
 Era:3102
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 10.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 10.mtf
@@ -22,7 +22,7 @@ mul id:6859
 Config:Biped
 TechBase:Clan
 Era:3120
-Source:Record Sheets: 3145 New Tech New Upgrades 
+Source:RS:3145-NTNU
 Rules Level:2
 role:Sniper
 

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 11.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 11.mtf
@@ -22,7 +22,7 @@ mul id:6858
 Config:Biped
 TechBase:Clan
 Era:3124
-Source:Record Sheets: 3145 New Tech New Upgrades 
+Source:RS:3145-NTNU
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 12.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 12.mtf
@@ -22,7 +22,7 @@ mul id:6857
 Config:Biped
 TechBase:Clan
 Era:3130
-Source:Record Sheets: 3145 New Tech New Upgrades 
+Source:RS:3145-NTNU
 Rules Level:4
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer WHM-8D2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer WHM-8D2.mtf
@@ -22,7 +22,7 @@ mul id:6868
 Config:Biped
 TechBase:Inner Sphere
 Era:3087
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3K.mtf
@@ -22,7 +22,7 @@ mul id:6949
 Config:Biped
 TechBase:Inner Sphere
 Era:3110
-Source:Record Sheets: 3145 New Tech New Upgrades 
+Source:RS:3145-NTNU
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3P.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3P.mtf
@@ -22,7 +22,7 @@ mul id:6950
 Config:Biped
 TechBase:Inner Sphere
 Era:3086
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-6O.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-6O.mtf
@@ -22,7 +22,7 @@ mul id:6825
 Config:Quad
 TechBase:Inner Sphere
 Era:3094
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-7O.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-7O.mtf
@@ -22,7 +22,7 @@ mul id:6824
 Config:Quad
 TechBase:Mixed (IS Chassis)
 Era:3119
-Source:Record Sheets: 3145 New Tech New Upgrades
+Source:RS:3145-NTNU
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Aphrodite.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Aphrodite.mtf
@@ -22,7 +22,7 @@ mul id:6688
 Config:Tripod Omnimech
 techbase:Mixed (IS Chassis)
 era:3136
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hades.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hades.mtf
@@ -22,7 +22,7 @@ mul id:6687
 Config:Tripod Omnimech
 techbase:Mixed (IS Chassis)
 era:3136
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hephaestus.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hephaestus.mtf
@@ -22,7 +22,7 @@ mul id:6689
 Config:Tripod Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3136
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hera.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hera.mtf
@@ -22,7 +22,7 @@ mul id:6686
 Config:Tripod Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3136
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Zeus.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Zeus.mtf
@@ -21,7 +21,7 @@ mul id:6685
 Config:Tripod Omnimech
 techbase:Mixed (IS Chassis)
 era:3136
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-O.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-O.mtf
@@ -22,7 +22,7 @@ mul id:6671
 Config:Quad Omnimech
 TechBase:Inner Sphere
 Era:3138
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OA.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OA.mtf
@@ -22,7 +22,7 @@ mul id:6704
 Config:Quad Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3138
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OB.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OB.mtf
@@ -22,7 +22,7 @@ mul id:6705
 Config:Quad Omnimech
 TechBase:Inner Sphere
 Era:3138
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OC.mtf
@@ -22,7 +22,7 @@ mul id:6706
 Config:Quad Omnimech
 TechBase:Inner Sphere
 Era:3138
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OD.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OD.mtf
@@ -22,7 +22,7 @@ mul id:6707
 Config:Quad Omnimech
 TechBase:Inner Sphere
 Era:3138
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OE.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OE.mtf
@@ -22,7 +22,7 @@ mul id:6708
 Config:Quad Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3138
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-04-R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-04-R.mtf
@@ -21,7 +21,7 @@ mul id:6709
 Config:Quad
 techbase:Inner Sphere
 era:3138
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-05-X.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-05-X.mtf
@@ -22,7 +22,7 @@ mul id:6710
 Config:Quad
 techbase:Inner Sphere
 era:3138
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-O.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-O.mtf
@@ -22,7 +22,7 @@ mul id:6678
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3121
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OA.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OA.mtf
@@ -22,7 +22,7 @@ mul id:6679
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3121
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OB.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OB.mtf
@@ -22,7 +22,7 @@ mul id:6680
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3121
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OC.mtf
@@ -22,7 +22,7 @@ mul id:6681
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3121
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OD.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OD.mtf
@@ -22,7 +22,7 @@ mul id:6682
 Config:Biped Omnimech
 TechBase:Mixed (IS Chassis)
 Era:3121
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-BD.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-BD.mtf
@@ -22,7 +22,7 @@ mul id:6672
 Config:Biped
 TechBase:Clan
 Era:3134
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-C.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-C.mtf
@@ -22,7 +22,7 @@ mul id:6711
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA Wolpertinger.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA Wolpertinger.mtf
@@ -22,7 +22,7 @@ mul id:6713
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3142
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA.mtf
@@ -22,7 +22,7 @@ mul id:6712
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Republic/Kheper KHP-7R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Kheper KHP-7R.mtf
@@ -22,7 +22,7 @@ mul id:6675
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-2R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-2R.mtf
@@ -22,7 +22,7 @@ mul id:6676
 Config:Biped
 TechBase:Inner Sphere
 Era:3126
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-3C.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-3C.mtf
@@ -22,7 +22,7 @@ mul id:6722
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-3R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-3R.mtf
@@ -22,7 +22,7 @@ mul id:6723
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-4RC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-4RC.mtf
@@ -22,7 +22,7 @@ mul id:6724
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3137
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XP.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XP.mtf
@@ -22,7 +22,7 @@ mul id:6725
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3139
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XT.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XT.mtf
@@ -22,7 +22,7 @@ mul id:6683
 Config:Biped
 TechBase:Inner Sphere
 Era:3134
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XV.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XV.mtf
@@ -22,7 +22,7 @@ mul id:6726
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3140
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-YZ.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-YZ.mtf
@@ -22,7 +22,7 @@ mul id:6727
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3142
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K1.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K1.mtf
@@ -22,7 +22,7 @@ mul id:6718
 Config:Biped
 TechBase:Inner Sphere
 Era:3134
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K3.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K3.mtf
@@ -22,7 +22,7 @@ mul id:6674
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K4.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K4.mtf
@@ -22,7 +22,7 @@ mul id:6719
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K7.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K7.mtf
@@ -22,7 +22,7 @@ mul id:6720
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-KC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-KC.mtf
@@ -22,7 +22,7 @@ mul id:6721
 Config:Biped
 TechBase:Inner Sphere
 Era:3136
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:4
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Poseidon PSD-V2.mtf
+++ b/data/mekfiles/meks/3145/Republic/Poseidon PSD-V2.mtf
@@ -22,7 +22,7 @@ mul id:6684
 Config:Tripod
 techbase:Mixed (IS Chassis)
 era:3136
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:3
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R.mtf
@@ -22,7 +22,7 @@ mul id:6673
 Config:Quad
 TechBase:Inner Sphere
 Era:3139
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R2.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R2.mtf
@@ -22,7 +22,7 @@ mul id:6714
 Config:Quad
 TechBase:Inner Sphere
 Era:3139
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R3.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R3.mtf
@@ -22,7 +22,7 @@ mul id:6715
 Config:Quad
 TechBase:Inner Sphere
 Era:3141
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R4.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R4.mtf
@@ -22,7 +22,7 @@ mul id:6716
 Config:Quad
 TechBase:Inner Sphere
 Era:3142
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R7.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R7.mtf
@@ -22,7 +22,7 @@ mul id:6717
 Config:Quad
 TechBase:Inner Sphere
 Era:3144
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Republic/Uraeus UAE-7R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Uraeus UAE-7R.mtf
@@ -22,7 +22,7 @@ mul id:6677
 Config:Biped
 TechBase:Inner Sphere
 Era:3135
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M2.mtf
@@ -22,7 +22,7 @@ mul id:6609
 Config:Biped
 TechBase:Inner Sphere
 Era:3101
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M3.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M3.mtf
@@ -22,7 +22,7 @@ mul id:6610
 Config:Biped
 TechBase:Inner Sphere
 Era:3104
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M4.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M4.mtf
@@ -22,7 +22,7 @@ mul id:6611
 Config:Biped
 TechBase:Inner Sphere
 Era:3109
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1O.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1O.mtf
@@ -22,7 +22,7 @@ mul id:6621
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3128
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OA.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OA.mtf
@@ -22,7 +22,7 @@ mul id:6622
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3128
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OB.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OB.mtf
@@ -22,7 +22,7 @@ mul id:6623
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3128
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OC.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OC.mtf
@@ -22,7 +22,7 @@ mul id:6624
 Config:Biped Omnimech
 TechBase:Inner Sphere
 Era:3128
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Gotterdammerung GTD-20S.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gotterdammerung GTD-20S.mtf
@@ -21,7 +21,7 @@ mul id:6629
 Config:Biped
 techbase:Inner Sphere
 era:3138
-source:TRO: 3145 Lyran Commonwealth
+source:TR:3145:LC
 rules level:2
 role:Brawler
 

--- a/data/mekfiles/meks/3145/Steiner/Jaguar 2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Jaguar 2.mtf
@@ -22,7 +22,7 @@ mul id:6613
 Config:Quad
 TechBase:Clan
 Era:3123
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Striker
 

--- a/data/mekfiles/meks/3145/Steiner/Jaguar.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Jaguar.mtf
@@ -22,7 +22,7 @@ mul id:6612
 Config:Quad
 TechBase:Clan
 Era:3121
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/3145/Steiner/King Crab KGC-009.mtf
+++ b/data/mekfiles/meks/3145/Steiner/King Crab KGC-009.mtf
@@ -22,7 +22,7 @@ mul id:6635
 Config:Biped
 TechBase:Inner Sphere
 Era:3104
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Juggernaut
 

--- a/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T1.mtf
@@ -22,7 +22,7 @@ mul id:6618
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3092
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:4
 role:Striker
 

--- a/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T2.mtf
@@ -22,7 +22,7 @@ mul id:6619
 Config:Biped
 TechBase:Mixed (Clan Chassis)
 Era:3108
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:4
 role:Striker
 

--- a/data/mekfiles/meks/3145/Steiner/Scourge SCG-WD1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Scourge SCG-WD1.mtf
@@ -22,7 +22,7 @@ mul id:6626
 Config:Biped
 TechBase:Inner Sphere
 Era:3131
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Scourge SCG-WF1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Scourge SCG-WF1.mtf
@@ -22,7 +22,7 @@ mul id:6625
 Config:Biped
 TechBase:Inner Sphere
 Era:3133
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R1.mtf
@@ -22,7 +22,7 @@ mul id:6615
 Config:Biped
 TechBase:Inner Sphere
 Era:3097
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R2.mtf
@@ -22,7 +22,7 @@ mul id:6616
 Config:Biped
 TechBase:Inner Sphere
 Era:3098
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R3.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R3.mtf
@@ -22,7 +22,7 @@ mul id:6614
 Config:Biped
 TechBase:Inner Sphere
 Era:3106
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:2
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R4.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R4.mtf
@@ -22,7 +22,7 @@ mul id:6617
 Config:Biped
 TechBase:Inner Sphere
 Era:3108
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Scout
 

--- a/data/mekfiles/meks/3145/Steiner/Ursa URA-2A.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Ursa URA-2A.mtf
@@ -22,7 +22,7 @@ mul id:6627
 Config:Quad
 TechBase:Inner Sphere
 Era:3122
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Ursa URA-2C.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Ursa URA-2C.mtf
@@ -22,7 +22,7 @@ mul id:6628
 Config:Quad
 TechBase:Clan
 Era:3125
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Viking IIC.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Viking IIC.mtf
@@ -22,7 +22,7 @@ mul id:6634
 Config:Biped
 TechBase:Clan
 Era:3095
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:3
 role:Missile Boat
 

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X.mtf
@@ -22,7 +22,7 @@ mul id:6631
 Config:Biped
 TechBase:Inner Sphere
 Era:3054
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X2.mtf
@@ -22,7 +22,7 @@ mul id:6632
 Config:Biped
 TechBase:Inner Sphere
 Era:3069
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X3.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X3.mtf
@@ -21,7 +21,7 @@ mul id:6633
 Config:Biped
 techbase:Inner Sphere
 era:3089
-source:TRO: 3145 Lyran Commonwealth
+source:TR:3145:LC
 rules level:4
 role:Skirmisher
 

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X4.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X4.mtf
@@ -22,7 +22,7 @@ mul id:6630
 Config:Biped
 TechBase:Inner Sphere
 Era:3119
-Source:TRO: 3145 Lyran Commonwealth
+Source:TR:3145:LC
 Rules Level:4
 role:Sniper
 

--- a/data/mekfiles/meks/3150/Gotterdammerung GTD-20C.mtf
+++ b/data/mekfiles/meks/3150/Gotterdammerung GTD-20C.mtf
@@ -21,7 +21,7 @@ mul id:8061
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3138
-source:TRO: 3145 Lyran Commonwealth
+source:TR:3145:LC
 rules level:3
 
 mass:75

--- a/data/mekfiles/meks/3150/Gotterdammerung GTD-30S.mtf
+++ b/data/mekfiles/meks/3150/Gotterdammerung GTD-30S.mtf
@@ -21,7 +21,7 @@ mul id:8062
 Config:Biped
 techbase:Inner Sphere
 era:3138
-source:TRO: 3145 Lyran Commonwealth
+source:TR:3145:LC
 rules level:2
 
 mass:75

--- a/data/mekfiles/meks/Dark Age/Agrotera AGT-1A.mtf
+++ b/data/mekfiles/meks/Dark Age/Agrotera AGT-1A.mtf
@@ -21,7 +21,7 @@ mul id:6459
 Config:Biped
 techbase:Inner Sphere
 era:3108
-source:TRO: 3145 Capellan Confederation
+source:TR:3145:CC
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/QuadVees/Arion.mtf
+++ b/data/mekfiles/meks/QuadVees/Arion.mtf
@@ -22,7 +22,7 @@ mul id:6252
 Config:QuadVee
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Striker
 

--- a/data/mekfiles/meks/QuadVees/Cyllaros.mtf
+++ b/data/mekfiles/meks/QuadVees/Cyllaros.mtf
@@ -22,7 +22,7 @@ mul id:6253
 Config:QuadVee
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Skirmisher
 

--- a/data/mekfiles/meks/QuadVees/Harpagos.mtf
+++ b/data/mekfiles/meks/QuadVees/Harpagos.mtf
@@ -22,7 +22,7 @@ mul id:6254
 Config:QuadVee
 TechBase:Clan
 Era:3136
-Source:TRO: 3145 The Clans
+Source:TR:3145:C
 Rules Level:3
 role:Sniper
 

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-KA.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-KA.mtf
@@ -23,7 +23,7 @@ mul id:6712
 Config:Biped
 techbase:Mixed (Clan Chassis)
 era:3135
-source:TRO: 3145 Republic of the Sphere
+source:TR:3145:RotS
 rules level:3
 role:Striker
 

--- a/data/mekfiles/meks/Turning Points/TP Epsilon Eridani/Lament LMT-2R (Manes).mtf
+++ b/data/mekfiles/meks/Turning Points/TP Epsilon Eridani/Lament LMT-2R (Manes).mtf
@@ -22,7 +22,7 @@ mul id:7400
 Config:Biped
 TechBase:Mixed (IS Chassis)
 Era:3126
-Source:TRO: 3145 Republic of the Sphere
+Source:TR:3145:RotS
 Rules Level:3
 role:Brawler
 

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Vulpes VLP-1DX _Beast_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Vulpes VLP-1DX _Beast_.mtf
@@ -22,7 +22,7 @@ mul id:8382
 Config:Biped
 techbase:Mixed (IS Chassis)
 era:3134
-source:TRO: 3145 Federated Suns
+source:TR:3145:FS
 rules level:3
 role:Brawler
 

--- a/data/sourcebooks/TR_3145_C.yaml
+++ b/data/sourcebooks/TR_3145_C.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 The Clans'
+abbrev: TR:3145:C
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_CC.yaml
+++ b/data/sourcebooks/TR_3145_CC.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Capellan Confederation'
+abbrev: TR:3145:CC
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_DC.yaml
+++ b/data/sourcebooks/TR_3145_DC.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Draconis Combine'
+abbrev: TR:3145:DC
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_FS.yaml
+++ b/data/sourcebooks/TR_3145_FS.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Federated Suns'
+abbrev: TR:3145:FS
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_FWL.yaml
+++ b/data/sourcebooks/TR_3145_FWL.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Free Worlds League'
+abbrev: TR:3145:FWL
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_LC.yaml
+++ b/data/sourcebooks/TR_3145_LC.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Lyran Commonwealth'
+abbrev: TR:3145:LC
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_Merc.yaml
+++ b/data/sourcebooks/TR_3145_Merc.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Mercenaries'
+abbrev: TR:3145:Merc
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440

--- a/data/sourcebooks/TR_3145_RotS.yaml
+++ b/data/sourcebooks/TR_3145_RotS.yaml
@@ -1,0 +1,23 @@
+id: -1
+sku: ''
+title: 'Technical Readout: 3145 Republic of the Sphere'
+abbrev: TR:3145:RotS
+image: http://cfw.sarna.net/wiki/images/thumb/0/00/TRO3145.jpg/280px-aehcroru1se3cgk0rmmgeg451t73x2t.jpg?timestamp=20130929205855
+url: https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf
+ispublished: true
+description: '<p><strong>Eve of Destruction</strong></p><p>&nbsp;</p><p>The great
+  experiment that was the Republic of the Sphere has failed. Withdrawn behind the
+  Fortress walls, the once-great power has become a silent, opaque remnant of its
+  former glory. Without its influence, old hatreds have risen anew. As war once more
+  rages across the Inner Sphere, new equipment strides across ancient battlefields.
+  Technology, once stagnated by trade restrictions and peace treaties, now surges
+  forward again, testing these new machines in the fierce crucible of war.</p><p><strong>Technical
+  Readout: 3145</strong> introduces the latest wave of new battle armor, vehicle,
+  ''Mech, and aerospace units appearing in the Republic Armed Forces and across the
+  Inner Sphere in the Dark Age era. Featuring new equipment described in <i>Era Report:
+  3145</i> and <i>Field Manual: 3145</i>, this book brings players an update on the
+  advancing technologies used in the battlefields of the thirty-second century.</p><p>&nbsp;</p><p><br><a
+  href="https://store.catalystgamelabs.com/products/battletech-technical-readout-3145-pdf">Buy
+  the PDF at the Catalyst Game Labs Store</a></p><p><a href="https://www.drivethrurpg.com/product/153256/BattleTech-Technical-Readout-3145">Buy
+  the PDF at DriveThruRPG</a></p>'
+mul_url: http://www.masterunitlist.info/Source/Details/440


### PR DESCRIPTION
Also adds sourcebook data for TRO: 3145 The Clans and similar. These are not available in the MUL and they all link to the basic TRO: 3145. 