### PR TITLE
Update Grenadier II manipulators to match XTRO Republic III/Record Sheets

### DIFF
--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ B(Sqd4)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis) Advanced
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis) Advanced
 <role>
 Missile Boat
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,15 +69,60 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
-Clan BA Stealth:LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):LA
 BattleArmorC3:LA
 CLBALRM4:Body
 BACL Ammo LRM-4:Body:Shots4#
 BACL Ammo LRM-4:Body:Shots4#
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+This variant carries a Battle Armor C3 System in the left arm and a Clan-spec LRM-4 with eight reloads on the body.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -104,40 +148,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-This variant carries a Battle Armor C3 System in the left arm and a Clan-spec LRM-4 with eight reloads on the body.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ B(Sqd5)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis) Advanced
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis) Advanced
 <role>
 Missile Boat
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,15 +69,63 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
-Clan BA Stealth:LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):LA
 BattleArmorC3:LA
 CLBALRM4:Body
 BACL Ammo LRM-4:Body:Shots4#
 BACL Ammo LRM-4:Body:Shots4#
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+This variant carries a Battle Armor C3 System in the left arm and a Clan-spec LRM-4 with eight reloads on the body.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -104,40 +151,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-This variant carries a Battle Armor C3 System in the left arm and a Clan-spec LRM-4 with eight reloads on the body.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ B(Sqd6)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis) Advanced
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis) Advanced
 <role>
 Missile Boat
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,15 +69,66 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
-Clan BA Stealth:LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):LA
 BattleArmorC3:LA
 CLBALRM4:Body
 BACL Ammo LRM-4:Body:Shots4#
 BACL Ammo LRM-4:Body:Shots4#
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<Trooper 6 Equipment>
+</Trooper 6 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+This variant carries a Battle Armor C3 System in the left arm and a Clan-spec LRM-4 with eight reloads on the body.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -104,40 +154,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-This variant carries a Battle Armor C3 System in the left arm and a Clan-spec LRM-4 with eight reloads on the body.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ C(Sqd4)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis)
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis)
 <role>
 Ambusher
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,13 +69,58 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
-Clan BA Stealth:LA
-ISBAFlamer:LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):LA
+CLBAFlamer:LA
 ISBAMediumLaser:Body
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+This version uses a Flamer on the arm and a Medium Laser on the torso mount.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -102,40 +146,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-This version uses a Flamer on the arm and a Medium Laser on the torso mount.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ C(Sqd5)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis)
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis)
 <role>
 Ambusher
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,13 +69,61 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
-Clan BA Stealth:LA
-ISBAFlamer:LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):LA
+CLBAFlamer:LA
 ISBAMediumLaser:Body
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+This version uses a Flamer on the arm and a Medium Laser on the torso mount.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -102,40 +149,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-This version uses a Flamer on the arm and a Medium Laser on the torso mount.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ C(Sqd6)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis)
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis)
 <role>
 Ambusher
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,13 +69,64 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
-Clan BA Stealth:LA
-ISBAFlamer:LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):LA
+CLBAFlamer:LA
 ISBAMediumLaser:Body
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<Trooper 6 Equipment>
+</Trooper 6 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+This version uses a Flamer on the arm and a Medium Laser on the torso mount.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -102,40 +152,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-This version uses a Flamer on the arm and a Medium Laser on the torso mount.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ D(Sqd4)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis) Advanced
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis) Advanced
 <role>
 Missile Boat
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,15 +69,15 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-BABasicManipulator:LA
 ISBAFireDrakeNeedler:LA
 ISBATubeArtillery:Body
 ISBATubeArtilleryAmmo:Body:Shots4#
 ISBATubeArtilleryAmmo:Body:Shots4#
-Clan BA Stealth:LA
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+BABasicManipulator:RA
 </Squad Equipment>
 
 <Trooper 1 Equipment>
@@ -92,6 +91,38 @@ Clan BA Stealth:RA
 
 <Trooper 4 Equipment>
 </Trooper 4 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+Exclusive to The Republic of the Sphere, this configuration carries a Firedrake Support Needler on the arm mount and a BA Tube Artillery system on the body mount. The artillery system has an eight shot magazine.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -117,40 +148,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-Exclusive to The Republic of the Sphere, this configuration carries a Firedrake Support Needler on the arm mount and a BA Tube Artillery system on the body mount. The artillery system has an eight shot magazine.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ D(Sqd5)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis) Advanced
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis) Advanced
 <role>
 Missile Boat
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,16 +69,63 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-BABasicManipulator:LA
 ISBAFireDrakeNeedler:LA
 ISBATubeArtillery:Body
 ISBATubeArtilleryAmmo:Body:Shots4#
 ISBATubeArtilleryAmmo:Body:Shots4#
-Clan BA Stealth:LA
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+Exclusive to The Republic of the Sphere, this configuration carries a Firedrake Support Needler on the arm mount and a BA Tube Artillery system on the body mount. The artillery system has an eight shot magazine.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -105,40 +151,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-Exclusive to The Republic of the Sphere, this configuration carries a Firedrake Support Needler on the arm mount and a BA Tube Artillery system on the body mount. The artillery system has an eight shot magazine.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -45,6 +36,10 @@ D(Sqd6)
 3137
 </year>
 
+<originalBuildYear>
+3137
+</originalBuildYear>
+
 <type>
 Mixed (IS Chassis) Advanced
 </type>
@@ -52,6 +47,10 @@ Mixed (IS Chassis) Advanced
 <role>
 Missile Boat
 </role>
+
+<quirks>
+difficult_maintain
+</quirks>
 
 <motion_type>
 Leg
@@ -70,16 +69,66 @@ Leg
 </armor_tech>
 
 <Squad Equipment>
-BABasicManipulator:LA
 ISBAFireDrakeNeedler:LA
 ISBATubeArtillery:Body
 ISBATubeArtilleryAmmo:Body:Shots4#
 ISBATubeArtilleryAmmo:Body:Shots4#
-Clan BA Stealth:LA
-Clan BA Stealth:LA
-Clan BA Stealth:RA
-Clan BA Stealth:RA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):LA
+Clan BA Stealth (Standard):RA
+Clan BA Stealth (Standard):RA
+BABasicManipulator:RA
 </Squad Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<Trooper 6 Equipment>
+</Trooper 6 Equipment>
+
+<capabilities>
+The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
+</capabilities>
+
+<overview>
+The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
+</overview>
+
+<deployment>
+Exclusive to The Republic of the Sphere, this configuration carries a Firedrake Support Needler on the arm mount and a BA Tube Artillery system on the body mount. The artillery system has an eight shot magazine.
+</deployment>
+
+<history>
+It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
+</history>
+
+<manufacturer>
+General Motors
+</manufacturer>
+
+<primaryFactory>
+Talcott
+</primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 XTR:RotS 3
@@ -105,40 +154,4 @@ biped
 3
 </weightclass>
 
-<overview>
-The Grenadier II battle armor suit is an evolution of the Grenadier suit already in use by the AFFS.
-</overview>
-
-<capabilities>
-The Grenadier II has a Modular Weapon Mount in the left arm and a second mounted in the body. The right arm has a single Basic Manipulator.
-</capabilities>
-
-<deployment>
-Exclusive to The Republic of the Sphere, this configuration carries a Firedrake Support Needler on the arm mount and a BA Tube Artillery system on the body mount. The artillery system has an eight shot magazine.
-</deployment>
-
-<history>
-It uses lighter Clan-spec Standard Stealth armor mated to an Inner Sphere chassis to save weight. This allows the Grenadier II to pack as much firepower and protection as a Grenadier, but at a lighter weight. In addition, the lighter weight of the Grenadier II means it can be transported by OmniMechs.
-</history>
-
-<manufacturer>
-General Motors
-</manufacturer>
-
-<primaryFactory>
-Talcott
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>
-
-<quirks>
-difficult_maintain
-</quirks>
 


### PR DESCRIPTION
Switches or adds manipulators to Grenadier II B, C, and D variants so that it matches the entry in XTRO Republic III and the corresponding record sheet. 

Other formatting changes introduced from saving in newer version of MML.

Closes #268. 