### PR TITLE
Updates source field for Rifleman II Legend Killer and Rifleman (Legend Killer 2)

### DIFF
--- a/data/mekfiles/meks/3055U/Rifleman II RFL-3N-2 (Legend Killer).mtf
+++ b/data/mekfiles/meks/3055U/Rifleman II RFL-3N-2 (Legend Killer).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,13 +15,14 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-generator:MegaMek Suite 0.50.12-nightly-2026-02-26 on 2026-02-28
+generator:MegaMek Suite 0.50.12-nightly-2026-03-28 on 2026-03-31
 chassis:Rifleman II
 model:RFL-3N-2 (Legend Killer)
 
 Config:Biped
 techbase:Inner Sphere
 era:3050
+source:Record Sheets: 3055 Upgrade
 rules level:2
 
 
@@ -48,12 +49,12 @@ RTR armor:6
 RTC armor:10
 
 Weapons:6
-LB 10-X AC, Right Arm
+Large Laser, Left Arm
 LB 10-X AC, Left Arm
 Large Laser, Right Arm
-Large Laser, Left Arm
-Medium Laser, Right Torso
+LB 10-X AC, Right Arm
 Medium Laser, Left Torso
+Medium Laser, Right Torso
 
 Left Arm:
 Shoulder
@@ -167,7 +168,6 @@ IS Endo Steel
 -Empty-
 -Empty-
 
-# Fluff Date: 2026-03-12 17:30:00
 overview:<p>The Rifleman II emerged from the Star League Defense Force's Royal program in 2773, representing a dramatic reimagining of Kallon Industries' venerable anti-aircraft platform. By adding twenty tons to the chassis weight and incorporating the most advanced technologies available, SLDF engineers transformed a capable fire-support 'Mech into a devastating assault-weight weapons platform. The design served exclusively with Royal units, never seeing widespread distribution before the Exodus.</p><p>When General Kerensky led the SLDF into exile, the Rifleman II accompanied them, disappearing from the Inner Sphere entirely. Rumors persisted throughout the Succession Wars of advanced Rifleman variants hidden in Periphery caches or carried by fortunate mercenary commands, but no confirmed sightings occurred for centuries. The most persistent legend involved the infamous Gray Noton, whose "Legend-Killer" Rifleman dominated the Solaris VII arenas, whispers suggested he had discovered an abandoned Rifleman II during his Periphery mercenary days and disguised it as a standard model to maintain his competitive advantage.</p>
 
 capabilities:<p>The Rifleman II builds upon its predecessor's anti-aircraft excellence while addressing nearly every weakness that plagued the original design. An Endo Steel internal structure and Extralight fusion engine free sufficient weight for twelve tons of standard armor, a sixty percent improvement over the RFL-3N. The weapons array replaces the original's mixed armament with paired LB 10-X autocannons and Large Pulse Lasers, one of each mounted in the distinctive arm assemblies. This combination provides devastating firepower against both aerial and ground targets, with the cluster ammunition option offering particular effectiveness against fast-moving aircraft.</p><p>Fourteen double heat sinks manage the thermal load far more effectively than the original's ten single units, enabling sustained fire that the RFL-3N could never achieve. A Beagle Active Probe enhances the already-exceptional sensor capabilities, allowing pilots to detect hidden enemies and coordinate with friendly forces. Torso-mounted medium lasers provide close-range backup. The only significant drawback is the XL engine's vulnerability to side torso damage, a trade-off the Royal engineers deemed acceptable given the design's intended role engaging enemies at range rather than brawling in close quarters.</p>
@@ -179,4 +179,7 @@ history:<p>The Rifleman II served exclusively with SLDF Royal regiments during i
 manufacturer:Kallon Weapon Industries
 
 primaryfactory:Nanking
+
+fluffdate:2026-03-12 17:30:00
+
 

--- a/data/mekfiles/meks/3055U/Rilfeman RFL-3N (Legend Killer 2).mtf
+++ b/data/mekfiles/meks/3055U/Rilfeman RFL-3N (Legend Killer 2).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,13 +15,14 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-generator:MegaMek Suite 0.50.12-nightly-2026-02-26 on 2026-02-28
+generator:MegaMek Suite 0.50.12-nightly-2026-03-28 on 2026-03-31
 chassis:Rifleman
 model:RFL-3N (Legend Killer 2)
 
 Config:Biped
 techbase:Inner Sphere
 era:3025
+source:Record Sheets: 3055 Upgrade
 rules level:1
 role:Sniper
 
@@ -49,10 +50,10 @@ RTR armor:6
 RTC armor:9
 
 Weapons:4
-AC/5, Right Arm
 AC/5, Left Arm
-Medium Laser, Right Arm
 Medium Laser, Left Arm
+AC/5, Right Arm
+Medium Laser, Right Arm
 
 Left Arm:
 Shoulder
@@ -166,7 +167,6 @@ Heat Sink
 -Empty-
 -Empty-
 
-# Fluff Date: 2026-03-12 17:30:00
 overview:<p>The Rifleman traces its origins to 2505, when Kallon Industries submitted the FALCON GRAY proposal to the Hegemony Armed Forces as one of the earliest dedicated BattleMech designs. The original fifty-ton platform relied purely on energy weapons and dispensed with hand actuators to achieve an unparalleled field of fire for its era. The design served adequately through the Reunification War before an improved variant in 2556 transformed the chassis into the definitive anti-aircraft platform, establishing the Rifleman's legendary reputation for centuries to come.</p><p>When Kallon unveiled the heavier sixty-ton model in 2770, the Star League embraced the design enthusiastically, and the Rifleman's continued production through the collapse of the Star League, the Succession Wars, and into the modern era speaks to its enduring value. Fielded by every Successor State military and widely available to mercenary commands and Periphery nations, the Rifleman remains one of the most recognizable heavy BattleMech silhouettes in the Inner Sphere.</p>
 
 capabilities:<p>The Rifleman excels in its intended role as a fire-support and anti-aircraft platform, built around its exceptional Garret D2j targeting and tracking system. This advanced electronics suite enables pilots to maintain accurate locks on fast-moving aerial targets with remarkable precision. The standard RFL-3N configuration pairs two Magna Mk. III Large Lasers with two Imperator-A medium autocannons in distinctive swiveling arm mounts, supplemented by torso-mounted Magna Mk. II medium lasers for close defense. The over-and-under arm-mounted weapon arrangement became the configuration's signature feature, allowing pilots the option of alternating weapons fire to cool down while maintaining an offensive posture.</p><p>These advantages come at significant cost. The Rifleman carries only seven and a half tons of armor, leaving it dangerously vulnerable when forced into direct combat with similarly-massed opponents. Its ten heat sinks prove grossly inadequate for sustained fire, though this matters less in the anti-aircraft role where targets require intermittent engagement between passes. The single twenty-round ammunition magazine provides sufficient firepower for sharp engagements but runs dry quickly in prolonged battles. The lack of hand and lower-arm actuators further hampers close combat performance, and the distinctive wing-shaped Garret T11-A communications antenna tends to draw enemy fire. Perhaps most especially, the design's ability to flip its arms over the shoulders allows engagement of targets behind the 'Mech, presenting a nasty surprise for enemies attempting flanking maneuvers through what appears to be a significant blind spot.</p>
@@ -178,4 +178,7 @@ history:<p>House Davion fielded the largest concentration of Riflemen throughout
 manufacturer:Kallon Weapon Industries
 
 primaryfactory:Nanking
+
+fluffdate:2026-03-12 17:30:00
+
 


### PR DESCRIPTION
Source field was updated to Record Sheet: 3055 Upgrade for both. 

This isn't listed on https://masterunitlist.info/Source/Index so it was manually added instead of being added to the sources folder.

Closes #307 