### PR TITLE
PR: Incorporate Fidelis and re-constituted Smoke Jaguars

### DIFF
--- a/data/universe/commands/ROS.FID.yml
+++ b/data/universe/commands/ROS.FID.yml
@@ -1,0 +1,44 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+key: ROS.FID
+name: Fidelis
+yearsActive:
+  - start: 3081
+    end: 3151
+tags:
+  - MINOR
+  - IS
+logo: Inner Sphere/Republic of the Sphere.png
+background: Inner Sphere/Republic of the Sphere.png
+camos: Republic of the Sphere/Fidelis.jpg
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
+fallBackFactions:
+  - ROS
+  - IS
+factionLeaders:
+  - title: "Custos"
+    firstName: "Paul"
+    surname: "Moon"
+    gender: "MALE"
+    startYear: 3081
+    endYear: 3151

--- a/data/universe/commands/SL3.CSJ.yml
+++ b/data/universe/commands/SL3.CSJ.yml
@@ -1,0 +1,44 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+key: SL3.CSJ
+name: Star League (Clan Smoke Jaguar)
+capital: New Home
+yearsActive:
+  - start: 3151
+tags:
+  - MINOR
+  - CLAN
+logo: Clan/Clan Smoke Jaguar.png
+background: Clan/Clan Smoke Jaguar.png
+camos: Star League Defense Force/SLDF Drab.jpg
+nameGenerator: Clan
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
+fallBackFactions:
+  - SL3
+  - CLAN.IS
+factionLeaders:
+  - title: "Khan"
+    firstName: "Prohaska"
+    surname: "Moon"
+    gender: "FEMALE"
+    startYear: 3151

--- a/data/universe/factions/CSJ.yml
+++ b/data/universe/factions/CSJ.yml
@@ -23,7 +23,6 @@ capitalChanges:
 yearsActive:
   - start: 2807
     end: 3060
-  - start: 3151
 tags:
   - PLAYABLE
   - MINOR
@@ -94,8 +93,3 @@ factionLeaders:
     gender: "MALE"
     startYear: 3052
     endYear: 3060
-  - title: "Khan"
-    firstName: "Prohaska"
-    surname: "Moon"
-    gender: "FEMALE"
-    startYear: 3151

--- a/data/universe/factions/FID.yml
+++ b/data/universe/factions/FID.yml
@@ -1,0 +1,58 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+key: FID
+name: Fidelis
+capital: Wayside
+capitalChanges:
+  3078: New Earth
+yearsActive:
+  - start: 3060
+    end: 3081
+  - start: 3151
+tags:
+  - MINOR
+  - CLAN
+color:
+  red: 153
+  green: 153
+  blue: 153
+logo: Clan/Clan Smoke Jaguar.png
+background: Clan/Clan Smoke Jaguar.png
+camos: Republic of the Sphere/Fidelis.jpg
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
+fallBackFactions:
+  - CLAN.IS
+  - Stone
+factionLeaders:
+  - title: "Custos"
+    firstName: "Paul"
+    surname: "Moon"
+    gender: "MALE"
+    startYear: 3061
+    endYear: 3081
+  - title: "Custos"
+    firstName: "Paul"
+    surname: "Moon"
+    gender: "MALE"
+    startYear: 3151
+    endYear: 3156


### PR DESCRIPTION
Proof of life after death...

Added Fidelis as a stand-alone, minor, non-playable faction for 3060 to 3081 (formation of the Republic).  After that, they become a sub-command of the ROS as ROS.FID.  With the fall of the Republic in 3151, they return to being an independent faction with Clan Smoke Jaguar being re-constituted as a new faction (SL3.CSJ).

Clan Smoke Jaguar faction information is now truncated at 3060.