### PR TITLE
Improvement: Disabled Two 'Hidden Unit' Scenario Modifiers

### DIFF
--- a/data/scenariomodifiers/modifiermanifest.xml
+++ b/data/scenariomodifiers/modifiermanifest.xml
@@ -122,12 +122,14 @@
             Need objective system
             TrainingExercise.xml
         </modifier-->
-        <modifier>
+        <!--modifier>
+            Disabled until Princess can better manage Hidden units
             EnemyAmbush.xml
-        </modifier>
-        <modifier>
+        </modifier-->
+        <!--modifier>
+            Disabled until Princess can better manage Hidden units
             PlayerAmbush.xml
-        </modifier>
+        <</modifier-->
         <modifier>
             AlliedAirSupport.xml
         </modifier>


### PR DESCRIPTION
While work is being done to improve Princess' handling of Hidden units it won't be ready until 50.12. This PR disables the two 'hidden unit' scenario modifiers, preventing them from spawning in StratCon scenarios. These modifiers have not been deleted so can still be manually applied.