### PR TITLE
Improvement: Updated StratCon Contracts to Increase Objective Count & Improve Scaling; Adjusted 'Early Finish' Applicability on Some Contracts; Fixed Scenario Objective Classification on Some Contracts

### DIFF
--- a/data/stratconcontractdefinitions/Assassination.xml
+++ b/data/stratconcontractdefinitions/Assassination.xml
@@ -40,7 +40,7 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>1.0</objectiveCount>
+            <objectiveCount>-2.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/CadreDuty.xml
+++ b/data/stratconcontractdefinitions/CadreDuty.xml
@@ -40,7 +40,7 @@
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
-            <objectiveCount>-1</objectiveCount>
+            <objectiveCount>-2</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>AlliedTraineesGround.xml</objectiveScenarioModifier>

--- a/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -40,8 +40,8 @@
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
-            <objectiveCount>-1.0</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveCount>-2.0</objectiveCount>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Assassination.xml</objectiveScenario>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/Espionage.xml
+++ b/data/stratconcontractdefinitions/Espionage.xml
@@ -21,7 +21,7 @@
     <contractTypeName>Espionage</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Conduct reconnaissance while evading hostile forces.</briefing>
-    <allowEarlyVictory>true</allowEarlyVictory>
+    <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>10</scenarioOdds>
@@ -48,7 +48,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>
@@ -58,7 +58,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ExtractionRaid.xml
+++ b/data/stratconcontractdefinitions/ExtractionRaid.xml
@@ -40,7 +40,7 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>
@@ -50,7 +50,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/GarrisonDuty.xml
+++ b/data/stratconcontractdefinitions/GarrisonDuty.xml
@@ -40,7 +40,7 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-1</objectiveCount>
+            <objectiveCount>-2</objectiveCount>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -21,7 +21,7 @@
     <contractTypeName>Guerrilla Warfare</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Engage hostile forces. Be quick.</briefing>
-    <allowEarlyVictory>true</allowEarlyVictory>
+    <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>
@@ -48,8 +48,8 @@
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveCount>-2.0</objectiveCount>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/MoleHunting.xml
+++ b/data/stratconcontractdefinitions/MoleHunting.xml
@@ -39,7 +39,7 @@
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
-            <objectiveCount>-1</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
@@ -48,7 +48,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>1.0</objectiveCount>
+            <objectiveCount>-2.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ObjectiveRaid.xml
+++ b/data/stratconcontractdefinitions/ObjectiveRaid.xml
@@ -40,11 +40,11 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ObservationRaid.xml
+++ b/data/stratconcontractdefinitions/ObservationRaid.xml
@@ -40,7 +40,7 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>1.0</objectiveCount>
+            <objectiveCount>2.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>

--- a/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/data/stratconcontractdefinitions/PirateHunting.xml
@@ -40,15 +40,15 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-0.33</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-0.33</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.33</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveCount>-1.0</objectiveCount>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Escort.xml</objectiveScenario>
                 <objectiveScenario>Critical Convoy Escort.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/PlanetaryAssault.xml
+++ b/data/stratconcontractdefinitions/PlanetaryAssault.xml
@@ -21,7 +21,7 @@
     <contractTypeName>Planetary Assault</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Destroy or capture designated facilities.</briefing>
-    <allowEarlyVictory>true</allowEarlyVictory>
+    <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
@@ -40,11 +40,11 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-1</objectiveCount>
+            <objectiveCount>-2</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveCount>-2.0</objectiveCount>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Annihilation.xml</objectiveScenario>
                 <objectiveScenario>Breakthrough.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ReconRaid.xml
+++ b/data/stratconcontractdefinitions/ReconRaid.xml
@@ -40,7 +40,7 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>
@@ -50,7 +50,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ReliefDuty.xml
+++ b/data/stratconcontractdefinitions/ReliefDuty.xml
@@ -40,11 +40,11 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/data/stratconcontractdefinitions/RiotDuty.xml
@@ -40,10 +40,10 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Irregular Force Assault.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/Sabotage.xml
+++ b/data/stratconcontractdefinitions/Sabotage.xml
@@ -48,11 +48,11 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-1</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveCount>-1.0</objectiveCount>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Deep Raid.xml</objectiveScenario>
                 <objectiveScenario>Deep Raid Defense.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/SecurityDuty.xml
+++ b/data/stratconcontractdefinitions/SecurityDuty.xml
@@ -43,7 +43,7 @@
             <objectiveCount>-1</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Escort.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/Terrorism.xml
+++ b/data/stratconcontractdefinitions/Terrorism.xml
@@ -21,7 +21,7 @@
     <contractTypeName>Black-Ops Insurgency</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Destabilize local government using insurgency tactics</briefing>
-    <allowEarlyVictory>true</allowEarlyVictory>
+    <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>
@@ -41,15 +41,15 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveCount>-1</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
                 <objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveCount>-2.0</objectiveCount>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>


### PR DESCRIPTION
This PR is a partial response to https://github.com/MegaMek/mekhq/issues/8194 it updates all contract types to having objectives scaling based on contract intensity. Previously many of them were fixed to a single strategic objective per sector.

I also spotted a couple of bugs where we were incorrectly classifying a objective as 'any scenario' instead of 'fixed scenario'.

Finally, I adjusted whether early finish is allowable for a number of contracts where it was logical for the employer to sign the campaign on for the duration of the contract.

Routing the enemy on non-garrison type contracts will still end the contract early.