### PR TITLE
Task: Updated Stock Presets for New 'No Deliveries in Transit' Campaign Option

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -248,6 +248,7 @@
         <acquisitionPersonnelCategory>LOGISTICS</acquisitionPersonnelCategory>
         <techLevel>0</techLevel>
         <unitTransitTime>1</unitTransitTime>
+        <noDeliveriesInTransit>false</noDeliveriesInTransit>
         <usePlanetaryAcquisition>false</usePlanetaryAcquisition>
         <planetAcquisitionFactionLimit>NEUTRAL</planetAcquisitionFactionLimit>
         <planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -190,6 +190,7 @@
         <acquisitionPersonnelCategory>LOGISTICS</acquisitionPersonnelCategory>
         <techLevel>3</techLevel>
         <unitTransitTime>2</unitTransitTime>
+        <noDeliveriesInTransit>true</noDeliveriesInTransit>
         <usePlanetaryAcquisition>true</usePlanetaryAcquisition>
         <planetAcquisitionFactionLimit>NEUTRAL</planetAcquisitionFactionLimit>
         <planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>

--- a/data/campaignPresets/3 - Campaign Operations Preset.xml
+++ b/data/campaignPresets/3 - Campaign Operations Preset.xml
@@ -190,6 +190,7 @@
         <acquisitionPersonnelCategory>SUPPORT</acquisitionPersonnelCategory>
         <techLevel>3</techLevel>
         <unitTransitTime>2</unitTransitTime>
+        <noDeliveriesInTransit>false</noDeliveriesInTransit>
         <usePlanetaryAcquisition>false</usePlanetaryAcquisition>
         <planetAcquisitionFactionLimit>NEUTRAL</planetAcquisitionFactionLimit>
         <planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>


### PR DESCRIPTION
# Requires [Improvement: Added a Campaign Option to Obstruct Delivery of Parts and Units While in Transit](https://github.com/MegaMek/mekhq/pull/8024)

This PR updates the stock presets to take advantage of the new campaign option