### PR TITLE
Improvement: Changed Four Flaws to 'Origin Only' in Response to Player Feedback

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -1695,7 +1695,7 @@ If Advanced Medical is disabled the character gains a single Hit, instead of the
 
 While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
         <xpCost>-500</xpCost>
-        <originOnly>false</originOnly>
+        <originOnly>true</originOnly>
         <weight>1</weight>
         <skillPrereq />
     </ability>
@@ -1708,7 +1708,7 @@ If Advanced Medical is disabled the character suffers 1 Hit, instead of the Inju
 
 While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
         <xpCost>-400</xpCost>
-        <originOnly>false</originOnly>
+        <originOnly>true</originOnly>
         <weight>1</weight>
         <skillPrereq />
     </ability>
@@ -1723,7 +1723,7 @@ While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
 
 While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
         <xpCost>-400</xpCost>
-        <originOnly>false</originOnly>
+        <originOnly>true</originOnly>
         <weight>1</weight>
         <skillPrereq />
     </ability>
@@ -1736,7 +1736,7 @@ If Advanced Medical is disabled 1-2 Hits are inflicted, instead of Injuries.
 
 While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
         <xpCost>-500</xpCost>
-        <originOnly>false</originOnly>
+        <originOnly>true</originOnly>
         <weight>1</weight>
         <skillPrereq />
     </ability>


### PR DESCRIPTION
This PR changes the following Flaws to be 'origin only'. An origin only SPA/Flaw is one that can only appear on a character when that character is generated. They will not appear via coming of age or veterancy awards.

- Clinical Insanity - Catatonia
- Major Psychosis - Regression
- Major Psychosis - Hysteria
- Clinical Insanity - Berserker

Player feedback - as well as developer monitoring of the situation (see https://github.com/MegaMek/mekhq/pull/7949) - has shown that the Flaws listed above were having a disproportionate impact on player campaigns.

Some ideas were floated by player regarding advanced systems, or expansions to other systems, that could be used to mitigate this issue. Ultimately, I opted not to go with any of them for the following reasons:

- developer time investment required
- user experience complexity - the need to ensure that the solutions to the problems posed by the above were obvious and manageable
- any attempt to reduce the impact of these Flaws resulted in them not being worth the 400-500 XP they're rated as. With that kind of XP bump we need to ensure that the player is facing a proportionate inconvenience.

By marking these Flaws as 'origin only' we ensure that player interactions with them are largely consensual.