### PR TITLE
Improvement: Made the Amaris Coup Ultimatum Available for Terran Hegemony

### DIFF
--- a/data/universe/factionStandingUltimatums.yml
+++ b/data/universe/factionStandingUltimatums.yml
@@ -75,6 +75,19 @@ ultimatums:
       role: MEKWARRIOR
       factionCode: SL
     isViolentTransition: true
+  - date: 2766-12-26
+    # Represents the date when Stefan Amaris shot Richard Cameron II and caused the downfall of the Star League
+    name: AMARIS_COUP
+    affectedFactionCode: TH
+    challenger:
+      name: First Citizen Stefan Amaris
+      role: NOBLE
+      factionCode: TH
+    incumbent:
+      name: General Aleksandr Kerensky
+      role: MEKWARRIOR
+      factionCode: SL
+    isViolentTransition: true
   - date: 2784-11-05
     # Represents the date when the SLDF left the inner sphere. I opted to go with this date rather than Kerensky's
     # address as it results in the least amount of downtime between when the exodus begins and when the player will


### PR DESCRIPTION
This makes the Amaris Coup ultimatum appear both for Star League campaigns and Terran Hegemony campaigns, rather than just Star League