### PR TITLE
Fix: Removed Duplicate Weapon Specialist Entry

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -444,21 +444,6 @@
         </skillPrereq>
     </ability>
     <ability>
-        <lookupName>weapon_specialist</lookupName>
-        <xpCost>50</xpCost>
-        <originOnly>false</originOnly>
-        <weight>4</weight>
-        <skillPrereq>
-            <skill>Gunnery/Mek::Green</skill>
-            <skill>Gunnery/ProtoMek::Green</skill>
-            <skill>Gunnery/Aircraft::Green</skill>
-            <skill>Gunnery/Aerospace::Green</skill>
-            <skill>Gunnery/Spacecraft::Green</skill>
-            <skill>Gunnery/BattleArmor::Green</skill>
-            <skill>Gunnery/Vehicle::Green</skill>
-        </skillPrereq>
-    </ability>
-    <ability>
         <lookupName>aptitude_gunnery</lookupName>
         <xpCost>500</xpCost>
         <originOnly>false</originOnly>


### PR DESCRIPTION
This removes a duplicate SPA entry that was causing the Weapon Specialist SPA to potentially be listed at 50 xp instead of 150