### PR TITLE
Improvement: Updated Stock Presets to Account for Use Better Extra Income Campaign Option

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -550,6 +550,7 @@
         <simulateGrayMonday>false</simulateGrayMonday>
         <allowMonthlyReinvestment>true</allowMonthlyReinvestment>
         <allowMonthlyConnections>true</allowMonthlyConnections>
+        <useBetterExtraIncome>true</useBetterExtraIncome>
         <useSmallArmsOnly>false</useSmallArmsOnly>
         <commonPartPriceMultiplier>1.0</commonPartPriceMultiplier>
         <innerSphereUnitPriceMultiplier>1.0</innerSphereUnitPriceMultiplier>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -492,6 +492,7 @@
         <simulateGrayMonday>true</simulateGrayMonday>
         <allowMonthlyReinvestment>true</allowMonthlyReinvestment>
         <allowMonthlyConnections>true</allowMonthlyConnections>
+        <useBetterExtraIncome>true</useBetterExtraIncome>
         <useSmallArmsOnly>false</useSmallArmsOnly>
         <commonPartPriceMultiplier>1.0</commonPartPriceMultiplier>
         <innerSphereUnitPriceMultiplier>1.0</innerSphereUnitPriceMultiplier>

--- a/data/campaignPresets/3 - Campaign Operations Preset.xml
+++ b/data/campaignPresets/3 - Campaign Operations Preset.xml
@@ -492,6 +492,7 @@
         <simulateGrayMonday>false</simulateGrayMonday>
         <allowMonthlyReinvestment>false</allowMonthlyReinvestment>
         <allowMonthlyConnections>false</allowMonthlyConnections>
+        <useBetterExtraIncome>false</useBetterExtraIncome>
         <useSmallArmsOnly>true</useSmallArmsOnly>
         <commonPartPriceMultiplier>1.0</commonPartPriceMultiplier>
         <innerSphereUnitPriceMultiplier>1.0</innerSphereUnitPriceMultiplier>


### PR DESCRIPTION
This is the mm-data side of [Feature: Implemented 'Extra-Income' A Time of War Trait](https://github.com/MegaMek/mekhq/pull/7517). Updating our stock presets to account for the new 'Better Extra Income' campaign option.