### PR TITLE
Fix: Improved & Fixed Soldier Spawning in New Personnel Market Data

### DIFF
--- a/data/universe/markets/personnelMarket/clanMarketCamOpsRevised.yaml
+++ b/data/universe/markets/personnelMarket/clanMarketCamOpsRevised.yaml
@@ -92,13 +92,6 @@
   extinctionYear: -1
   fallbackProfession: SOLDIER
 
-- weight: 1389
-  profession: SOLDIER
-  count: 25
-  introductionYear: 0
-  extinctionYear: -1
-  fallbackProfession: DEPENDENT
-
 - weight: 2084 # CamOps has it at 2778 but we need to also include BA, so we split the chance 3:1
   profession: SOLDIER
   count: 25

--- a/data/universe/markets/personnelMarket/clanMarketMekHQ.yaml
+++ b/data/universe/markets/personnelMarket/clanMarketMekHQ.yaml
@@ -143,7 +143,7 @@
 
 - weight: 1389
   profession: SOLDIER
-  count: 6
+  count: 25
   introductionYear: 0
   extinctionYear: -1
   fallbackProfession: DEPENDENT

--- a/data/universe/markets/personnelMarket/innerSphereMarketCamOpsRevised.yaml
+++ b/data/universe/markets/personnelMarket/innerSphereMarketCamOpsRevised.yaml
@@ -109,7 +109,7 @@
 
 - weight: 2222 # CamOps states that this result is 2778 so we divided it across conv. infantry and BA 4:1
   profession: SOLDIER
-  count: 25
+  count: 28
   introductionYear: 0
   extinctionYear: -1
   fallbackProfession: DEPENDENT

--- a/data/universe/markets/personnelMarket/innerSphereMarketCamOpsStrict.yaml
+++ b/data/universe/markets/personnelMarket/innerSphereMarketCamOpsStrict.yaml
@@ -59,7 +59,7 @@
 
 - weight: 2778
   profession: SOLDIER
-  count: 25
+  count: 28
   introductionYear: 0
   extinctionYear: -1
   fallbackProfession: DEPENDENT

--- a/data/universe/markets/personnelMarket/innerSphereMarketMekHQ.yaml
+++ b/data/universe/markets/personnelMarket/innerSphereMarketMekHQ.yaml
@@ -150,7 +150,7 @@
 
 - weight: 2315
   profession: SOLDIER
-  count: 6
+  count: 28
   introductionYear: 0
   extinctionYear: -1
   fallbackProfession: DEPENDENT


### PR DESCRIPTION
- Removed duplicate Soldier entry from `clanMarketCamOpsRevised.yaml`
- Fixed Soldier spawn count in `innerSphereMarketCamOpsRevised.yaml` and `innerSphereMarketCamOpsStrict.yaml` to be at a rate of 28 and not 25 (that's the Clan value)
- Increases the number of Soldiers generated per 'soldier' result in the MekHQ Clan and Inner Sphere markets to 25 & 28 respectively. This was based on player feedback regarding the difficulty of crewing infantry platoons.