### PR TITLE
Adjust MAL-XV to match record sheet.

### DIFF
--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XV.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XV.mtf
@@ -98,7 +98,7 @@ IS Ammo LAC/5
 IS Ammo LAC/5
 IS Ammo LAC/5
 IS Ammo LAC/5
-CLCASEII
+ISCASEII
 
 Right Torso:
 Fusion Engine
@@ -112,7 +112,7 @@ IS Ammo LAC/5
 IS Ammo LAC/5
 IS Ammo LAC/5
 IS Ammo LAC/5
-CLCASEII
+ISCASEII
 
 Center Torso:
 Fusion Engine


### PR DESCRIPTION
Adjusts the CASE II on the MAL-XV to Inner Sphere tech base, bringing it in line with the published Record Sheet and fixing it being underweight. Closes #181. 