### PR TITLE
Change CT medium pulse laser on War Crow B to pod mounted.

### DIFF
--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow B.mtf
@@ -180,5 +180,5 @@ systemmanufacturer:ENGINE:Redline
 systemmode:ENGINE:350 XL
 systemmanufacturer:ARMOR:Compound LZ-7 Ferro-Lamellor
 systemmanufacturer:COMMUNICATIONS:TDWS-37 Mk. 2.2
-systemmanufacturer:TARGETING:“Hermes” CT-44
+systemmanufacturer:TARGETING:"Hermes" CT-44
 


### PR DESCRIPTION
A medium pulse laser in the CT of the War Crow B was marked as fixed equipment. This change brings the unit stats in line with the RecGuide 7 entry/sheet. Additional minor updates from saving in newer MML version.

Closes #283. 