### PR TITLE
Perseus E Equipment Adjustment

### DIFF
--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Perseus P1E.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Perseus P1E.mtf
@@ -111,9 +111,9 @@ Fusion Engine
 Fusion Engine
 IS Gauss Ammo (OMNIPOD)
 IS Gauss Ammo (OMNIPOD)
-Communications Equipment (OMNIPOD):SIZE:1.0
-Communications Equipment (OMNIPOD):SIZE:1.0
-Communications Equipment (OMNIPOD):SIZE:1.0
+Communications Equipment (OMNIPOD):SIZE:3.0
+Communications Equipment (OMNIPOD):SIZE:3.0
+Communications Equipment (OMNIPOD):SIZE:3.0
 IS Endo Steel
 IS Endo Steel
 IS Endo Steel


### PR DESCRIPTION
Updates the Perseus E configuration to match Record Sheets 3067 Unabridged by adding two VGLs. Also consolidates the Communications Equipment into a single 3 slot item instead of 3 separate 1 slot items.

Closes #305. 