### PR TITLE
Fixing Clan CASE errors on several units

### DIFF
--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank D.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank D.blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -96,7 +96,6 @@ false
 Hyper-Assault Gauss Rifle/20 Ammo:OMNI
 Hyper-Assault Gauss Rifle/20 Ammo:OMNI
 CLTargeting Computer:OMNI
-CLCASE:OMNI
 </Body Equipment>
 
 <Front Equipment>
@@ -115,29 +114,15 @@ CLERMediumLaser:OMNI
 
 <Turret Equipment>
 CLHAG20:OMNI
-CLCASE:OMNI
 </Turret Equipment>
-
-<source>
-TR:3060
-</source>
-
-<tonnage>
-50.0
-</tonnage>
-
-<baseChassisTurretWeight>
-1.0
-</baseChassisTurretWeight>
-
-# Fluff Date: 2026-03-05 17:18:25
-<overview>
-<p>The Epona is a fifty-ton Clan OmniVehicle designed and exclusively produced by Clan Hell's Horses. Introduced in 2884 at Niles Industriplex Alpha, the Epona was the first combat vehicle in Clan history to incorporate OmniPod technology, a reflection of the Horses' deep respect for conventional forces in an era dominated by BattleMech supremacy. Purpose-built as a fast pursuit and reconnaissance platform, the Epona operates in the most prestigious front-line Galaxies of the Horses' touman, a distinction typically reserved for OmniMechs in other Clans. The design's versatility and proven combat record have served the Hell's Horses for well over a century, yet other Clans have largely refused to adopt the concept. According to the Horses, it is only Clan bias toward BattleMechs and the hubris of rival warriors that prevents wider use of the Epona and OmniVehicles in general.</p>
-</overview>
 
 <capabilities>
 <p>The Epona is constructed on the heaviest hovercraft chassis available, giving it a stable fifty-ton platform that maximizes both pod capacity and structural integrity. A Fusion 215 engine propels the vehicle to a flanking speed of 150 kilometers per hour, making it one of the fastest medium-weight combat vehicles in any Clan touman. This speed comes at a cost, as the chassis devotes only five tons to Compound VM20 ferro-fibrous armor, leaving the Epona lightly protected for its weight class. Seventeen tons of pod space are distributed across the hull, with a maximum of ten tons mountable in the turret.</p><p>The Epona's OmniPod technology allows rapid reconfiguration between missions, but this modularity introduces crew complexity. The roles of driver, gunner, and commander shift depending on the weapons loadout, requiring each crew station to be programmable for all possible tasks. New crews must train extensively before deploying, as the transitions between configurations demand proficiency across multiple combat roles. In its Prime configuration, the vehicle mounts four medium pulse lasers and a Streak SRM-4 in the turret, providing accurate close-quarters firepower capable of threatening even BattleMechs.</p>
 </capabilities>
+
+<overview>
+<p>The Epona is a fifty-ton Clan OmniVehicle designed and exclusively produced by Clan Hell's Horses. Introduced in 2884 at Niles Industriplex Alpha, the Epona was the first combat vehicle in Clan history to incorporate OmniPod technology, a reflection of the Horses' deep respect for conventional forces in an era dominated by BattleMech supremacy. Purpose-built as a fast pursuit and reconnaissance platform, the Epona operates in the most prestigious front-line Galaxies of the Horses' touman, a distinction typically reserved for OmniMechs in other Clans. The design's versatility and proven combat record have served the Hell's Horses for well over a century, yet other Clans have largely refused to adopt the concept. According to the Horses, it is only Clan bias toward BattleMechs and the hubris of rival warriors that prevents wider use of the Epona and OmniVehicles in general.</p>
+</overview>
 
 <deployment>
 <p>Introduced during the Jihad in 3068, the D configuration exploits Clan advances in Gauss technology. A Hyper-Assault Gauss Rifle/20 serves as the primary weapon, delivering a devastating spread of projectiles at high velocity. A targeting computer linked to a pair of ER medium lasers provides precision secondary fire, allowing crews to soften targets with the main gun before delivering accurate follow-up shots. This configuration has proven popular in Trials, where its combination of raw firepower and guided precision gives crews a decisive edge in formal combat.</p>
@@ -170,4 +155,17 @@ ARMOR:Compound VM20 Ferro-Fibrous
 COMMUNICATIONS:Build 1700/5 Tacticom
 TARGETING:Series XL FWS
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+50.0
+</tonnage>
+
+<baseChassisTurretWeight>
+1.0
+</baseChassisTurretWeight>
+
 

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank E.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank E.blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -97,7 +97,6 @@ CLPlasmaCannonAmmo:OMNI
 CLPlasmaCannonAmmo:OMNI
 CLAPGaussRifle Ammo:OMNI
 CLAPGaussRifle Ammo:OMNI
-CLCASE:OMNI
 </Body Equipment>
 
 <Front Equipment>
@@ -121,29 +120,20 @@ CLAPGaussRifle:OMNI
 CLAPGaussRifle:OMNI
 CLAPGaussRifle:OMNI
 CLAPGaussRifle:OMNI
-CLCASE:OMNI
 </Turret Equipment>
 
-<source>
-TR:3060
-</source>
-
-<tonnage>
-50.0
-</tonnage>
-
-<baseChassisTurretWeight>
-1.0
-</baseChassisTurretWeight>
-
-# Fluff Date: 2026-03-05 17:18:25
-<overview>
-<p>The Epona is a fifty-ton Clan OmniVehicle designed and exclusively produced by Clan Hell's Horses. Introduced in 2884 at Niles Industriplex Alpha, the Epona was the first combat vehicle in Clan history to incorporate OmniPod technology, a reflection of the Horses' deep respect for conventional forces in an era dominated by BattleMech supremacy. Purpose-built as a fast pursuit and reconnaissance platform, the Epona operates in the most prestigious front-line Galaxies of the Horses' touman, a distinction typically reserved for OmniMechs in other Clans. The design's versatility and proven combat record have served the Hell's Horses for well over a century, yet other Clans have largely refused to adopt the concept. According to the Horses, it is only Clan bias toward BattleMechs and the hubris of rival warriors that prevents wider use of the Epona and OmniVehicles in general.</p>
-</overview>
+<slotless_equipment>
+CLCASE
+CLCASE
+</slotless_equipment>
 
 <capabilities>
 <p>The Epona is constructed on the heaviest hovercraft chassis available, giving it a stable fifty-ton platform that maximizes both pod capacity and structural integrity. A Fusion 215 engine propels the vehicle to a flanking speed of 150 kilometers per hour, making it one of the fastest medium-weight combat vehicles in any Clan touman. This speed comes at a cost, as the chassis devotes only five tons to Compound VM20 ferro-fibrous armor, leaving the Epona lightly protected for its weight class. Seventeen tons of pod space are distributed across the hull, with a maximum of ten tons mountable in the turret.</p><p>The Epona's OmniPod technology allows rapid reconfiguration between missions, but this modularity introduces crew complexity. The roles of driver, gunner, and commander shift depending on the weapons loadout, requiring each crew station to be programmable for all possible tasks. New crews must train extensively before deploying, as the transitions between configurations demand proficiency across multiple combat roles. In its Prime configuration, the vehicle mounts four medium pulse lasers and a Streak SRM-4 in the turret, providing accurate close-quarters firepower capable of threatening even BattleMechs.</p>
 </capabilities>
+
+<overview>
+<p>The Epona is a fifty-ton Clan OmniVehicle designed and exclusively produced by Clan Hell's Horses. Introduced in 2884 at Niles Industriplex Alpha, the Epona was the first combat vehicle in Clan history to incorporate OmniPod technology, a reflection of the Horses' deep respect for conventional forces in an era dominated by BattleMech supremacy. Purpose-built as a fast pursuit and reconnaissance platform, the Epona operates in the most prestigious front-line Galaxies of the Horses' touman, a distinction typically reserved for OmniMechs in other Clans. The design's versatility and proven combat record have served the Hell's Horses for well over a century, yet other Clans have largely refused to adopt the concept. According to the Horses, it is only Clan bias toward BattleMechs and the hubris of rival warriors that prevents wider use of the Epona and OmniVehicles in general.</p>
+</overview>
 
 <deployment>
 <p>Introduced in 3070, the E configuration is purpose-built to counter battle armor and light combatants. Twin plasma cannons serve as the primary armament, generating intense heat that can overwhelm an opponent's cooling systems and devastate infantry formations. Six anti-personnel Gauss rifles provide a withering curtain of fire against battle armor and unarmored targets, backed by generous ammunition stores. While primarily an anti-infantry platform, the plasma cannons have proven equally dangerous to light OmniMechs that underestimate the Epona's firepower.</p>
@@ -176,4 +166,17 @@ ARMOR:Compound VM20 Ferro-Fibrous
 COMMUNICATIONS:Build 1700/5 Tacticom
 TARGETING:Series XL FWS
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+50.0
+</tonnage>
+
+<baseChassisTurretWeight>
+1.0
+</baseChassisTurretWeight>
+
 

--- a/data/mekfiles/vehicles/3060u/Hachiman Fire Support Tank (AAA).blk
+++ b/data/mekfiles/vehicles/3060u/Hachiman Fire Support Tank (AAA).blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -85,7 +85,6 @@ Hyper-Assault Gauss Rifle/20 Ammo
 Hyper-Assault Gauss Rifle/20 Ammo
 Hyper-Assault Gauss Rifle/20 Ammo
 Hyper-Assault Gauss Rifle/20 Ammo
-CLCASE
 </Body Equipment>
 
 <Front Equipment>
@@ -105,25 +104,15 @@ CLHAG20
 CLHAG20
 CLERMediumLaser
 CLERMediumLaser
-CLCASE
 </Turret Equipment>
-
-<source>
-TR:3060
-</source>
-
-<tonnage>
-50.0
-</tonnage>
-
-# Fluff Date: 2026-03-07 16:36:16
-<overview>
-<p>The Hachiman Fire Support Tank is a second-line Clan combat vehicle introduced in 2842, born from the need to provide reliable indirect fire support across the Clans' extensive touman hierarchies. Designed to operate alongside front-line BattleMechs and heavier OmniMechs in a supporting role, the Hachiman is produced at numerous Clan homeworld facilities by a variety of manufacturers, reflecting its widespread adoption. Despite the cultural bias many Clan warriors hold toward combat vehicles, the Hachiman's consistent battlefield effectiveness has ensured its continued place in Clan arsenals. Clans that favor combined-arms approaches, such as Clan Hell's Horses and Clan Blood Spirit, have integrated the Hachiman into front-line formations, a reflection of the design's practical value even within a culture that prizes the BattleMech above all else.</p>
-</overview>
 
 <capabilities>
 <p>The Hachiman is built around a pair of turret-mounted Type XX "Great Bow" LRM-20 launchers, each linked to an Artemis IV Fire Control System. The Artemis integration tightens missile grouping noticeably, increasing damage consistency at range. Four tons of LRM ammunition supports sustained fire through a typical Trial or skirmish, but crews engaged in prolonged conventional warfare can exhaust the magazines quickly, leaving the vehicle reliant on its secondary weapons.</p><p>When opponents close the distance, the Hachiman responds with a pair of Series 2d Extended Range Medium Lasers and a hull-mounted Pattern J6 Streak SRM-4. The Streak launcher fires only on a confirmed lock, preventing wasted ammunition, and provides a meaningful short-range punch for a vehicle of this class. The combination of long-range precision and short-range backup gives the Hachiman reasonable flexibility across engagement ranges, though it is clearly most effective at distance.</p><p>Seven tons of Compound G5 ferro-fibrous armor provides solid protection for a 50-ton tracked vehicle, and the Hachiman's compartmentalized crew layout maximizes crew survival in the event of a penetrating hit. The trade-off is reduced inter-crew communication. The compartmentalization impairs coordination between the driver, gunners, and commander, degrading fighting effectiveness when compared to an open-crew design. Scientist-caste studies have confirmed this reduces combat efficiency, though the same studies acknowledge the Hachiman achieves the highest crew survival rate of any Clan armored vehicle. At a top speed of 65 km/h, the design is reasonably mobile for a missile-focused platform, allowing it to reposition between firing positions more readily than heavier fire-support vehicles.</p>
 </capabilities>
+
+<overview>
+<p>The Hachiman Fire Support Tank is a second-line Clan combat vehicle introduced in 2842, born from the need to provide reliable indirect fire support across the Clans' extensive touman hierarchies. Designed to operate alongside front-line BattleMechs and heavier OmniMechs in a supporting role, the Hachiman is produced at numerous Clan homeworld facilities by a variety of manufacturers, reflecting its widespread adoption. Despite the cultural bias many Clan warriors hold toward combat vehicles, the Hachiman's consistent battlefield effectiveness has ensured its continued place in Clan arsenals. Clans that favor combined-arms approaches, such as Clan Hell's Horses and Clan Blood Spirit, have integrated the Hachiman into front-line formations, a reflection of the design's practical value even within a culture that prizes the BattleMech above all else.</p>
+</overview>
 
 <deployment>
 <p>The AAA variant is deployed in dedicated anti-aircraft and anti-aerospace roles, most commonly in garrison clusters and defensive perimeter assignments where aerospace threats are a primary concern. Developed during the Jihad, it entered service through Snow Raven production on Dante and reflects the changed threat environment of that era, when aerospace assets were employed offensively against ground installations with greater frequency. The twin HAG-20s provide a punishing deterrent against low-altitude or hovering aerospace fighters, and the retained ER Medium Lasers give the crew a secondary option against ground targets if the situation demands it. The Republic of the Sphere continued production of the AAA through the Dark Age period, and the variant has been observed in Clan and Inner Sphere service in roles ranging from spaceport defense to convoy escort against aerospace interdiction.</p>
@@ -156,4 +145,13 @@ ARMOR:Compound G5 Ferro-Fibrous
 COMMUNICATIONS:JNE Integrated
 TARGETING:Build 2 JRD TTS with Artemis IV FCS
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+50.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3060u/Indra Infantry Transport (BA).blk
+++ b/data/mekfiles/vehicles/3060u/Indra Infantry Transport (BA).blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -94,7 +94,6 @@ CLPlasmaCannonAmmo
 CLPlasmaCannonAmmo
 CLAPGaussRifle Ammo
 CLAPGaussRifle Ammo
-CLCASE
 </Body Equipment>
 
 <Front Equipment>
@@ -116,29 +115,15 @@ CLAPGaussRifle
 CLAPGaussRifle
 CLAPGaussRifle
 CLAPGaussRifle
-CLCASE
 </Turret Equipment>
-
-<slotless_equipment>
-ISBPodAmmo
-</slotless_equipment>
-
-<source>
-TR:3060
-</source>
-
-<tonnage>
-35.0
-</tonnage>
-
-# Fluff Date: 2026-03-08 18:30:06
-<overview>
-<p>The Indra Infantry Transport is a wheeled Clan combat vehicle developed in 2842 to fill the need for a protected personnel carrier capable of operating alongside frontline combat units in contested zones. Built on Clan homeworlds across multiple production facilities, it carries a smaller infantry complement than many dedicated transports but compensates with heavy armament and solid protection. The vehicle takes its name from the Brahmanic archer-god of lightning, a reference apt to its primary weapon, which is unusually formidable for a vehicle of its type. A persistent rivalry exists between Indra and Zorya light tank crews, rooted in the common perception that the infantry transport outclasses the dedicated combat vehicle across nearly every measurable category. The Indra has served numerous Clans across the Kerensky Cluster and, following Inner Sphere exposure during the Clan Invasion, found limited but consequential production outside the Homeworlds.</p>
-</overview>
 
 <capabilities>
 <p>The Indra's defining characteristic is its choice of primary armament. A fixed-forward Type 22 Extended Range PPC gives the vehicle hitting power well beyond what most infantry transports carry, but the weapon's mass demands nearly as much again in heat sinks, and sustained fire builds heat in the cargo compartment to dangerous levels. An attempt to install a dedicated cooling circuit around the infantry bay provided little practical relief.</p><p>Anti-personnel defense comes from four Series IX Machine Guns mounted in a micro-turret, providing 360-degree coverage against unarmored infantry. The turret weapons have demonstrated unexpected effectiveness against lightly armored vehicles as well, fouling tracks, disabling turret mechanisms, and damaging control surfaces at close range well beyond their nominal anti-armor rating.</p><p>Five tons of Compound K4 ferro-fibrous armor provide solid protection for the vehicle's size, with front and side coverage adequate against heavy direct-fire weapons. Rear and turret armor is lighter, capable of stopping small arms and most anti-vehicle weapons but not designed to absorb main battle fire from multiple angles. The Indra's tires incorporate a self-sealing HarJel polymer gel system, used on WarShips and Elemental battle suits, allowing punctured tires to repair and re-inflate against impacts up to 50mm caliber. Larger rounds defeat the system, but it provides meaningful protection in the small-arms environment most infantry transports operate in. The Fusion 155 power plant delivers a flanking speed of 86 kph, competitive with the mechanized formations it typically supports.</p>
 </capabilities>
+
+<overview>
+<p>The Indra Infantry Transport is a wheeled Clan combat vehicle developed in 2842 to fill the need for a protected personnel carrier capable of operating alongside frontline combat units in contested zones. Built on Clan homeworlds across multiple production facilities, it carries a smaller infantry complement than many dedicated transports but compensates with heavy armament and solid protection. The vehicle takes its name from the Brahmanic archer-god of lightning, a reference apt to its primary weapon, which is unusually formidable for a vehicle of its type. A persistent rivalry exists between Indra and Zorya light tank crews, rooted in the common perception that the infantry transport outclasses the dedicated combat vehicle across nearly every measurable category. The Indra has served numerous Clans across the Kerensky Cluster and, following Inner Sphere exposure during the Clan Invasion, found limited but consequential production outside the Homeworlds.</p>
+</overview>
 
 <deployment>
 <p>The (BA) variant was developed in 3069 to address the specialized demands of anti-insurgency and urban pacification operations, particularly in the aftermath of the Hell's Horses invasion of former Lyran worlds. This configuration retains the standard chassis but modifies the infantry bay and loadout to better accommodate battle armor operations and close-range anti-infantry engagements. Production is limited to the Quikscell Company facility on Pandora. The vehicle is issued primarily to Clan Wolf forces operating in occupation zones where anti-insurgency capability takes priority over conventional armored transport. The Indra's association with the Turtle Bay massacre creates a persistent public relations burden for units equipped with this variant, one that Wolf commanders have had limited success in addressing through rebranding or operational distinction.</p>
@@ -171,4 +156,13 @@ ARMOR:Compound K4 Ferro-Fibrous
 COMMUNICATIONS:Consolidated Type 2I
 TARGETING:Series VI KITT
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+35.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3060u/Mithras Light Tank (ERLL).blk
+++ b/data/mekfiles/vehicles/3060u/Mithras Light Tank (ERLL).blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -87,12 +87,10 @@ false
 <Body Equipment>
 CLAPGaussRifle Ammo
 CLTargeting Computer
-CLCASE
 </Body Equipment>
 
 <Front Equipment>
 CLAPGaussRifle
-CLCASE
 </Front Equipment>
 
 <Right Equipment>
@@ -108,22 +106,13 @@ CLCASE
 CLERLargeLaser
 </Turret Equipment>
 
-<source>
-TR:3060
-</source>
-
-<tonnage>
-25.0
-</tonnage>
-
-# Fluff Date: 2026-03-09 16:42:39
-<overview>
-<p>The Mithras Light Tank is a Clan combat vehicle designed to serve as both a swift cavalry unit and a versatile fire support platform. Developed by Clan scientists in the mid-twenty-ninth century, the design emerged as a practical answer to the need for fast, hard-hitting light armor capable of engaging targets across multiple range brackets. The Mithras occupies a well-established niche in Clan vehicle doctrine, operating as a quick-response unit equally suited to harrying flanks, supporting Elemental assaults, or sustaining pressure on retreating forces. Though its thin armor limits staying power in sustained engagements, the design's combination of speed and weapons flexibility has made it a reliable fixture across multiple Clans throughout the Succession Wars era and beyond.</p>
-</overview>
-
 <capabilities>
 <p>The Mithras is operated by a two-man crew. The driver manages vehicle movement and sensor operations, while the gunner handles the weapons and communication systems using an integrated Combined Weapon System. The CWS allows both turret weapons to be aimed and fired simultaneously, a significant tactical advantage. The absence of a secondary gun sight means the front-mounted laser cannot be fired if the vehicle's sensors are disabled, reducing the gunner's options when the CWS becomes inoperative.</p><p>The primary weapon is a Type 25 Ultra Autocannon/2 mounted in the turret for full arc coverage. Its advanced autoloader allows variable rates of fire, up to twelve rounds per minute at full speed. The recoil mechanism is prone to fouling the autoloader track, however, which can jam the system and render the gun useless at critical moments. Two Series 2b Extended Range Medium Lasers complement the cannon. One is mounted coaxially in the turret to cover the autocannon's dead zone, while the second is fixed in the hull front for suppression when the turret is engaged elsewhere.</p><p>The Mithras carries only three tons of armor, but the Compound Alpha Ferro-Fibrous construction provides protection equivalent to more than four tons of standard plating. The vehicle can absorb hits from all but the largest weapons as a result. The rear armor is the design's primary weakness, as a single hit from even a light or medium weapon can breach it, leaving the vehicle vulnerable to catastrophic damage from behind.</p>
 </capabilities>
+
+<overview>
+<p>The Mithras Light Tank is a Clan combat vehicle designed to serve as both a swift cavalry unit and a versatile fire support platform. Developed by Clan scientists in the mid-twenty-ninth century, the design emerged as a practical answer to the need for fast, hard-hitting light armor capable of engaging targets across multiple range brackets. The Mithras occupies a well-established niche in Clan vehicle doctrine, operating as a quick-response unit equally suited to harrying flanks, supporting Elemental assaults, or sustaining pressure on retreating forces. Though its thin armor limits staying power in sustained engagements, the design's combination of speed and weapons flexibility has made it a reliable fixture across multiple Clans throughout the Succession Wars era and beyond.</p>
+</overview>
 
 <deployment>
 <p>The ERLL variant is fielded primarily by forces operating from the Hector facility during the Jihad and early Dark Age periods. Its Clan Extended Range Large Laser and AP Gauss Rifle combination, guided by a Targeting Computer, makes the variant a capable long-range fire support platform that can engage targets well beyond the reach of the base model. The ERLL trades the autocannon's sustained-fire flexibility for concentrated precision, making it most effective in defensive positions or when attached to larger formations where it can specialize in picking off light vehicles and battle armor at extended range.</p>
@@ -156,4 +145,13 @@ ARMOR:Compound Alpha
 COMMUNICATIONS:BMR 6c
 TARGETING:Mark II CWS
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+25.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle (ATM).blk
+++ b/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle (ATM).blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -108,25 +108,15 @@ CLCASE
 CLATM9
 CLAPGaussRifle
 CLAPGaussRifle
-CLCASE
 </Turret Equipment>
-
-<source>
-TR:3060
-</source>
-
-<tonnage>
-35.0
-</tonnage>
-
-# Fluff Date: 2026-03-11 21:02:11
-<overview>
-<p>The Svantovit Infantry Fighting Vehicle emerged during the Succession Wars era as a purpose-built transport for second-line Clan garrison forces. Originally conceived to carry conventional infantry platoons, the design was substantially reworked in 2870 to serve the more demanding requirements of Elemental Point transportation, recognizing that non-OmniMech units lacked the handholds necessary for battle armor to ride into combat. Manufactured across numerous Clan Homeworld facilities under no single producing entity, the Svantovit became a ubiquitous fixture of Clan second-line and garrison operations across virtually every Clan. Its exceptional hover speed made it well-suited to repositioning infantry assets rapidly across diverse terrain, though the vehicle's light armor demanded careful tactical employment. Few designs so thoroughly defined the logistics of non-OmniMech Elemental delivery in the era before more capable carriers became widely available.</p>
-</overview>
 
 <capabilities>
 <p>The 'Masada' replaces the standard fusion engine with an XL unit, pushing the vehicle's flanking speed to 183 kph while freeing weight for a significantly heavier weapons suite. The five-ton infantry compartment and three tons of Compound Alpha ferro-fibrous armor are retained from the standard Svantovit, preserving the variant's core Elemental transport function. The rear hatch deployment limitation and the associated halt-before-deployment operating procedure remain unchanged.</p><p>The turret armament is substantially upgraded. A single ATM-9 launcher fed by three tons of ammunition replaces the Streak SRM launchers, giving the 'Masada' multi-range engagement capability at the cost of the standard model's point-defense focus. A pair of anti-personnel Gauss rifles supplementing the ATM system provide effective suppression against infantry targets, though their effectiveness against armored opponents is limited. The combination makes the 'Masada' a more capable fire support vehicle than the standard Svantovit, but the lighter anti-infantry weapons and heavier reliance on the ATM system require skilled fire control to employ effectively. As with all ATM-equipped vehicles, ammunition selection determines the engagement envelope, and logistics support for multiple ATM munition types is an ongoing operational concern.</p>
 </capabilities>
+
+<overview>
+<p>The Svantovit Infantry Fighting Vehicle emerged during the Succession Wars era as a purpose-built transport for second-line Clan garrison forces. Originally conceived to carry conventional infantry platoons, the design was substantially reworked in 2870 to serve the more demanding requirements of Elemental Point transportation, recognizing that non-OmniMech units lacked the handholds necessary for battle armor to ride into combat. Manufactured across numerous Clan Homeworld facilities under no single producing entity, the Svantovit became a ubiquitous fixture of Clan second-line and garrison operations across virtually every Clan. Its exceptional hover speed made it well-suited to repositioning infantry assets rapidly across diverse terrain, though the vehicle's light armor demanded careful tactical employment. Few designs so thoroughly defined the logistics of non-OmniMech Elemental delivery in the era before more capable carriers became widely available.</p>
+</overview>
 
 <deployment>
 <p>The 'Masada' entered service with Clan Hell's Horse and Clan Snow Leopard forces primarily operating in the Homeworlds during the Jihad era. Production at Csesztreg supplied Hell's Horse touman units, while the Niles facility provided vehicles to Snow Leopard forces during the same period. The variant's combination of improved speed and heavier weapons made it a preferred Elemental transport when available, though limited production meant distribution remained concentrated among Homeworld Clan forces rather than spreading broadly to Inner Sphere theaters.</p>
@@ -159,4 +149,13 @@ ARMOR:Compound Alpha Ferro-Fibrous
 COMMUNICATIONS:Type 2I
 TARGETING:Series II GPS
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+35.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle.blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -25,27 +25,27 @@ Svantovit Infantry Fighting Vehicle
 </Name>
 
 <Model>
-
+(ATM) 'Masada'
 </Model>
 
 <mul id:>
-3139
+3137
 </mul id:>
 
 <year>
-2870
+3069
 </year>
 
 <originalBuildYear>
-2870
+3069
 </originalBuildYear>
 
 <type>
-Clan Level 2
+Clan Level 3
 </type>
 
 <role>
-Missile Boat
+Striker
 </role>
 
 <motion_type>
@@ -57,16 +57,12 @@ troopspace:5.0
 </transporters>
 
 <cruiseMP>
-10
+11
 </cruiseMP>
 
 <engine_type>
-0
+2
 </engine_type>
-
-<clan_engine>
-false
-</clan_engine>
 
 <armor_type>
 1
@@ -77,7 +73,7 @@ false
 </armor_tech_rating>
 
 <armor_tech_level>
-2
+6
 </armor_tech_level>
 
 <armor>
@@ -89,52 +85,40 @@ false
 </armor>
 
 <Body Equipment>
-Clan Machine Gun Ammo - Half
-Clan Ammo LRM-5
-Clan Streak SRM 2 Ammo
-CLCASE
+Clan Ammo ATM-9
+Clan Ammo ATM-9 ER
+Clan Ammo ATM-9 HE
+CLAPGaussRifle Ammo
 </Body Equipment>
 
 <Front Equipment>
-CLLRM5
-CLLRM5
 </Front Equipment>
 
 <Right Equipment>
-CLMG
 </Right Equipment>
 
 <Left Equipment>
-CLMG
 </Left Equipment>
 
 <Rear Equipment>
 </Rear Equipment>
 
 <Turret Equipment>
-CLStreakSRM2
-CLStreakSRM2
+CLATM9
+CLAPGaussRifle
+CLAPGaussRifle
 </Turret Equipment>
 
-<source>
-TR:3060
-</source>
+<capabilities>
+<p>The 'Masada' replaces the standard fusion engine with an XL unit, pushing the vehicle's flanking speed to 183 kph while freeing weight for a significantly heavier weapons suite. The five-ton infantry compartment and three tons of Compound Alpha ferro-fibrous armor are retained from the standard Svantovit, preserving the variant's core Elemental transport function. The rear hatch deployment limitation and the associated halt-before-deployment operating procedure remain unchanged.</p><p>The turret armament is substantially upgraded. A single ATM-9 launcher fed by three tons of ammunition replaces the Streak SRM launchers, giving the 'Masada' multi-range engagement capability at the cost of the standard model's point-defense focus. A pair of anti-personnel Gauss rifles supplementing the ATM system provide effective suppression against infantry targets, though their effectiveness against armored opponents is limited. The combination makes the 'Masada' a more capable fire support vehicle than the standard Svantovit, but the lighter anti-infantry weapons and heavier reliance on the ATM system require skilled fire control to employ effectively. As with all ATM-equipped vehicles, ammunition selection determines the engagement envelope, and logistics support for multiple ATM munition types is an ongoing operational concern.</p>
+</capabilities>
 
-<tonnage>
-35.0
-</tonnage>
-
-# Fluff Date: 2026-03-11 21:02:11
 <overview>
 <p>The Svantovit Infantry Fighting Vehicle emerged during the Succession Wars era as a purpose-built transport for second-line Clan garrison forces. Originally conceived to carry conventional infantry platoons, the design was substantially reworked in 2870 to serve the more demanding requirements of Elemental Point transportation, recognizing that non-OmniMech units lacked the handholds necessary for battle armor to ride into combat. Manufactured across numerous Clan Homeworld facilities under no single producing entity, the Svantovit became a ubiquitous fixture of Clan second-line and garrison operations across virtually every Clan. Its exceptional hover speed made it well-suited to repositioning infantry assets rapidly across diverse terrain, though the vehicle's light armor demanded careful tactical employment. Few designs so thoroughly defined the logistics of non-OmniMech Elemental delivery in the era before more capable carriers became widely available.</p>
 </overview>
 
-<capabilities>
-<p>The Svantovit's fusion power plant drives it to a flanking speed of 162 kph, allowing the vehicle to cross open ground quickly when transporting Elementals to a contact point. The five-ton infantry compartment, accessible via a large rear hatch, can accommodate a full Elemental Point. That hatch is also the vehicle's most significant tactical liability: it occupies the entire rear facing, eliminating any rearward firing arc and demanding careful positioning when deploying troops. Standard operating procedure requires the Svantovit to come to a complete halt before opening the hatch, as the rapid weight shift during high-speed deceleration has been known to cause serious handling problems and crashes. Experienced crews learned to manage crash-deceleration from near-flank speed to a full stop in seconds, a technique that is rough on personnel but minimizes the vehicle's exposure during the vulnerable deployment window.</p><p>Firepower is organized to support the disembarking troops. Two Type V "Longbow" LRM-5 launchers fixed in the forward arc provide ranged suppression and can also fire indirectly. A pair of Pattern J2 Streak SRM-2 launchers in a full-traverse turret gives 360-degree defensive coverage, though the Streak guidance system requires target lock and cannot engage speculatively. Series IX Machine Guns on each side discourage enemy infantry from approaching the vehicle's flanks during troop deployment. The Streak turret cannot cover the sides of the vehicle's hull at close range, leaving a dead zone that infantry and light vehicles can exploit. Compound Alpha ferro-fibrous armor provides only three tons of protection, and the Svantovit must rely on speed and its escorts rather than durability to survive sustained fire.</p>
-</capabilities>
-
 <deployment>
-<p>The standard Svantovit was distributed to second-line and garrison formations across every Clan from 2870 onward. Clans Blood Spirit and Hell's Horses operated the greatest concentrations, fielding the vehicle in numbers that reflected their reliance on conventional forces and Elemental Points in garrison roles. Clans Star Adder and Jade Falcon operated minimal numbers, with Jade Falcon limiting use to training exercises. Inner Sphere forces gained access to the design through Clan occupation zones and salvage from the Clan Invasion onward, with Draconis Combine production eventually restarting on Irece and later at Hyner.</p>
+<p>The 'Masada' entered service with Clan Hell's Horse and Clan Snow Leopard forces primarily operating in the Homeworlds during the Jihad era. Production at Csesztreg supplied Hell's Horse touman units, while the Niles facility provided vehicles to Snow Leopard forces during the same period. The variant's combination of improved speed and heavier weapons made it a preferred Elemental transport when available, though limited production meant distribution remained concentrated among Homeworld Clan forces rather than spreading broadly to Inner Sphere theaters.</p>
 </deployment>
 
 <history>
@@ -142,11 +126,11 @@ TR:3060
 </history>
 
 <manufacturer>
-Various
+Csesztreg Industriplex Beta|Niles Industriplex Beta
 </manufacturer>
 
 <primaryFactory>
-Various
+Csesztreg|Niles
 </primaryFactory>
 
 <systemManufacturers>
@@ -159,9 +143,18 @@ TARGETING:Unknown
 
 <systemModels>
 CHASSIS:Unknown
-ENGINE:175
+ENGINE:XL
 ARMOR:Compound Alpha Ferro-Fibrous
 COMMUNICATIONS:Type 2I
 TARGETING:Series II GPS
 </systemModels>
+
+<source>
+TR:3060
+</source>
+
+<tonnage>
+35.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle.blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
+#Saved from version 0.50.12 on 2026-02-26
 <UnitType>
 Tank
 </UnitType>
@@ -25,27 +25,27 @@ Svantovit Infantry Fighting Vehicle
 </Name>
 
 <Model>
-(ATM) 'Masada'
+
 </Model>
 
 <mul id:>
-3137
+3139
 </mul id:>
 
 <year>
-3069
+2870
 </year>
 
 <originalBuildYear>
-3069
+2870
 </originalBuildYear>
 
 <type>
-Clan Level 3
+Clan Level 2
 </type>
 
 <role>
-Striker
+Missile Boat
 </role>
 
 <motion_type>
@@ -57,12 +57,16 @@ troopspace:5.0
 </transporters>
 
 <cruiseMP>
-11
+10
 </cruiseMP>
 
 <engine_type>
-2
+0
 </engine_type>
+
+<clan_engine>
+false
+</clan_engine>
 
 <armor_type>
 1
@@ -73,7 +77,7 @@ troopspace:5.0
 </armor_tech_rating>
 
 <armor_tech_level>
-6
+2
 </armor_tech_level>
 
 <armor>
@@ -85,40 +89,52 @@ troopspace:5.0
 </armor>
 
 <Body Equipment>
-Clan Ammo ATM-9
-Clan Ammo ATM-9 ER
-Clan Ammo ATM-9 HE
-CLAPGaussRifle Ammo
+Clan Machine Gun Ammo - Half
+Clan Ammo LRM-5
+Clan Streak SRM 2 Ammo
+CLCASE
 </Body Equipment>
 
 <Front Equipment>
+CLLRM5
+CLLRM5
 </Front Equipment>
 
 <Right Equipment>
+CLMG
 </Right Equipment>
 
 <Left Equipment>
+CLMG
 </Left Equipment>
 
 <Rear Equipment>
 </Rear Equipment>
 
 <Turret Equipment>
-CLATM9
-CLAPGaussRifle
-CLAPGaussRifle
+CLStreakSRM2
+CLStreakSRM2
 </Turret Equipment>
 
-<capabilities>
-<p>The 'Masada' replaces the standard fusion engine with an XL unit, pushing the vehicle's flanking speed to 183 kph while freeing weight for a significantly heavier weapons suite. The five-ton infantry compartment and three tons of Compound Alpha ferro-fibrous armor are retained from the standard Svantovit, preserving the variant's core Elemental transport function. The rear hatch deployment limitation and the associated halt-before-deployment operating procedure remain unchanged.</p><p>The turret armament is substantially upgraded. A single ATM-9 launcher fed by three tons of ammunition replaces the Streak SRM launchers, giving the 'Masada' multi-range engagement capability at the cost of the standard model's point-defense focus. A pair of anti-personnel Gauss rifles supplementing the ATM system provide effective suppression against infantry targets, though their effectiveness against armored opponents is limited. The combination makes the 'Masada' a more capable fire support vehicle than the standard Svantovit, but the lighter anti-infantry weapons and heavier reliance on the ATM system require skilled fire control to employ effectively. As with all ATM-equipped vehicles, ammunition selection determines the engagement envelope, and logistics support for multiple ATM munition types is an ongoing operational concern.</p>
-</capabilities>
+<source>
+TR:3060
+</source>
 
+<tonnage>
+35.0
+</tonnage>
+
+# Fluff Date: 2026-03-11 21:02:11
 <overview>
 <p>The Svantovit Infantry Fighting Vehicle emerged during the Succession Wars era as a purpose-built transport for second-line Clan garrison forces. Originally conceived to carry conventional infantry platoons, the design was substantially reworked in 2870 to serve the more demanding requirements of Elemental Point transportation, recognizing that non-OmniMech units lacked the handholds necessary for battle armor to ride into combat. Manufactured across numerous Clan Homeworld facilities under no single producing entity, the Svantovit became a ubiquitous fixture of Clan second-line and garrison operations across virtually every Clan. Its exceptional hover speed made it well-suited to repositioning infantry assets rapidly across diverse terrain, though the vehicle's light armor demanded careful tactical employment. Few designs so thoroughly defined the logistics of non-OmniMech Elemental delivery in the era before more capable carriers became widely available.</p>
 </overview>
 
+<capabilities>
+<p>The Svantovit's fusion power plant drives it to a flanking speed of 162 kph, allowing the vehicle to cross open ground quickly when transporting Elementals to a contact point. The five-ton infantry compartment, accessible via a large rear hatch, can accommodate a full Elemental Point. That hatch is also the vehicle's most significant tactical liability: it occupies the entire rear facing, eliminating any rearward firing arc and demanding careful positioning when deploying troops. Standard operating procedure requires the Svantovit to come to a complete halt before opening the hatch, as the rapid weight shift during high-speed deceleration has been known to cause serious handling problems and crashes. Experienced crews learned to manage crash-deceleration from near-flank speed to a full stop in seconds, a technique that is rough on personnel but minimizes the vehicle's exposure during the vulnerable deployment window.</p><p>Firepower is organized to support the disembarking troops. Two Type V "Longbow" LRM-5 launchers fixed in the forward arc provide ranged suppression and can also fire indirectly. A pair of Pattern J2 Streak SRM-2 launchers in a full-traverse turret gives 360-degree defensive coverage, though the Streak guidance system requires target lock and cannot engage speculatively. Series IX Machine Guns on each side discourage enemy infantry from approaching the vehicle's flanks during troop deployment. The Streak turret cannot cover the sides of the vehicle's hull at close range, leaving a dead zone that infantry and light vehicles can exploit. Compound Alpha ferro-fibrous armor provides only three tons of protection, and the Svantovit must rely on speed and its escorts rather than durability to survive sustained fire.</p>
+</capabilities>
+
 <deployment>
-<p>The 'Masada' entered service with Clan Hell's Horse and Clan Snow Leopard forces primarily operating in the Homeworlds during the Jihad era. Production at Csesztreg supplied Hell's Horse touman units, while the Niles facility provided vehicles to Snow Leopard forces during the same period. The variant's combination of improved speed and heavier weapons made it a preferred Elemental transport when available, though limited production meant distribution remained concentrated among Homeworld Clan forces rather than spreading broadly to Inner Sphere theaters.</p>
+<p>The standard Svantovit was distributed to second-line and garrison formations across every Clan from 2870 onward. Clans Blood Spirit and Hell's Horses operated the greatest concentrations, fielding the vehicle in numbers that reflected their reliance on conventional forces and Elemental Points in garrison roles. Clans Star Adder and Jade Falcon operated minimal numbers, with Jade Falcon limiting use to training exercises. Inner Sphere forces gained access to the design through Clan occupation zones and salvage from the Clan Invasion onward, with Draconis Combine production eventually restarting on Irece and later at Hyner.</p>
 </deployment>
 
 <history>
@@ -126,11 +142,11 @@ CLAPGaussRifle
 </history>
 
 <manufacturer>
-Csesztreg Industriplex Beta|Niles Industriplex Beta
+Various
 </manufacturer>
 
 <primaryFactory>
-Csesztreg|Niles
+Various
 </primaryFactory>
 
 <systemManufacturers>
@@ -143,18 +159,9 @@ TARGETING:Unknown
 
 <systemModels>
 CHASSIS:Unknown
-ENGINE:XL
+ENGINE:175
 ARMOR:Compound Alpha Ferro-Fibrous
 COMMUNICATIONS:Type 2I
 TARGETING:Series II GPS
 </systemModels>
-
-<source>
-TR:3060
-</source>
-
-<tonnage>
-35.0
-</tonnage>
-
 

--- a/data/mekfiles/vehicles/3075/Bellona Hover Tank.blk
+++ b/data/mekfiles/vehicles/3075/Bellona Hover Tank.blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -110,7 +110,6 @@ CLLightMG
 </Left Equipment>
 
 <Rear Equipment>
-CLCASE
 </Rear Equipment>
 
 <Turret Equipment>
@@ -119,22 +118,13 @@ CLFlamer
 CLUltraAC10
 </Turret Equipment>
 
-<source>
-TR:3075
-</source>
-
-<tonnage>
-45.0
-</tonnage>
-
-# Fluff Date: 2026-03-02 15:52:16
-<overview>
-<p>The Bellona Hover Tank is a forty-five-ton cavalry vehicle developed by Clan Hell's Horses during the Jihad era as part of Khan James Cobb's campaign to reassert the Horses' presence among the Inner Sphere Clans. Named for the Roman goddess of war, the vehicle was designed as a rapid strike and flanking platform, built around the Hell's Horses cavalry tenet that speed is the finest armor a vehicle can carry. First produced at HH Complex Beta in the Clan Homeworlds, the Bellona arrived in the Inner Sphere in limited numbers during the Jihad and quickly earned a fierce reputation among Hell's Horses warriors and their Clan opponents. The design has since become a mainstay of Hell's Horses toumans across multiple eras, valued for the combination of high-speed mobility and consistent firepower it delivers to fast cavalry formations.</p>
-</overview>
-
 <capabilities>
 <p>The Bellona's primary offensive weapon is a Type 9 Ultra Autocannon/10 mounted in an armored turret, giving the crew the ability to engage targets across a broad range band whether advancing or withdrawing. The turret mount is central to the vehicle's tactical design, allowing the autocannon's reach to be applied regardless of the Bellona's direction of travel, a critical attribute for a vehicle whose doctrine emphasizes continuous forward pressure. Four Series HL-II Light Machine Guns and two Type 14b Flamers round out the weapons suite, providing meaningful anti-infantry and anti-Elemental capability. The flamers proved particularly useful in close engagements where Elementals would otherwise overwhelm a lighter vehicle, and they have become a signature component of the Bellona's tactical identity in Hell's Horses formations.</p><p>Eight tons of Forging HTT05 armor protect the hull and motive system, representing the maximum the designers could mount while preserving the vehicle's speed. Coverage prioritizes the forward hull, reflecting the design's preference for head-on engagement, though the turret is not neglected. A Fusion Type 170 powerplant provides a cruising speed of ninety-seven kilometers per hour and a flank speed exceeding one hundred fifty, making the Bellona one of the fastest armed vehicles deployed by Hell's Horses. Series XII ComSys communications and Build IX TTS targeting systems are standard equipment. The design's primary limitation is the Light Machine Guns, which are most effective against unarmored infantry and offer little penetrating power against the armored opposition Hell's Horses most commonly faces on Clan front lines.</p>
 </capabilities>
+
+<overview>
+<p>The Bellona Hover Tank is a forty-five-ton cavalry vehicle developed by Clan Hell's Horses during the Jihad era as part of Khan James Cobb's campaign to reassert the Horses' presence among the Inner Sphere Clans. Named for the Roman goddess of war, the vehicle was designed as a rapid strike and flanking platform, built around the Hell's Horses cavalry tenet that speed is the finest armor a vehicle can carry. First produced at HH Complex Beta in the Clan Homeworlds, the Bellona arrived in the Inner Sphere in limited numbers during the Jihad and quickly earned a fierce reputation among Hell's Horses warriors and their Clan opponents. The design has since become a mainstay of Hell's Horses toumans across multiple eras, valued for the combination of high-speed mobility and consistent firepower it delivers to fast cavalry formations.</p>
+</overview>
 
 <deployment>
 <p>The base Bellona was distributed among Hell's Horses frontline Clusters engaged against Clan Wolf and Clan Ice Hellion during the Jihad, primarily in the fighting across the Horses' contested occupation corridor. Given severe supply constraints imposed by the Homeworld logistics chain, individual Stars and Points were seeded into existing vehicle Stars rather than forming dedicated Bellona formations. As Csesztreg production ramped up during the Dark Age, Hell's Horses garrison and frontline Clusters throughout the occupation zones received the Bellona in larger numbers, and it has become the standard fast cavalry vehicle in Hell's Horses toumans across the Inner Sphere holdings.</p>
@@ -169,4 +159,13 @@ JUMP_JET:N/A
 COMMUNICATIONS:Series XII ComSys
 TARGETING:Build IX TTS
 </systemModels>
+
+<source>
+TR:3075
+</source>
+
+<tonnage>
+45.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3075/SM Tank Destroyer SM3.blk
+++ b/data/mekfiles/vehicles/3075/SM Tank Destroyer SM3.blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -108,7 +108,6 @@ CLGaussRifle
 </Left Equipment>
 
 <Rear Equipment>
-CLCASE
 </Rear Equipment>
 
 <Turret Equipment>
@@ -118,29 +117,13 @@ CLLightMG
 CLLightMG
 </Turret Equipment>
 
-
-
-
-
-
-
-
-<source>
-TR:3075
-</source>
-
-<tonnage>
-50.0
-</tonnage>
-
-# Fluff Date: 2026-03-11 21:02:11
-<overview>
-<p>The SM Tank Destroyer emerged from Clan Nova Cat's efforts to adapt to Inner Sphere combined-arms warfare after the Clan's integration into the Draconis Combine in 3060. Finding their advanced manufacturing capacity insufficient for traditional BattleMech-focused operations, the Nova Cats partnered with Luthien Armor Works to develop a fast, affordable strike vehicle to supplement their diminished touman. The resulting SM1 is a fifty-ton hovertank defined by its unusual paired ferro-glass bubble cockpits, which earned the vehicle the nickname "Suicide Machine" among early crews who found the exposed design unsettling. Despite this initial reluctance, the SM1's speed and firepower quickly proved their worth in Nova Cat formations during the Jihad. Subsequent variants refined the base design, and production eventually shifted entirely to Combine control following the destruction of the Irece facility. The SM Tank Destroyer family has since spread to both the Draconis Combine military and the broader mercenary market, cementing its place as one of the more successful combined-arms designs of the post-Jihad era.</p>
-</overview>
-
 <capabilities>
 <p>The SM1's primary offensive weapon is a nose-fixed Type 10 Ultra Autocannon/20, one of the most powerful autocannons available. The fixed mounting sacrifices turret flexibility for structural simplicity, requiring the crew to orient the entire vehicle toward its target. Six tons of ammunition support sustained engagements, and the UAC/20's double-fire capability allows the SM1 to deliver devastating bursts at close range. A small turret mounts four Series 2C Light Machine Guns for anti-infantry coverage the main gun cannot address.</p><p>The vehicle's real tactical asset is its 165-rated fusion powerplant, which drives the hover chassis to 129 km/h. This speed lets SM1 crews exploit flanks, disengage from unfavorable engagements, and keep pace with other fast combined-arms elements. Seven and a half tons of Advanced Compound Beta armor provides meaningful protection for a vehicle of its size. The dual cockpit design is fully redundant, and each module can eject independently, giving crews a survival option rarely seen in conventional combat vehicles. The primary limitation beyond the fixed main gun is the Light Machine Gun turret's limited effectiveness in close urban terrain, where the hover chassis also loses some of its speed advantage on confined ground.</p>
 </capabilities>
+
+<overview>
+<p>The SM Tank Destroyer emerged from Clan Nova Cat's efforts to adapt to Inner Sphere combined-arms warfare after the Clan's integration into the Draconis Combine in 3060. Finding their advanced manufacturing capacity insufficient for traditional BattleMech-focused operations, the Nova Cats partnered with Luthien Armor Works to develop a fast, affordable strike vehicle to supplement their diminished touman. The resulting SM1 is a fifty-ton hovertank defined by its unusual paired ferro-glass bubble cockpits, which earned the vehicle the nickname "Suicide Machine" among early crews who found the exposed design unsettling. Despite this initial reluctance, the SM1's speed and firepower quickly proved their worth in Nova Cat formations during the Jihad. Subsequent variants refined the base design, and production eventually shifted entirely to Combine control following the destruction of the Irece facility. The SM Tank Destroyer family has since spread to both the Draconis Combine military and the broader mercenary market, cementing its place as one of the more successful combined-arms designs of the post-Jihad era.</p>
+</overview>
 
 <deployment>
 <p>The SM3 entered service in 3074, trading the SM1's autocannon for a Gauss rifle and Medium Pulse Laser combination. This shift prioritizes standoff engagement capability and accuracy over the SM1's close-range shock power, making the SM3 better suited to formations that engage at longer ranges or require more precise fire. The Gauss rifle's thirty-two rounds and pooled light machine gun ammunition support extended operations. The SM3 was produced at the Irece facility and later at Hyner, continuing through the ilClan era.</p>
@@ -173,4 +156,13 @@ ARMOR:Advanced Compound Beta
 COMMUNICATIONS:Unit 2J2 "Basher"
 TARGETING:Able-Seven Sensor Suite
 </systemModels>
+
+<source>
+TR:3075
+</source>
+
+<tonnage>
+50.0
+</tonnage>
+
 

--- a/data/mekfiles/vehicles/3145/Clans/Aesir Medium AA Vehicle (HAG).blk
+++ b/data/mekfiles/vehicles/3145/Clans/Aesir Medium AA Vehicle (HAG).blk
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.00-nightly-2026-05-01 on 2026-05-02
 <UnitType>
 Tank
 </UnitType>
@@ -112,25 +112,15 @@ Hyper-Assault Gauss Rifle/40 Ammo
 
 <Turret Equipment>
 CLHAG40
-CLCASE
 </Turret Equipment>
-
-<source>
-TR:3145:C
-</source>
-
-<tonnage>
-55.0
-</tonnage>
-
-# Fluff Date: 2026-03-01 12:28:32
-<overview>
-<p>Clan Wolf developed the Aesir medium anti-aircraft vehicle in the mid 3090s to address a growing need for dedicated air defense assets across their Inner Sphere occupation zone. Designed to bolster second-line garrison forces against airborne raiding threats, the Aesir serves as a slow but dependable mobile gun emplacement, typically deployed in full Stars to protect critical fixed installations. With the vehicle entering production at both Gienah Automotive and the W-7 Facilities on Weingarten, Clan Wolf ensured sufficient volume to distribute the platform across their garrison clusters. The design's straightforward construction and ammunition efficiency make it well suited to the defensive posture demanded of occupation zone units, where engagements are more likely to involve deterring fast-moving attackers than pursuing them.</p>
-</overview>
 
 <capabilities>
 <p>Too slow to participate in offensive operations or respond to rapidly developing threats, the Aesir instead excels as a static or semi-mobile air defense platform. A quartet of turret-mounted Type Sierra LB 2-X Autocannons provides long-range flak coverage capable of saturating a wide portion of airspace, with cluster munitions offering particular effectiveness against fast-moving aerospace targets. Two tons of ammunition supply adequate endurance for extended engagements without requiring frequent resupply.</p><p>Protection is substantial for a vehicle of its weight class, with nine and a half tons of Forging OTR20d ferro-fibrous armor supplemented by CASE to contain ammunition explosions and an Armored Motive System to protect the wheeled drive train from crippling mobility kills. The Omni 145 fusion engine provides only modest speed at fifty-four kilometers per hour, reinforcing the Aesir's role as a positional defender rather than a mobile combatant. The TRTTS Mark V AirTracker targeting and tracking system, though aging by current standards, remains effective at acquiring and tracking airborne contacts ranging from VTOLs to DropShips. A Build 1685 Tacticom communications suite rounds out the electronics package.</p>
 </capabilities>
+
+<overview>
+<p>Clan Wolf developed the Aesir medium anti-aircraft vehicle in the mid 3090s to address a growing need for dedicated air defense assets across their Inner Sphere occupation zone. Designed to bolster second-line garrison forces against airborne raiding threats, the Aesir serves as a slow but dependable mobile gun emplacement, typically deployed in full Stars to protect critical fixed installations. With the vehicle entering production at both Gienah Automotive and the W-7 Facilities on Weingarten, Clan Wolf ensured sufficient volume to distribute the platform across their garrison clusters. The design's straightforward construction and ammunition efficiency make it well suited to the defensive posture demanded of occupation zone units, where engagements are more likely to involve deterring fast-moving attackers than pursuing them.</p>
+</overview>
 
 <deployment>
 <p>The HAG variant was developed by Clan Hell's Horses following their absorption of Weingarten and the W-7 Facilities that had previously manufactured the base model under Clan Wolf ownership. Replacing the four LB 2-X Autocannons with a single HAG/40, this configuration trades the saturating flak coverage of the original for concentrated firepower better suited to operations in smaller detachments or individual vehicle deployments. Six tons of ammunition feed the larger weapon, but the increased consumption rate makes the HAG variant less suited to the extended engagements for which the base model was designed.</p>
@@ -163,4 +153,13 @@ ARMOR:OTR20d
 COMMUNICATIONS:Build 1685
 TARGETING:Mark V AirTracker
 </systemModels>
+
+<source>
+TR:3145:C
+</source>
+
+<tonnage>
+55.0
+</tonnage>
+
 


### PR DESCRIPTION
Several Clan vehicles were failing to validate because of CASE mounted in non-body locations.  These changes remove CASE entirely from the blk file as Clan vehicles are automatically given weight/slot free CASE. 

Any additional changes are from editing in a newer version of MML.

Closes #317. 