### PR TITLE
Fix malformed `yearsActive` blocks in faction YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ units.cache
 # Ignore Gradle build output directory
 /build
 .claude/
+/bin

--- a/data/universe/factions/ARC.yml
+++ b/data/universe/factions/ARC.yml
@@ -23,7 +23,7 @@ nameChanges:
 capital: Coromodir
 yearsActive:
   - start: 2910
-  - end: 2028
+    end: 3028
 capitalChanges:
   3022: New Abilene
   3026: Coromodir

--- a/data/universe/factions/MG.yml
+++ b/data/universe/factions/MG.yml
@@ -19,7 +19,6 @@ key: MG
 name: Mercenary Guild
 capital: Solaris
 yearsActive:
-  - start: 0
   - end: 2789
 tags:
   - IS

--- a/data/universe/factions/MRB.yml
+++ b/data/universe/factions/MRB.yml
@@ -20,7 +20,7 @@ name: Mercenary Review Board
 capital: Galatea
 yearsActive:
   - start: 2789
-  - end: 3052
+    end: 3052
 tags:
   - IS
   - MERC

--- a/data/universe/factions/MRBC.yml
+++ b/data/universe/factions/MRBC.yml
@@ -22,7 +22,7 @@ capitalChanges:
   3067: Galatea
 yearsActive:
   - start: 3052
-  - end: 3133
+    end: 3133
 tags:
   - IS
   - MERC


### PR DESCRIPTION
## Description
Several faction files used a two-list-item form for `yearsActive` (e.g. `- start: X` followed by `- end: Y`), which YAML parses as two separate open-ended `DateRange` entries instead of a single bounded range.

`ARC` (Aurigan Coalition) also had a typo (`end: 2028` instead of `3028`), making the faction parse as effectively immortal in `isActiveInYear` and contributing to MekHQ issue [#6451](https://github.com/MegaMek/mekhq/issues/6451) (extinct Aurigan Coalition still hiring mercs in 3035).

### Files fixed
- `data/universe/factions/ARC.yml` — merge to single range and fix typo: `start: 2910, end: 3028`
- `data/universe/factions/MG.yml` — merge to single range: `end: 2789`
- `data/universe/factions/MRB.yml` — merge to single range: `start: 2789, end: 3052`
- `data/universe/factions/MRBC.yml` — merge to single range: `start: 3052, end: 3133`

### Related
- MekHQ issue: MegaMek/mekhq#6451
- I need to do a PR in MekHQ to also harden this issue on the MekHQ side (filtering extinct factions out of contract employer/enemy pools regardless of stale planet-ownership data).