### PR TITLE
Fix unit validation issue for SM1 and SM1A Tank Destroyers

### DIFF
--- a/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1.blk
+++ b/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1.blk
@@ -145,7 +145,7 @@ Hyner,Irece
 <systemManufacturers>
 ENGINE:165 Standard Fusion
 ARMOR:Advanced Compound Beta
-COMMUNICATIONS:Unit 2J2 “Basher”
+COMMUNICATIONS:Unit 2J2 "Basher"
 TARGETING:Able-Seven Sensor Suite
 </systemManufacturers>
 

--- a/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1A.blk
+++ b/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1A.blk
@@ -146,7 +146,7 @@ Hyner,Irece
 <systemManufacturers>
 ENGINE:165 Standard Fusion
 ARMOR:Advanced Compound Beta
-COMMUNICATIONS:Unit 2J2 “Basher”
+COMMUNICATIONS:Unit 2J2 "Basher"
 TARGETING:Able-Seven Sensor Suite
 </systemManufacturers>
 


### PR DESCRIPTION
Both of these had extraneous Clan CASE equipment added to the rear location in the BLK file that was causing a validation issue. These are Clan tech base units, so CASE is provided automatically. This removes the extraneous equipment lines and fixes the validation issue with no other changes to the units. Saving from a newer MML version also introduced some minor updates to the BLK file.

Fixes #118.  