### PR TITLE
Update CS/WOB equipment ratings for full A-F levels

### DIFF
--- a/data/forcegenerator/factions.xml
+++ b/data/forcegenerator/factions.xml
@@ -898,7 +898,7 @@
     </faction>
     <faction key='CS.EC' name='Explorer Corps' minor='false' clan='false' periphery='false'>
         <years>2959-</years>
-        <ratingLevels>B,A</ratingLevels>
+        <ratingLevels>F,D,C,B,A</ratingLevels>
         <parentFaction>CS</parentFaction>
     </faction>
     <faction key='FC.FCC' name='Federated Commonwealth Corps' minor='false' clan='false'
@@ -1281,7 +1281,7 @@
     </faction>
     <faction key='WOB.PM' name='Protectorate Militia' minor='false' clan='false' periphery='false'>
         <years>3066-3078</years>
-        <ratingLevels>B</ratingLevels>
+        <ratingLevels>F,D,C,B,A</ratingLevels>
         <parentFaction>WOB</parentFaction>
     </faction>
     <faction key='DC.RR' name='Rasalhague Regulars' minor='false' clan='false' periphery='false'>
@@ -1369,7 +1369,7 @@
     </faction>
     <faction key='WOB.SD' name='Shadow Divisions' minor='false' clan='false' periphery='false'>
         <years>3067-3081</years>
-        <ratingLevels>A</ratingLevels>
+        <ratingLevels>F,D,C,B,A</ratingLevels>
         <parentFaction>WOB</parentFaction>
     </faction>
     <faction key='DC.SHIN' name='Shin Legion' minor='false' clan='false' periphery='false'>

--- a/data/universe/commands/CS.EC.yml
+++ b/data/universe/commands/CS.EC.yml
@@ -20,6 +20,9 @@ name: Explorer Corps
 yearsActive:
   - start: 2959
 ratingLevels:
+  - F
+  - D
+  - C
   - B
   - A
 fallBackFactions:

--- a/data/universe/commands/WOB.PM.yml
+++ b/data/universe/commands/WOB.PM.yml
@@ -21,6 +21,10 @@ yearsActive:
   - start: 3066
     end: 3078
 ratingLevels:
+  - F
+  - D
+  - C
   - B
+  - A
 fallBackFactions:
   - WOB

--- a/data/universe/commands/WOB.SD.yml
+++ b/data/universe/commands/WOB.SD.yml
@@ -21,6 +21,10 @@ yearsActive:
   - start: 3067
     end: 3081
 ratingLevels:
+  - F
+  - D
+  - C
+  - B
   - A
 fallBackFactions:
   - WOB

--- a/data/universe/factions/CS.yml
+++ b/data/universe/factions/CS.yml
@@ -40,6 +40,9 @@ logo: Inner Sphere/ComStar.png
 background: Inner Sphere/ComStar.png
 camos: ComStar
 ratingLevels:
+  - F
+  - D
+  - C
   - B
   - A
 fallBackFactions:

--- a/data/universe/factions/WOB.yml
+++ b/data/universe/factions/WOB.yml
@@ -34,6 +34,9 @@ logo: Inner Sphere/Word of Blake.png
 background: Inner Sphere/Word of Blake.png
 camos: Word of Blake
 ratingLevels:
+  - F
+  - D
+  - C
   - B
   - A
 fallBackFactions:


### PR DESCRIPTION
Sometime around the YAML-ification of the faction data, I updated the CS and WOB factions to the standard A/B/C/D/F equipment levels as the other factions.  However, this never made it through to the YAML files which are now being used to determine those levels.

This updates CS and WOB factions, including sub-factions, to the standard equipment levels which addresses a few availability issues, including [this one in MegaMek](https://github.com/MegaMek/mm-data/issues/235#issue-3703258728) in part.