### PR TITLE
Fix: Fixed 'Exception Attribute - Edge' Description

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -1114,7 +1114,9 @@ This SPA increases that maximum by 1, but does not increase the Attribute itself
     <ability>
         <lookupName>exceptional_attribute_edge</lookupName>
         <displayName>Exceptional Attribute - Edge (ATOW)</displayName>
-        <desc><![CDATA[Roleplay only (for now)]]></desc>
+        <desc><![CDATA[Characters can only increase their Attributes up to a maximum determined by their Phenotype.
+
+This SPA increases that maximum by 1, but does not increase the Attribute itself.]]></desc>
         <xpCost>200</xpCost>
         <originOnly>false</originOnly>
         <weight>1</weight>


### PR DESCRIPTION
`Roleplay only (for now)` -> `Characters can only increase their Attributes up to a maximum determined by their Phenotype. This SPA increases that maximum by 1, but does not increase the Attribute itself.`