### PR TITLE
Adds equipment to Sqd (5) and Sqd (6) versions of Water Elemental Mining Suits

### DIFF
--- a/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd4).blk
@@ -1,4 +1,21 @@
-#Saved from version 0.50.07 on 2025-10-03
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -10,10 +27,6 @@ Water Elemental Mining Suit
 <Model>
 (Sqd4)
 </Model>
-
-<mul id:>
-7671
-</mul id:>
 
 <year>
 2842
@@ -70,8 +83,10 @@ Mission Equipment Storage:Body:SIZE:200.0
 <Trooper 4 Equipment>
 </Trooper 4 Equipment>
 
-<Trooper 5 Equipment>
-</Trooper 5 Equipment>
+<slotless_equipment>
+BAUMU
+BAUMU
+</slotless_equipment>
 
 <capabilities>
 While not intended for combat, circumstances arose that pushed the units into battle. In 2860, visiting Clan Wolf forces on the world of Dagda became aware of the Goliath Scorpions' underwater mining programs, as well as the suits they used. A Wolf Star Captain, sensing the combat potential of the suits, issued a Trial of Possession for one of the units. The defense of the suits was assigned to Goliath Scorpion Point Commander Sarah who sensed that the Wolf forces eagerness could be used against them. She selected a nearby wetland with deep water ways, dangerous fauna, and hazardous terrain as the place for the Trial. Clan Wolf bid a Star of Jump Infantry against Scorpion warriors in the Water Elemental Mining Suits. In the end, Sarah had bargained well and the mobility of the Water Elemental Mining Suits in the wetlands allowed the Scorpions to defeat the Wolves with only the loss of one pilot. This defeat convinced Clan Wolf to acquire the suits via trade between the Merchant Castes. In another instance during the Golden Century, Star Commander Vikram of Clan Goliath Scorpion pressed a Star of Water Elementals into service on Circe to defeat Clan Mongoose in a rare and unusual underwater Trial.
@@ -122,7 +137,7 @@ biped
 </armor>
 
 <Trooper Count>
-5
+4
 </Trooper Count>
 
 <weightclass>

--- a/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -33,7 +24,7 @@ BattleArmor
 Water Elemental Mining Suit
 </Name>
 
-<model>
+<Model>
 (Sqd5)
 </Model>
 
@@ -53,13 +44,13 @@ Water Elemental Mining Suit
 Mixed (Clan Chassis) Experimental
 </type>
 
+<role>
+None
+</role>
 
 <motion_type>
 UMU
 </motion_type>
-
-<transporters>
-</transporters>
 
 <cruiseMP>
 1
@@ -70,19 +61,54 @@ UMU
 </armor_type>
 
 <armor_tech>
-7
+2
 </armor_tech>
 
-<Squad Equipment>
+<Point Equipment>
 BABasicManipulator:LA
 BAIndustrialDrill:RA
 BACuttingTorch:RA
 BACuttingTorch:LA
-ISBAExtendedLifeSupport:Body
+BAExtendedLifeSupport:Body
 BAPowerpack:Body
 HHSearchlight
-Mission Equipment Storage (200 kg):Body
-</Squad Equipment>
+Mission Equipment Storage:Body:SIZE:200.0
+</Point Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<slotless_equipment>
+BAUMU
+</slotless_equipment>
+
+<capabilities>
+While not intended for combat, circumstances arose that pushed the units into battle. In 2860, visiting Clan Wolf forces on the world of Dagda became aware of the Goliath Scorpions' underwater mining programs, as well as the suits they used. A Wolf Star Captain, sensing the combat potential of the suits, issued a Trial of Possession for one of the units. The defense of the suits was assigned to Goliath Scorpion Point Commander Sarah who sensed that the Wolf forces eagerness could be used against them. She selected a nearby wetland with deep water ways, dangerous fauna, and hazardous terrain as the place for the Trial. Clan Wolf bid a Star of Jump Infantry against Scorpion warriors in the Water Elemental Mining Suits. In the end, Sarah had bargained well and the mobility of the Water Elemental Mining Suits in the wetlands allowed the Scorpions to defeat the Wolves with only the loss of one pilot. This defeat convinced Clan Wolf to acquire the suits via trade between the Merchant Castes. In another instance during the Golden Century, Star Commander Vikram of Clan Goliath Scorpion pressed a Star of Water Elementals into service on Circe to defeat Clan Mongoose in a rare and unusual underwater Trial.
+</capabilities>
+
+<overview>
+The Water Elemental Mining Suit were sophisticated underwater mining and construction units created by Clan Goliath Scorpion that provided the technological and engineering basis for the creation of Clan battle armor.
+</overview>
+
+<deployment>
+The Water Elemental Mining Suit was not built for combat. It was equipped with cutting torches, a searchlight, an industrial drill, and a basic manipulator for underwater industrial work.
+</deployment>
+
+<history>
+The suit was produced at the Hades Industrial Complex on Dagda. The mining suit moved effortlessly through the water thanks to a series of synchronized micro thrusters linked to pressure sensors in its inner lining. The wearer of the suit could easily control their movements with just a few simple gestures, allowing them to complete complicated underwater tasks simply. The unit also had advanced software that could control the thrusters to hold the suite motionless against a strong current. This allowed for precision work without the concerns of being moved by the shifting water around the wearer. A series of pressure protections, buoyancy control devices, and an array of sensors prevented the divers from ascending too quickly while also monitoring remaining power and air supply.
+</history>
 
 <manufacturer>
 Clan Goliath Scorpion
@@ -91,6 +117,14 @@ Clan Goliath Scorpion
 <primaryFactory>
 Hades Industrial Complex
 </primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 TR:GC
@@ -116,35 +150,4 @@ biped
 2
 </weightclass>
 
-<overview>
-The Water Elemental Mining Suit were sophisticated underwater mining and construction units created by Clan Goliath Scorpion that provided the technological and engineering basis for the creation of Clan battle armor.
-</overview>
 
-<capabilities>
-While not intended for combat, circumstances arose that pushed the units into battle. In 2860, visiting Clan Wolf forces on the world of Dagda became aware of the Goliath Scorpions' underwater mining programs, as well as the suits they used. A Wolf Star Captain, sensing the combat potential of the suits, issued a Trial of Possession for one of the units. The defense of the suits was assigned to Goliath Scorpion Point Commander Sarah who sensed that the Wolf forces eagerness could be used against them. She selected a nearby wetland with deep water ways, dangerous fauna, and hazardous terrain as the place for the Trial. Clan Wolf bid a Star of Jump Infantry against Scorpion warriors in the Water Elemental Mining Suits. In the end, Sarah had bargained well and the mobility of the Water Elemental Mining Suits in the wetlands allowed the Scorpions to defeat the Wolves with only the loss of one pilot. This defeat convinced Clan Wolf to acquire the suits via trade between the Merchant Castes. In another instance during the Golden Century, Star Commander Vikram of Clan Goliath Scorpion pressed a Star of Water Elementals into service on Circe to defeat Clan Mongoose in a rare and unusual underwater Trial.
-</capabilities>
-
-<deployment>
-The Water Elemental Mining Suit was not built for combat. It was equipped with cutting torches, a searchlight, an industrial drill, and a basic manipulator for underwater industrial work.
-</deployment>
-
-<history>
-The suit was produced at the Hades Industrial Complex on Dagda. The mining suit moved effortlessly through the water thanks to a series of synchronized micro thrusters linked to pressure sensors in its inner lining. The wearer of the suit could easily control their movements with just a few simple gestures, allowing them to complete complicated underwater tasks simply. The unit also had advanced software that could control the thrusters to hold the suite motionless against a strong current. This allowed for precision work without the concerns of being moved by the shifting water around the wearer. A series of pressure protections, buoyancy control devices, and an array of sensors prevented the divers from ascending too quickly while also monitoring remaining power and air supply.
-</history>
-
-<manufacturer>
-Hades Industrial Complex
-</manufacturer>
-
-<primaryFactory>
-Dagda
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>

--- a/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,16 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#building block data file
-<BlockVersion>
-1
-</BlockVersion>
-
-# Write the version number just in case...
-<Version>
-MAM0
-</Version>
-
+#Saved from version 0.50.12-nightly-2026-02-26 on 2026-02-28
 <UnitType>
 BattleArmor
 </UnitType>
@@ -33,7 +24,7 @@ BattleArmor
 Water Elemental Mining Suit
 </Name>
 
-<model>
+<Model>
 (Sqd6)
 </Model>
 
@@ -49,12 +40,13 @@ Water Elemental Mining Suit
 Mixed (Clan Chassis) Experimental
 </type>
 
+<role>
+None
+</role>
+
 <motion_type>
 UMU
 </motion_type>
-
-<transporters>
-</transporters>
 
 <cruiseMP>
 1
@@ -65,19 +57,57 @@ UMU
 </armor_type>
 
 <armor_tech>
-7
+2
 </armor_tech>
 
-<Squad Equipment>
+<Point Equipment>
 BABasicManipulator:LA
 BAIndustrialDrill:RA
 BACuttingTorch:RA
 BACuttingTorch:LA
-ISBAExtendedLifeSupport:Body
+BAExtendedLifeSupport:Body
 BAPowerpack:Body
 HHSearchlight
-Mission Equipment Storage (200 kg):Body
-</Squad Equipment>
+Mission Equipment Storage:Body:SIZE:200.0
+</Point Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<Trooper 5 Equipment>
+</Trooper 5 Equipment>
+
+<Trooper 6 Equipment>
+</Trooper 6 Equipment>
+
+<slotless_equipment>
+BAUMU
+</slotless_equipment>
+
+<capabilities>
+While not intended for combat, circumstances arose that pushed the units into battle. In 2860, visiting Clan Wolf forces on the world of Dagda became aware of the Goliath Scorpions' underwater mining programs, as well as the suits they used. A Wolf Star Captain, sensing the combat potential of the suits, issued a Trial of Possession for one of the units. The defense of the suits was assigned to Goliath Scorpion Point Commander Sarah who sensed that the Wolf forces eagerness could be used against them. She selected a nearby wetland with deep water ways, dangerous fauna, and hazardous terrain as the place for the Trial. Clan Wolf bid a Star of Jump Infantry against Scorpion warriors in the Water Elemental Mining Suits. In the end, Sarah had bargained well and the mobility of the Water Elemental Mining Suits in the wetlands allowed the Scorpions to defeat the Wolves with only the loss of one pilot. This defeat convinced Clan Wolf to acquire the suits via trade between the Merchant Castes. In another instance during the Golden Century, Star Commander Vikram of Clan Goliath Scorpion pressed a Star of Water Elementals into service on Circe to defeat Clan Mongoose in a rare and unusual underwater Trial.
+</capabilities>
+
+<overview>
+The Water Elemental Mining Suit were sophisticated underwater mining and construction units created by Clan Goliath Scorpion that provided the technological and engineering basis for the creation of Clan battle armor.
+</overview>
+
+<deployment>
+The Water Elemental Mining Suit was not built for combat. It was equipped with cutting torches, a searchlight, an industrial drill, and a basic manipulator for underwater industrial work.
+</deployment>
+
+<history>
+The suit was produced at the Hades Industrial Complex on Dagda. The mining suit moved effortlessly through the water thanks to a series of synchronized micro thrusters linked to pressure sensors in its inner lining. The wearer of the suit could easily control their movements with just a few simple gestures, allowing them to complete complicated underwater tasks simply. The unit also had advanced software that could control the thrusters to hold the suite motionless against a strong current. This allowed for precision work without the concerns of being moved by the shifting water around the wearer. A series of pressure protections, buoyancy control devices, and an array of sensors prevented the divers from ascending too quickly while also monitoring remaining power and air supply.
+</history>
 
 <manufacturer>
 Clan Goliath Scorpion
@@ -86,6 +116,14 @@ Clan Goliath Scorpion
 <primaryFactory>
 Hades Industrial Complex
 </primaryFactory>
+
+<systemManufacturers>
+CHASSIS:Unknown
+ENGINE:Unknown
+ARMOR:Unknown
+COMMUNICATIONS:Unknown
+TARGETING:Unknown
+</systemManufacturers>
 
 <source>
 TR:GC
@@ -111,35 +149,4 @@ biped
 2
 </weightclass>
 
-<overview>
-The Water Elemental Mining Suit were sophisticated underwater mining and construction units created by Clan Goliath Scorpion that provided the technological and engineering basis for the creation of Clan battle armor.
-</overview>
 
-<capabilities>
-While not intended for combat, circumstances arose that pushed the units into battle. In 2860, visiting Clan Wolf forces on the world of Dagda became aware of the Goliath Scorpions' underwater mining programs, as well as the suits they used. A Wolf Star Captain, sensing the combat potential of the suits, issued a Trial of Possession for one of the units. The defense of the suits was assigned to Goliath Scorpion Point Commander Sarah who sensed that the Wolf forces eagerness could be used against them. She selected a nearby wetland with deep water ways, dangerous fauna, and hazardous terrain as the place for the Trial. Clan Wolf bid a Star of Jump Infantry against Scorpion warriors in the Water Elemental Mining Suits. In the end, Sarah had bargained well and the mobility of the Water Elemental Mining Suits in the wetlands allowed the Scorpions to defeat the Wolves with only the loss of one pilot. This defeat convinced Clan Wolf to acquire the suits via trade between the Merchant Castes. In another instance during the Golden Century, Star Commander Vikram of Clan Goliath Scorpion pressed a Star of Water Elementals into service on Circe to defeat Clan Mongoose in a rare and unusual underwater Trial.
-</capabilities>
-
-<deployment>
-The Water Elemental Mining Suit was not built for combat. It was equipped with cutting torches, a searchlight, an industrial drill, and a basic manipulator for underwater industrial work.
-</deployment>
-
-<history>
-The suit was produced at the Hades Industrial Complex on Dagda. The mining suit moved effortlessly through the water thanks to a series of synchronized micro thrusters linked to pressure sensors in its inner lining. The wearer of the suit could easily control their movements with just a few simple gestures, allowing them to complete complicated underwater tasks simply. The unit also had advanced software that could control the thrusters to hold the suite motionless against a strong current. This allowed for precision work without the concerns of being moved by the shifting water around the wearer. A series of pressure protections, buoyancy control devices, and an array of sensors prevented the divers from ascending too quickly while also monitoring remaining power and air supply.
-</history>
-
-<manufacturer>
-Hades Industrial Complex
-</manufacturer>
-
-<primaryFactory>
-Dagda
-</primaryFactory>
-
-<systemManufacturers>
-CHASSIS:Unknown
-ENGINE:Unknown
-ARMOR:Unknown
-JUMPJET:Unknown
-COMMUNICATIONS:Unknown
-TARGETING:Unknown
-</systemManufacturers>


### PR DESCRIPTION
PR adds missing equipment to the Sqd5 and Sqd6 versions of the Water Elemental. Also the Sqd4 actually had five suits in the file, so that has been adjusted as well. 

Any other formatting changes are from saving in a newer version of MML.

These suits will show as Invalid because their introduction date is prior to BA Standard (Basic) armor's listed introduction date, but that was happening already with the current file. 

Closes #267. 