### PR TITLE
Fix: Adjusted Title of Painkiller Reliance to Medication Reliance

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -1706,8 +1706,8 @@ While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
     </ability>
     <ability>
         <lookupName>compulsion_addiction_painkillers</lookupName>
-        <displayName>Significant Compulsion - Painkiller Reliance (ATOW)</displayName>
-        <desc><![CDATA[Once per week, the company will be required to pay a small stipend of 42 C-Bills. If the character has any prosthetics, this stipend is multiplied by the number of prosthetics the character possesses (plus 1).
+        <displayName>Significant Compulsion - Drug Reliance (ATOW)</displayName>
+        <desc><![CDATA[Once per week, the company will be required to pay a small stipend of 42 C-Bills to pay for medicine. If the character has any prosthetics, this stipend is multiplied by the number of prosthetics the character possesses (plus 1).
 
 If the stipend cannot be paid, a Willpower check is made (with a -2 penalty). If failed, the character suffers the Discontinuation Syndrome Injury and gains two Fatigue (if Fatigue is enabled).
 


### PR DESCRIPTION
Painkiller Reliance -> Drug Reliance (changed to make it more universal, otherwise we'll see user contact about Pain Shunt inflicting it).