### PR TITLE
Fix #112: Explicitly Excluded units.cache From Build Process Preventing Duplicate Unit Issue in MML and MHQ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ tasks.register<Zip>("unitFilesZip") {
         exclude("*.txt")
         exclude("*.xml")
         exclude("units.cache")
-        into("mekfiles")
     }
 }
 


### PR DESCRIPTION
Fix #112

This PR applies paranoid exclusion lines to all instances where we're building the contents of `data/mekfiles/` this ensures that we never pass `units.cache` downstream. It also should exclude `units.cache` from being built while staging files. That should help reduce build time. As previously it looks like we were building the cache, and then rebuilding it when the apps launched. This _appears_ to have only been affecting mml and mhq. As the cache was being created during the substantializing of mm.