### PR TITLE
Improvement: Decreased Size of Allied Force Modifiers

### DIFF
--- a/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/data/scenariomodifiers/HouseOfficerAir.xml
@@ -34,7 +34,7 @@
         <destinationZone>5</destinationZone>
         <fixedUnitCount>0</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>0.25</forceMultiplier>
+        <forceMultiplier>0.1</forceMultiplier>
         <forceName>Joint Force</forceName>
         <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>

--- a/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/data/scenariomodifiers/HouseOfficerGround.xml
@@ -38,7 +38,7 @@
         <destinationZone>5</destinationZone>
         <fixedUnitCount>0</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>0.25</forceMultiplier>
+        <forceMultiplier>0.1</forceMultiplier>
         <forceName>Joint Force</forceName>
         <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>

--- a/data/scenariomodifiers/IntegratedAlliesAir.xml
+++ b/data/scenariomodifiers/IntegratedAlliesAir.xml
@@ -34,7 +34,7 @@
         <destinationZone>5</destinationZone>
         <fixedUnitCount>0</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>0.5</forceMultiplier>
+        <forceMultiplier>0.1</forceMultiplier>
         <forceName>Integrated Allies</forceName>
         <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>

--- a/data/scenariomodifiers/IntegratedAlliesGround.xml
+++ b/data/scenariomodifiers/IntegratedAlliesGround.xml
@@ -38,7 +38,7 @@
         <destinationZone>5</destinationZone>
         <fixedUnitCount>0</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>0.5</forceMultiplier>
+        <forceMultiplier>0.1</forceMultiplier>
         <forceName>Integrated Allies</forceName>
         <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>


### PR DESCRIPTION
This PR reduces the BV Budget of allied modifiers spawned from Command Rights. This change is implemented for the following reasons:

- Keeps the focus on the player forces
- Reduces scenario size, especially for large campaigns (such as those using StratCon Single Drop). If you had 50k worth of player forces in a scenario, the OpFor previously would have had 25% of that (12.5k, for 62.5k total). This would have resulted in (at minimum) 62.5k of enemies, but usually a lot more due to other modifiers having an effect. Now the increase would have only been an additional 5k. A couple of additional units. For small campaigns this won't have a noticeable effect due to how scenario generation works. Those campaigns would have already only been seeing a single allied unit will continue to only see a single allied unit.