### PR TITLE
Fix: Fixed Spelling of 'Charisma' in SPAs

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -2631,7 +2631,7 @@
             </skillPrereq>
         </ability>
         <ability>
-            <displayName>Exceptional Attribute - Chrisma (ATOW)</displayName>
+            <displayName>Exceptional Attribute - Charisma (ATOW)</displayName>
             <lookupName>exceptional_attribute_charisma</lookupName>
             <desc>Characters can only increase their Attributes up to a maximum determined by their Phenotype.
 

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -2573,7 +2573,7 @@
             </skillPrereq>
         </ability>
         <ability>
-            <displayName>Exceptional Attribute - Chrisma (ATOW)</displayName>
+            <displayName>Exceptional Attribute - Charisma (ATOW)</displayName>
             <lookupName>exceptional_attribute_charisma</lookupName>
             <desc>Characters can only increase their Attributes up to a maximum determined by their Phenotype.
 

--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -1079,7 +1079,7 @@ This SPA increases that maximum by 1, but does not increase the Attribute itself
     </ability>
     <ability>
         <lookupName>exceptional_attribute_charisma</lookupName>
-        <displayName>Exceptional Attribute - Chrisma (ATOW)</displayName>
+        <displayName>Exceptional Attribute - Charisma (ATOW)</displayName>
         <desc><![CDATA[Characters can only increase their Attributes up to a maximum determined by their Phenotype.
 
 This SPA increases that maximum by 1, but does not increase the Attribute itself.]]></desc>


### PR DESCRIPTION
`Chrsma` -> `Charisma`