### PR TITLE
Fix: Corrected Contract Definitions' Early End State

### DIFF
--- a/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Diversionary Raid</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Engage hostile forces.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>

--- a/data/stratconcontractdefinitions/ExtractionRaid.xml
+++ b/data/stratconcontractdefinitions/ExtractionRaid.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Extraction Raid</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Capture and extract designated assets.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>10</scenarioOdds>

--- a/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Guerrilla Warfare</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Engage hostile forces. Be quick.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>

--- a/data/stratconcontractdefinitions/ObjectiveRaid.xml
+++ b/data/stratconcontractdefinitions/ObjectiveRaid.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Objective Raid</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Destroy designated targets.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>10</scenarioOdds>

--- a/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/data/stratconcontractdefinitions/PirateHunting.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Pirate Hunting</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Locate and destroy pirate facilities.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>10</scenarioOdds>

--- a/data/stratconcontractdefinitions/PlanetaryAssault.xml
+++ b/data/stratconcontractdefinitions/PlanetaryAssault.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Planetary Assault</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Destroy or capture designated facilities.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>20</scenarioOdds>

--- a/data/stratconcontractdefinitions/ReconRaid.xml
+++ b/data/stratconcontractdefinitions/ReconRaid.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Recon Raid</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Conduct reconnaissance on designated units and locations.</briefing>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>10</scenarioOdds>

--- a/data/stratconcontractdefinitions/ReliefDuty.xml
+++ b/data/stratconcontractdefinitions/ReliefDuty.xml
@@ -21,6 +21,7 @@
     <contractTypeName>Relief Duty</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Destroy or capture designated facilities while holding existing gains.</briefing>
+    <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>20</scenarioOdds>


### PR DESCRIPTION
# Required By [Improvement: Added More Robust Notifications for When Contracts Can Be Ended Early](https://github.com/MegaMek/mekhq/pull/7837)

This fixes a bug where contracts were not being correctly marked as early end eligible. This is due to the value for `allowEarlyVictory` initializing as `false`. As only contracts where this value was `false` had an xml entry no contract was considered eligible for early end.