### PR TITLE
Improvement: Increased Minimum Weight Class of Units Generated in Several Modifiers

### DIFF
--- a/data/scenariomodifiers/AlliedOfficerMek.xml
+++ b/data/scenariomodifiers/AlliedOfficerMek.xml
@@ -41,8 +41,8 @@
         <forceName>Allied Officer Mek</forceName>
         <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
-        <maxWeightClass>3</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <maxWeightClass>4</maxWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>75</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>

--- a/data/scenariomodifiers/AlliedTraineesGround.xml
+++ b/data/scenariomodifiers/AlliedTraineesGround.xml
@@ -42,7 +42,8 @@
         <forceName>Trainees</forceName>
         <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
-        <maxWeightClass>1</maxWeightClass>
+        <minWeightClass>2</minWeightClass>
+        <maxWeightClass>2</maxWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>

--- a/data/scenariomodifiers/EnemyCommanderMek.xml
+++ b/data/scenariomodifiers/EnemyCommanderMek.xml
@@ -42,7 +42,7 @@
         <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>75</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>

--- a/data/scenariomodifiers/EnemyOfficerMek.xml
+++ b/data/scenariomodifiers/EnemyOfficerMek.xml
@@ -41,8 +41,8 @@
         <forceName>Enemy Officer Mek</forceName>
         <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
-        <maxWeightClass>3</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <maxWeightClass>4</maxWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>75</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>

--- a/data/scenariomodifiers/GroundedEnemyDropship.xml
+++ b/data/scenariomodifiers/GroundedEnemyDropship.xml
@@ -43,7 +43,7 @@
         <generationMethod>3</generationMethod>
         <generationOrder>3</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>0</minWeightClass>
+        <minWeightClass>1</minWeightClass>
         <retreatThreshold>50</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <syncDeploymentType>SameEdge</syncDeploymentType>

--- a/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/data/scenariomodifiers/HouseOfficerAir.xml
@@ -39,7 +39,7 @@
         <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>5</startingAltitude>
         <objectiveLinkedForces>

--- a/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/data/scenariomodifiers/HouseOfficerGround.xml
@@ -43,7 +43,7 @@
         <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>


### PR DESCRIPTION
This PR increases the minimum weight class for several modifiers. For 'officer' modifiers this is to make sure the officer is sitting in a nice heavy unit. For trainees it was getting them out of light units. They're already very fragile and difficult for the player to keep alive, hopefully this will give the player an easier time of things. Finally, I changed the min weight of DropShips from 0 (ultra-light) to 1 (light)