### PR TITLE
Re-adding updated ranks.xml with Republic of the Sphere ranks after reversion.

### DIFF
--- a/data/universe/ranks.xml
+++ b/data/universe/ranks.xml
@@ -5138,7 +5138,7 @@ Rank:
             <payMultiplier>4.0</payMultiplier>
         </rank> <!-- WO10 -->
         <rank>
-            <rankNames>-,-,-,,-,-,-,-,-</rankNames>
+            <rankNames>-,-,-,-,-,-,-,-,-</rankNames>
             <officer>true</officer>
             <payMultiplier>1.17</payMultiplier>
         </rank> <!-- O1 -->


### PR DESCRIPTION
This was originally completed via #216, but since then the file seems to have reverted to an older version. Changes utilizing the new ranks file done in #218 do not seem to have reverted.

Leaving marked as a draft at the moment at the suggestion of @IllianiBird until the reason for the reversion can be determined.  