### PR TITLE
Fix: Retired 2 Non-Era Agonistic Modifiers

### DIFF
--- a/data/scenariomodifiers/modifiermanifest.xml
+++ b/data/scenariomodifiers/modifiermanifest.xml
@@ -210,12 +210,12 @@
         <!--modifier>
             EnemyAceMekPXH1D.xml
         </modifier-->
-        <modifier>
+        <!--modifier>
             EnemyAirCav.xml
-        </modifier>
-        <modifier>
+        </modifier-->
+        <!--modifier>
             EnemyAirMobileInf.xml
-        </modifier>
+        </modifier-->
         <!--modifier>
         These have been disabled as they are not era agnostic
             EnemyMercFireSupport.xml
@@ -233,7 +233,6 @@
             AlliedCavLance.xml
         </modifier-->
         <!--modifier>
-            These have been disabled as they are not era agnostic
             AlliedMekAceCRD.xml
         </modifier-->
         <!--modifier>


### PR DESCRIPTION
Early in 2025 (or late in 2024) we made the decision to disable any non-era agonistic modifiers from appearing randomly on scenarios. Two modifiers were missed, this PR disables them. Note that these modifiers have not been deleted, so can still be used outside of a StratCon context.