### PR TITLE
Fix: Fixed Two Abilities Incorrectly Set As Origin Only

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -1937,7 +1937,7 @@ This penalty is removed once the character acquires level 4 in the Language/Any 
 
 This Flaw only has a mechanical effect when using Alternate Advanced Medical.]]></desc>
         <xpCost>-100</xpCost>
-        <originOnly>true</originOnly>
+        <originOnly>false</originOnly>
         <weight>1</weight>
         <skillPrereq />
     </ability>
@@ -1950,7 +1950,7 @@ The effects from multiple Super Spreaders do not stack.
 
 This Flaw only has a mechanical effect when using Alternate Advanced Medical.]]></desc>
         <xpCost>-100</xpCost>
-        <originOnly>true</originOnly>
+        <originOnly>false</originOnly>
         <weight>1</weight>
         <skillPrereq />
     </ability>


### PR DESCRIPTION
Vaccine Dodger & Super Spreader incorrectly set to Origin Only, now always available. Corporal Cletus doesn't believe in Space COVID.