### PR TITLE
Improvement: Updated ROS Faction to Use New ROS Rank System

### DIFF
--- a/data/universe/factions/ROS.yml
+++ b/data/universe/factions/ROS.yml
@@ -50,6 +50,7 @@ ratingLevels:
   - Stone's Brigade
 fallBackFactions:
   - IS
+rankSystem: ROS
 factionLeaders:
   - title: "Exarch"
     firstName: "Devlin"


### PR DESCRIPTION
This updates the Republic of the Sphere faction to use the faction-specific rank system introduced by #216