### PR TITLE
Adds separate IS and homeworld collectors for Bandit Caste

### DIFF
--- a/data/universe/commands/BAN.HW.yml
+++ b/data/universe/commands/BAN.HW.yml
@@ -16,13 +16,15 @@
 # affiliated with Microsoft.
 
 key: BAN.HW
-name: Bandit Caste (Homeworlds)
+# Bandit Caste groups in the Clan Homeworlds
+name: Bandit Caste (Homeworld)
 yearsActive:
   - start: 3052
-  - end: 3085
+    end: 3085
 tags:
   - CLAN
   - AGGREGATE
+nameGenerator: Clan
 ratingLevels:
   - Provisional Garrison
   - Solahma
@@ -30,4 +32,4 @@ ratingLevels:
   - Front Line
   - Keshik
 fallBackFactions:
-  - BAN
+  - CLAN.HW

--- a/data/universe/commands/BAN.IS.yml
+++ b/data/universe/commands/BAN.IS.yml
@@ -16,12 +16,14 @@
 # affiliated with Microsoft.
 
 key: BAN.IS
+# Bandit Caste groups in the Inner Sphere and near Periphery
 name: Bandit Caste (IS)
 yearsActive:
   - start: 3052
 tags:
   - CLAN
   - AGGREGATE
+nameGenerator: Clan
 ratingLevels:
   - Provisional Garrison
   - Solahma
@@ -29,4 +31,4 @@ ratingLevels:
   - Front Line
   - Keshik
 fallBackFactions:
-  - BAN
+  - CLAN.IS


### PR DESCRIPTION
Adds BAN.IS for Bandit Caste groups operating in the IS, and BAN.HW for those operating in the Clan homeworlds to better cover the differences in availability and salvage, starting with appropriate fallback factions (CLAN.IS and CLAN.HW).  No units are assigned to these factions yet, same with salvage percentages, weight class distribution, and other information stored in the availability XMLs - that will be coming with a later update.

Both start 3052, giving enough time for the BAN.IS group to get established after the initial invasion phases.  BAN.HW ends in 3085, same as homeworld Clans.