### PR TITLE
Fix: Fixed 'G-Tolerance (ATOW)' Description

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -551,8 +551,6 @@
     </ability>
     <ability>
         <lookupName>atow_g_tolerance</lookupName>
-        <displayName>G-Tolerance (ATOW)</displayName>
-        <desc><![CDATA[Roleplay only (for now)]]></desc>
         <xpCost>100</xpCost>
         <originOnly>false</originOnly>
         <weight>1</weight>


### PR DESCRIPTION
Removed placeholders so that name and description are inherited from MegaMek