### PR TITLE
Fix #226: Fixed Missing Scenario Modifiers Causing Scenario Generation to Fail

### DIFF
--- a/data/scenariomodifiers/airBattleModifiers.xml
+++ b/data/scenariomodifiers/airBattleModifiers.xml
@@ -71,7 +71,7 @@
         <!--modifier>
             Disabled until Princess can better manage Hidden units
             PlayerAmbush.xml
-        <</modifier-->
+        </modifier-->
         <modifier>
             AlliedAirSupport.xml
         </modifier>

--- a/data/scenariomodifiers/groundBattleModifiers.xml
+++ b/data/scenariomodifiers/groundBattleModifiers.xml
@@ -114,7 +114,7 @@
         <!--modifier>
             Disabled until Princess can better manage Hidden units
             PlayerAmbush.xml
-        <</modifier-->
+        </modifier-->
         <modifier>
             AlliedAirSupport.xml
         </modifier>


### PR DESCRIPTION
Fix #226

When disabling a handful of scenario modifiers I failed to spot that the information was duplicated in two other places and needed to be disabled there, too.