### PR TITLE
Fix FRR worlds incorrectly tagged as FR (Fixes #320)

### DIFF
--- a/data/universe/factions/AA.yml
+++ b/data/universe/factions/AA.yml
@@ -17,6 +17,7 @@
 
 key: AA
 name: Augustine Alliance
+# sucsCodes: []  # no SUCS equivalent
 capital: Augustine
 yearsActive:
   - start: 3139

--- a/data/universe/factions/AA.yml
+++ b/data/universe/factions/AA.yml
@@ -17,7 +17,7 @@
 
 key: AA
 name: Augustine Alliance
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Augustine
 yearsActive:
   - start: 3139

--- a/data/universe/factions/AB.yml
+++ b/data/universe/factions/AB.yml
@@ -17,6 +17,8 @@
 
 key: AB
 name: Azami Brotherhood
+# sucsCodes:
+#   - AB
 capital: Algedi
 yearsActive:
   - start: 2450

--- a/data/universe/factions/AB.yml
+++ b/data/universe/factions/AB.yml
@@ -17,8 +17,8 @@
 
 key: AB
 name: Azami Brotherhood
-# sucsCodes:
-#   - AB
+sucsCodes:
+  - AB
 capital: Algedi
 yearsActive:
   - start: 2450

--- a/data/universe/factions/ABN.yml
+++ b/data/universe/factions/ABN.yml
@@ -17,6 +17,8 @@
 
 key: ABN
 name: Abandoned
+# sucsCodes:
+#   - A
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/ABN.yml
+++ b/data/universe/factions/ABN.yml
@@ -17,8 +17,8 @@
 
 key: ABN
 name: Abandoned
-# sucsCodes:
-#   - A
+sucsCodes:
+  - A
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/AC.yml
+++ b/data/universe/factions/AC.yml
@@ -17,6 +17,8 @@
 
 key: AC
 name: Azami Caliphate
+# sucsCodes:
+#   - AC
 capital: Algedi
 successor: DC
 tags:

--- a/data/universe/factions/AC.yml
+++ b/data/universe/factions/AC.yml
@@ -17,8 +17,8 @@
 
 key: AC
 name: Azami Caliphate
-# sucsCodes:
-#   - AC
+sucsCodes:
+  - AC
 capital: Algedi
 successor: DC
 tags:

--- a/data/universe/factions/ACPS.yml
+++ b/data/universe/factions/ACPS.yml
@@ -17,6 +17,7 @@
 
 key: ACPS
 name: Asian Co-Prosperity Sphere
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: WA
 tags:

--- a/data/universe/factions/ACPS.yml
+++ b/data/universe/factions/ACPS.yml
@@ -17,7 +17,7 @@
 
 key: ACPS
 name: Asian Co-Prosperity Sphere
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: WA
 tags:

--- a/data/universe/factions/AE.yml
+++ b/data/universe/factions/AE.yml
@@ -17,6 +17,8 @@
 
 key: AE
 name: Amaris Empire
+# sucsCodes:
+#   - AE
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/AE.yml
+++ b/data/universe/factions/AE.yml
@@ -17,8 +17,8 @@
 
 key: AE
 name: Amaris Empire
-# sucsCodes:
-#   - AE
+sucsCodes:
+  - AE
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/AG.yml
+++ b/data/universe/factions/AG.yml
@@ -17,6 +17,8 @@
 
 key: AG
 name: Alliance of Galedon
+# sucsCodes:
+#   - AG
 capital: Galedon
 successor: DC
 tags:

--- a/data/universe/factions/AG.yml
+++ b/data/universe/factions/AG.yml
@@ -17,8 +17,8 @@
 
 key: AG
 name: Alliance of Galedon
-# sucsCodes:
-#   - AG
+sucsCodes:
+  - AG
 capital: Galedon
 successor: DC
 tags:

--- a/data/universe/factions/AML.yml
+++ b/data/universe/factions/AML.yml
@@ -17,6 +17,8 @@
 
 key: AML
 name: Alyina Mercantile League
+# sucsCodes:
+#   - AML
 capital: Alyina
 yearsActive:
   - start: 3151

--- a/data/universe/factions/AML.yml
+++ b/data/universe/factions/AML.yml
@@ -17,8 +17,8 @@
 
 key: AML
 name: Alyina Mercantile League
-# sucsCodes:
-#   - AML
+sucsCodes:
+  - AML
 capital: Alyina
 yearsActive:
   - start: 3151

--- a/data/universe/factions/ARC.yml
+++ b/data/universe/factions/ARC.yml
@@ -17,6 +17,8 @@
 
 key: ARC
 name: Aurigan Coalition
+# sucsCodes:
+#   - AuC
 nameChanges:
   3022: Arano Restoration
   3026: Aurigan Coalition

--- a/data/universe/factions/ARC.yml
+++ b/data/universe/factions/ARC.yml
@@ -17,8 +17,8 @@
 
 key: ARC
 name: Aurigan Coalition
-# sucsCodes:
-#   - AuC
+sucsCodes:
+  - AuC
 nameChanges:
   3022: Arano Restoration
   3026: Aurigan Coalition

--- a/data/universe/factions/ARD.yml
+++ b/data/universe/factions/ARD.yml
@@ -17,6 +17,8 @@
 
 key: ARD
 name: Aurigan Directorate
+# sucsCodes:
+#   - AuD
 capital: Coromodir
 yearsActive:
   - start: 3022

--- a/data/universe/factions/ARD.yml
+++ b/data/universe/factions/ARD.yml
@@ -17,8 +17,8 @@
 
 key: ARD
 name: Aurigan Directorate
-# sucsCodes:
-#   - AuD
+sucsCodes:
+  - AuD
 capital: Coromodir
 yearsActive:
   - start: 3022

--- a/data/universe/factions/ARDC.yml
+++ b/data/universe/factions/ARDC.yml
@@ -17,6 +17,7 @@
 
 key: ARDC
 name: Arc-Royal Defense Cordon
+# sucsCodes: []  # no SUCS equivalent
 capital: Arc-Royal
 yearsActive:
   - start: 3058

--- a/data/universe/factions/ARDC.yml
+++ b/data/universe/factions/ARDC.yml
@@ -17,7 +17,7 @@
 
 key: ARDC
 name: Arc-Royal Defense Cordon
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Arc-Royal
 yearsActive:
   - start: 3058

--- a/data/universe/factions/ARL.yml
+++ b/data/universe/factions/ARL.yml
@@ -17,6 +17,8 @@
 
 key: ARL
 name: Arc-Royal Liberty Coalition
+# sucsCodes:
+#   - ALC
 capital: Arc-Royal
 yearsActive:
   - start: 3151

--- a/data/universe/factions/ARL.yml
+++ b/data/universe/factions/ARL.yml
@@ -17,8 +17,8 @@
 
 key: ARL
 name: Arc-Royal Liberty Coalition
-# sucsCodes:
-#   - ALC
+sucsCodes:
+  - ALC
 capital: Arc-Royal
 yearsActive:
   - start: 3151

--- a/data/universe/factions/AXP.yml
+++ b/data/universe/factions/AXP.yml
@@ -17,6 +17,8 @@
 
 key: AXP
 name: Axumite Providence
+# sucsCodes:
+#   - AP
 capital: Thala
 tags:
   - DEEP_PERIPHERY

--- a/data/universe/factions/AXP.yml
+++ b/data/universe/factions/AXP.yml
@@ -17,8 +17,8 @@
 
 key: AXP
 name: Axumite Providence
-# sucsCodes:
-#   - AP
+sucsCodes:
+  - AP
 capital: Thala
 tags:
   - DEEP_PERIPHERY

--- a/data/universe/factions/Alf.yml
+++ b/data/universe/factions/Alf.yml
@@ -17,6 +17,7 @@
 
 key: Alf
 name: Alfirk
+# sucsCodes: []  # no SUCS equivalent
 capital: Alfirk
 tags:
   - MINOR

--- a/data/universe/factions/Alf.yml
+++ b/data/universe/factions/Alf.yml
@@ -17,7 +17,7 @@
 
 key: Alf
 name: Alfirk
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Alfirk
 tags:
   - MINOR

--- a/data/universe/factions/BAN.yml
+++ b/data/universe/factions/BAN.yml
@@ -17,6 +17,7 @@
 
 key: BAN
 name: Bandit Caste
+# sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 2830
 tags:

--- a/data/universe/factions/BAN.yml
+++ b/data/universe/factions/BAN.yml
@@ -17,7 +17,7 @@
 
 key: BAN
 name: Bandit Caste
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 2830
 tags:

--- a/data/universe/factions/BC.yml
+++ b/data/universe/factions/BC.yml
@@ -17,6 +17,7 @@
 
 key: BC
 name: Buena Collective
+# sucsCodes: []  # no SUCS equivalent
 capital: Buena
 tags:
   - MINOR

--- a/data/universe/factions/BC.yml
+++ b/data/universe/factions/BC.yml
@@ -17,7 +17,7 @@
 
 key: BC
 name: Buena Collective
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Buena
 tags:
   - MINOR

--- a/data/universe/factions/BH.yml
+++ b/data/universe/factions/BH.yml
@@ -17,6 +17,7 @@
 
 key: BH
 name: Butte Hold
+# sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 3018
     end: 3028

--- a/data/universe/factions/BH.yml
+++ b/data/universe/factions/BH.yml
@@ -17,7 +17,7 @@
 
 key: BH
 name: Butte Hold
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 3018
     end: 3028

--- a/data/universe/factions/BLORD.yml
+++ b/data/universe/factions/BLORD.yml
@@ -17,6 +17,7 @@
 
 key: BLORD
 name: Blessed Order
+# sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 3128
     end: 3141

--- a/data/universe/factions/BLORD.yml
+++ b/data/universe/factions/BLORD.yml
@@ -17,7 +17,7 @@
 
 key: BLORD
 name: Blessed Order
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 3128
     end: 3141

--- a/data/universe/factions/BoS.yml
+++ b/data/universe/factions/BoS.yml
@@ -17,6 +17,7 @@
 
 key: BoS
 name: Barony of Strang
+# sucsCodes: []  # no SUCS equivalent
 capital: Von Strang's World
 yearsActive:
   - start: 2779

--- a/data/universe/factions/BoS.yml
+++ b/data/universe/factions/BoS.yml
@@ -17,7 +17,7 @@
 
 key: BoS
 name: Barony of Strang
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Von Strang's World
 yearsActive:
   - start: 2779

--- a/data/universe/factions/CB.yml
+++ b/data/universe/factions/CB.yml
@@ -17,6 +17,8 @@
 
 key: CB
 name: Clan Burrock
+# sucsCodes:
+#   - CBR
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CB.yml
+++ b/data/universe/factions/CB.yml
@@ -17,8 +17,8 @@
 
 key: CB
 name: Clan Burrock
-# sucsCodes:
-#   - CBR
+sucsCodes:
+  - CBR
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CBS.yml
+++ b/data/universe/factions/CBS.yml
@@ -17,6 +17,8 @@
 
 key: CBS
 name: Clan Blood Spirit
+# sucsCodes:
+#   - CBS
 capital: York (Clan)
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CBS.yml
+++ b/data/universe/factions/CBS.yml
@@ -17,8 +17,8 @@
 
 key: CBS
 name: Clan Blood Spirit
-# sucsCodes:
-#   - CBS
+sucsCodes:
+  - CBS
 capital: York (Clan)
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CC.yml
+++ b/data/universe/factions/CC.yml
@@ -17,6 +17,8 @@
 
 key: CC
 name: Capellan Confederation
+# sucsCodes:
+#   - CC
 capital: Sian
 yearsActive:
   - start: 2367

--- a/data/universe/factions/CC.yml
+++ b/data/universe/factions/CC.yml
@@ -17,8 +17,8 @@
 
 key: CC
 name: Capellan Confederation
-# sucsCodes:
-#   - CC
+sucsCodes:
+  - CC
 capital: Sian
 yearsActive:
   - start: 2367

--- a/data/universe/factions/CCC.yml
+++ b/data/universe/factions/CCC.yml
@@ -17,6 +17,8 @@
 
 key: CCC
 name: Clan Cloud Cobra
+# sucsCodes:
+#   - CCC
 capital: Homer
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CCC.yml
+++ b/data/universe/factions/CCC.yml
@@ -17,8 +17,8 @@
 
 key: CCC
 name: Clan Cloud Cobra
-# sucsCodes:
-#   - CCC
+sucsCodes:
+  - CCC
 capital: Homer
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CCO.yml
+++ b/data/universe/factions/CCO.yml
@@ -17,6 +17,8 @@
 
 key: CCO
 name: Clan Coyote
+# sucsCodes:
+#   - CCY
 capital: Babylon
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CCO.yml
+++ b/data/universe/factions/CCO.yml
@@ -17,8 +17,8 @@
 
 key: CCO
 name: Clan Coyote
-# sucsCodes:
-#   - CCY
+sucsCodes:
+  - CCY
 capital: Babylon
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CCom.yml
+++ b/data/universe/factions/CCom.yml
@@ -17,6 +17,8 @@
 
 key: CCom
 name: Capellan Commonality
+# sucsCodes:
+#   - CCom
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/CCom.yml
+++ b/data/universe/factions/CCom.yml
@@ -17,8 +17,8 @@
 
 key: CCom
 name: Capellan Commonality
-# sucsCodes:
-#   - CCom
+sucsCodes:
+  - CCom
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/CCon.yml
+++ b/data/universe/factions/CCon.yml
@@ -17,6 +17,7 @@
 
 key: CCon
 name: Coreward Confederacy
+# sucsCodes: []  # no SUCS equivalent
 nameChanges:
   2371: Autocracy of New Virginia
   2400: Virginian Union

--- a/data/universe/factions/CCon.yml
+++ b/data/universe/factions/CCon.yml
@@ -17,7 +17,7 @@
 
 key: CCon
 name: Coreward Confederacy
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 nameChanges:
   2371: Autocracy of New Virginia
   2400: Virginian Union

--- a/data/universe/factions/CDP.yml
+++ b/data/universe/factions/CDP.yml
@@ -17,6 +17,8 @@
 
 key: CDP
 name: Calderon Protectorate
+# sucsCodes:
+#   - CDP
 capital: Erod's Escape
 yearsActive:
   - start: 3066

--- a/data/universe/factions/CDP.yml
+++ b/data/universe/factions/CDP.yml
@@ -17,8 +17,8 @@
 
 key: CDP
 name: Calderon Protectorate
-# sucsCodes:
-#   - CDP
+sucsCodes:
+  - CDP
 capital: Erod's Escape
 yearsActive:
   - start: 3066

--- a/data/universe/factions/CDS.yml
+++ b/data/universe/factions/CDS.yml
@@ -17,6 +17,9 @@
 
 key: CDS
 name: Clan Sea Fox
+# sucsCodes:
+#   - CDS
+#   - CSF
 nameChanges:
   2984: Clan Diamond Shark
   3100: Clan Sea Fox

--- a/data/universe/factions/CDS.yml
+++ b/data/universe/factions/CDS.yml
@@ -17,9 +17,9 @@
 
 key: CDS
 name: Clan Sea Fox
-# sucsCodes:
-#   - CDS
-#   - CSF
+sucsCodes:
+  - CDS
+  - CSF
 nameChanges:
   2984: Clan Diamond Shark
   3100: Clan Sea Fox

--- a/data/universe/factions/CEI.yml
+++ b/data/universe/factions/CEI.yml
@@ -17,6 +17,8 @@
 
 key: CEI
 name: Escorpión Imperio
+# sucsCodes:
+#   - EI
 nameChanges:
   3141: Scorpion Empire
 capital: Granada

--- a/data/universe/factions/CEI.yml
+++ b/data/universe/factions/CEI.yml
@@ -17,8 +17,8 @@
 
 key: CEI
 name: Escorpión Imperio
-# sucsCodes:
-#   - EI
+sucsCodes:
+  - EI
 nameChanges:
   3141: Scorpion Empire
 capital: Granada

--- a/data/universe/factions/CFM.yml
+++ b/data/universe/factions/CFM.yml
@@ -17,6 +17,8 @@
 
 key: CFM
 name: Clan Fire Mandrill
+# sucsCodes:
+#   - CFM
 capital: Shadow
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CFM.yml
+++ b/data/universe/factions/CFM.yml
@@ -17,8 +17,8 @@
 
 key: CFM
 name: Clan Fire Mandrill
-# sucsCodes:
-#   - CFM
+sucsCodes:
+  - CFM
 capital: Shadow
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CGB.yml
+++ b/data/universe/factions/CGB.yml
@@ -17,6 +17,9 @@
 
 key: CGB
 name: Clan Ghost Bear
+# sucsCodes:
+#   - CGB
+#   - GBD
 nameChanges:
   3060: Ghost Bear Dominion
 capital: Arcadia (Clan)

--- a/data/universe/factions/CGB.yml
+++ b/data/universe/factions/CGB.yml
@@ -17,9 +17,9 @@
 
 key: CGB
 name: Clan Ghost Bear
-# sucsCodes:
-#   - CGB
-#   - GBD
+sucsCodes:
+  - CGB
+  - GBD
 nameChanges:
   3060: Ghost Bear Dominion
 capital: Arcadia (Clan)

--- a/data/universe/factions/CGS.yml
+++ b/data/universe/factions/CGS.yml
@@ -17,6 +17,8 @@
 
 key: CGS
 name: Clan Goliath Scorpion
+# sucsCodes:
+#   - CGS
 nameChanges:
   3080: Escorpión Imperio
 capital: Roche

--- a/data/universe/factions/CGS.yml
+++ b/data/universe/factions/CGS.yml
@@ -17,8 +17,8 @@
 
 key: CGS
 name: Clan Goliath Scorpion
-# sucsCodes:
-#   - CGS
+sucsCodes:
+  - CGS
 nameChanges:
   3080: Escorpión Imperio
 capital: Roche

--- a/data/universe/factions/CH.yml
+++ b/data/universe/factions/CH.yml
@@ -17,6 +17,8 @@
 
 key: CH
 name: Capellan Hegemony
+# sucsCodes:
+#   - CH
 capital: Terra
 successor: CCom
 tags:

--- a/data/universe/factions/CH.yml
+++ b/data/universe/factions/CH.yml
@@ -17,8 +17,8 @@
 
 key: CH
 name: Capellan Hegemony
-# sucsCodes:
-#   - CH
+sucsCodes:
+  - CH
 capital: Terra
 successor: CCom
 tags:

--- a/data/universe/factions/CHH.yml
+++ b/data/universe/factions/CHH.yml
@@ -17,6 +17,8 @@
 
 key: CHH
 name: Clan Hell's Horses
+# sucsCodes:
+#   - CHH
 capital: Niles (Clan)
 capitalChanges:
   3074: Csesztreg

--- a/data/universe/factions/CHH.yml
+++ b/data/universe/factions/CHH.yml
@@ -17,8 +17,8 @@
 
 key: CHH
 name: Clan Hell's Horses
-# sucsCodes:
-#   - CHH
+sucsCodes:
+  - CHH
 capital: Niles (Clan)
 capitalChanges:
   3074: Csesztreg

--- a/data/universe/factions/CI.yml
+++ b/data/universe/factions/CI.yml
@@ -17,6 +17,8 @@
 
 key: CI
 name: Chainelane Isles
+# sucsCodes:
+#   - CI
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/CI.yml
+++ b/data/universe/factions/CI.yml
@@ -17,8 +17,8 @@
 
 key: CI
 name: Chainelane Isles
-# sucsCodes:
-#   - CI
+sucsCodes:
+  - CI
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/CIH.yml
+++ b/data/universe/factions/CIH.yml
@@ -17,6 +17,8 @@
 
 key: CIH
 name: Clan Ice Hellion
+# sucsCodes:
+#   - CIH
 capital: Hector
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CIH.yml
+++ b/data/universe/factions/CIH.yml
@@ -17,8 +17,8 @@
 
 key: CIH
 name: Clan Ice Hellion
-# sucsCodes:
-#   - CIH
+sucsCodes:
+  - CIH
 capital: Hector
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CIR.yml
+++ b/data/universe/factions/CIR.yml
@@ -17,6 +17,8 @@
 
 key: CIR
 name: Circinus Federation
+# sucsCodes:
+#   - CF
 capital: Circinus
 yearsActive:
   - start: 2785

--- a/data/universe/factions/CIR.yml
+++ b/data/universe/factions/CIR.yml
@@ -17,8 +17,8 @@
 
 key: CIR
 name: Circinus Federation
-# sucsCodes:
-#   - CF
+sucsCodes:
+  - CF
 capital: Circinus
 yearsActive:
   - start: 2785

--- a/data/universe/factions/CJF.yml
+++ b/data/universe/factions/CJF.yml
@@ -17,6 +17,8 @@
 
 key: CJF
 name: Clan Jade Falcon
+# sucsCodes:
+#   - CJF
 capital: Ironhold
 capitalChanges:
   3052: Sudeten

--- a/data/universe/factions/CJF.yml
+++ b/data/universe/factions/CJF.yml
@@ -17,8 +17,8 @@
 
 key: CJF
 name: Clan Jade Falcon
-# sucsCodes:
-#   - CJF
+sucsCodes:
+  - CJF
 capital: Ironhold
 capitalChanges:
   3052: Sudeten

--- a/data/universe/factions/CLAN.yml
+++ b/data/universe/factions/CLAN.yml
@@ -17,6 +17,8 @@
 
 key: CLAN
 name: All Clans
+# sucsCodes:
+#   - C
 capital: Strana Mechty
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CLAN.yml
+++ b/data/universe/factions/CLAN.yml
@@ -17,8 +17,8 @@
 
 key: CLAN
 name: All Clans
-# sucsCodes:
-#   - C
+sucsCodes:
+  - C
 capital: Strana Mechty
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CM.yml
+++ b/data/universe/factions/CM.yml
@@ -17,6 +17,7 @@
 
 key: CM
 name: Chaos March
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 yearsActive:
   - start: 3057

--- a/data/universe/factions/CM.yml
+++ b/data/universe/factions/CM.yml
@@ -17,7 +17,7 @@
 
 key: CM
 name: Chaos March
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 yearsActive:
   - start: 3057

--- a/data/universe/factions/CMG.yml
+++ b/data/universe/factions/CMG.yml
@@ -17,6 +17,8 @@
 
 key: CMG
 name: Clan Mongoose
+# sucsCodes:
+#   - CMN
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CMG.yml
+++ b/data/universe/factions/CMG.yml
@@ -17,8 +17,8 @@
 
 key: CMG
 name: Clan Mongoose
-# sucsCodes:
-#   - CMN
+sucsCodes:
+  - CMN
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CNC.yml
+++ b/data/universe/factions/CNC.yml
@@ -17,6 +17,8 @@
 
 key: CNC
 name: Clan Nova Cat
+# sucsCodes:
+#   - CNC
 capital: Barcella
 capitalChanges:
   3057: Irece

--- a/data/universe/factions/CNC.yml
+++ b/data/universe/factions/CNC.yml
@@ -17,8 +17,8 @@
 
 key: CNC
 name: Clan Nova Cat
-# sucsCodes:
-#   - CNC
+sucsCodes:
+  - CNC
 capital: Barcella
 capitalChanges:
   3057: Irece

--- a/data/universe/factions/CP.yml
+++ b/data/universe/factions/CP.yml
@@ -17,6 +17,7 @@
 
 key: CP
 name: Clan Protectorate
+# sucsCodes: []  # no SUCS equivalent
 capital: Marik
 yearsActive:
   - start: 3138

--- a/data/universe/factions/CP.yml
+++ b/data/universe/factions/CP.yml
@@ -17,7 +17,7 @@
 
 key: CP
 name: Clan Protectorate
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Marik
 yearsActive:
   - start: 3138

--- a/data/universe/factions/CRep.yml
+++ b/data/universe/factions/CRep.yml
@@ -17,6 +17,7 @@
 
 key: CRep
 name: Capellan Republic
+# sucsCodes: []  # no SUCS equivalent
 capital: Capella
 successor: CH
 tags:

--- a/data/universe/factions/CRep.yml
+++ b/data/universe/factions/CRep.yml
@@ -17,7 +17,7 @@
 
 key: CRep
 name: Capellan Republic
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Capella
 successor: CH
 tags:

--- a/data/universe/factions/CS.yml
+++ b/data/universe/factions/CS.yml
@@ -17,6 +17,8 @@
 
 key: CS
 name: SLCOMNET
+# sucsCodes:
+#   - CS
 nameChanges:
   2788: ComStar
 capital: Terra

--- a/data/universe/factions/CS.yml
+++ b/data/universe/factions/CS.yml
@@ -17,8 +17,8 @@
 
 key: CS
 name: SLCOMNET
-# sucsCodes:
-#   - CS
+sucsCodes:
+  - CS
 nameChanges:
   2788: ComStar
 capital: Terra

--- a/data/universe/factions/CSA.yml
+++ b/data/universe/factions/CSA.yml
@@ -17,6 +17,8 @@
 
 key: CSA
 name: Clan Star Adder
+# sucsCodes:
+#   - CSA
 capital: Sheridan (Clan)
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CSA.yml
+++ b/data/universe/factions/CSA.yml
@@ -17,8 +17,8 @@
 
 key: CSA
 name: Clan Star Adder
-# sucsCodes:
-#   - CSA
+sucsCodes:
+  - CSA
 capital: Sheridan (Clan)
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CSJ.yml
+++ b/data/universe/factions/CSJ.yml
@@ -17,6 +17,8 @@
 
 key: CSJ
 name: Clan Smoke Jaguar
+# sucsCodes:
+#   - CSJ
 capital: Huntress
 capitalChanges:
   3052: Luzerne

--- a/data/universe/factions/CSJ.yml
+++ b/data/universe/factions/CSJ.yml
@@ -17,8 +17,8 @@
 
 key: CSJ
 name: Clan Smoke Jaguar
-# sucsCodes:
-#   - CSJ
+sucsCodes:
+  - CSJ
 capital: Huntress
 capitalChanges:
   3052: Luzerne

--- a/data/universe/factions/CSL.yml
+++ b/data/universe/factions/CSL.yml
@@ -17,6 +17,8 @@
 
 key: CSL
 name: Clan Stone Lion
+# sucsCodes:
+#   - CSL
 capital: Tokasha
 yearsActive:
   - start: 3075

--- a/data/universe/factions/CSL.yml
+++ b/data/universe/factions/CSL.yml
@@ -17,8 +17,8 @@
 
 key: CSL
 name: Clan Stone Lion
-# sucsCodes:
-#   - CSL
+sucsCodes:
+  - CSL
 capital: Tokasha
 yearsActive:
   - start: 3075

--- a/data/universe/factions/CSR.yml
+++ b/data/universe/factions/CSR.yml
@@ -17,6 +17,8 @@
 
 key: CSR
 name: Clan Snow Raven
+# sucsCodes:
+#   - CSR
 nameChanges:
   3083: Raven Alliance
 capital: Circe

--- a/data/universe/factions/CSR.yml
+++ b/data/universe/factions/CSR.yml
@@ -17,8 +17,8 @@
 
 key: CSR
 name: Clan Snow Raven
-# sucsCodes:
-#   - CSR
+sucsCodes:
+  - CSR
 nameChanges:
   3083: Raven Alliance
 capital: Circe

--- a/data/universe/factions/CSV.yml
+++ b/data/universe/factions/CSV.yml
@@ -17,6 +17,8 @@
 
 key: CSV
 name: Clan Steel Viper
+# sucsCodes:
+#   - CSV
 capital: Homer
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CSV.yml
+++ b/data/universe/factions/CSV.yml
@@ -17,8 +17,8 @@
 
 key: CSV
 name: Clan Steel Viper
-# sucsCodes:
-#   - CSV
+sucsCodes:
+  - CSV
 capital: Homer
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CTL.yml
+++ b/data/universe/factions/CTL.yml
@@ -17,6 +17,8 @@
 
 key: CTL
 name: Chesterton Trade Federation
+# sucsCodes:
+#   - CTF
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/CTL.yml
+++ b/data/universe/factions/CTL.yml
@@ -17,8 +17,8 @@
 
 key: CTL
 name: Chesterton Trade Federation
-# sucsCodes:
-#   - CTF
+sucsCodes:
+  - CTF
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/CW.yml
+++ b/data/universe/factions/CW.yml
@@ -17,6 +17,8 @@
 
 key: CW
 name: Clan Wolf
+# sucsCodes:
+#   - CWF
 capital: Tranquil
 capitalChanges:
   3052: Tamar

--- a/data/universe/factions/CW.yml
+++ b/data/universe/factions/CW.yml
@@ -17,8 +17,8 @@
 
 key: CW
 name: Clan Wolf
-# sucsCodes:
-#   - CWF
+sucsCodes:
+  - CWF
 capital: Tranquil
 capitalChanges:
   3052: Tamar

--- a/data/universe/factions/CWE.yml
+++ b/data/universe/factions/CWE.yml
@@ -17,6 +17,8 @@
 
 key: CWE
 name: Wolf Empire
+# sucsCodes:
+#   - WE
 capital: Gienah
 yearsActive:
   - start: 3143

--- a/data/universe/factions/CWE.yml
+++ b/data/universe/factions/CWE.yml
@@ -17,8 +17,8 @@
 
 key: CWE
 name: Wolf Empire
-# sucsCodes:
-#   - WE
+sucsCodes:
+  - WE
 capital: Gienah
 yearsActive:
   - start: 3143

--- a/data/universe/factions/CWI.yml
+++ b/data/universe/factions/CWI.yml
@@ -17,6 +17,8 @@
 
 key: CWI
 name: Clan Widowmaker
+# sucsCodes:
+#   - CWM
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CWI.yml
+++ b/data/universe/factions/CWI.yml
@@ -17,8 +17,8 @@
 
 key: CWI
 name: Clan Widowmaker
-# sucsCodes:
-#   - CWM
+sucsCodes:
+  - CWM
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CWIE.yml
+++ b/data/universe/factions/CWIE.yml
@@ -17,6 +17,8 @@
 
 key: CWIE
 name: Clan Wolf-in-Exile
+# sucsCodes:
+#   - CWX
 capital: Arc-Royal
 yearsActive:
   - start: 3057

--- a/data/universe/factions/CWIE.yml
+++ b/data/universe/factions/CWIE.yml
@@ -17,8 +17,8 @@
 
 key: CWIE
 name: Clan Wolf-in-Exile
-# sucsCodes:
-#   - CWX
+sucsCodes:
+  - CWX
 capital: Arc-Royal
 yearsActive:
   - start: 3057

--- a/data/universe/factions/CWOV.yml
+++ b/data/universe/factions/CWOV.yml
@@ -17,6 +17,8 @@
 
 key: CWOV
 name: Clan Wolverine
+# sucsCodes:
+#   - CWV
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/CWOV.yml
+++ b/data/universe/factions/CWOV.yml
@@ -17,8 +17,8 @@
 
 key: CWOV
 name: Clan Wolverine
-# sucsCodes:
-#   - CWV
+sucsCodes:
+  - CWV
 capital: Terra
 yearsActive:
   - start: 2807

--- a/data/universe/factions/ChP.yml
+++ b/data/universe/factions/ChP.yml
@@ -17,6 +17,7 @@
 
 key: ChP
 name: Chisholm Protectorate
+# sucsCodes: []  # no SUCS equivalent
 capital: Elgin (Chisholm 2878-)
 successor: CC
 tags:

--- a/data/universe/factions/ChP.yml
+++ b/data/universe/factions/ChP.yml
@@ -17,7 +17,7 @@
 
 key: ChP
 name: Chisholm Protectorate
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Elgin (Chisholm 2878-)
 successor: CC
 tags:

--- a/data/universe/factions/CvW.yml
+++ b/data/universe/factions/CvW.yml
@@ -17,6 +17,7 @@
 
 key: CvW
 name: Covenant Worlds
+# sucsCodes: []  # no SUCS equivalent
 capital: Bordon
 yearsActive:
   - start: 3137

--- a/data/universe/factions/CvW.yml
+++ b/data/universe/factions/CvW.yml
@@ -17,7 +17,7 @@
 
 key: CvW
 name: Covenant Worlds
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Bordon
 yearsActive:
   - start: 3137

--- a/data/universe/factions/DA.yml
+++ b/data/universe/factions/DA.yml
@@ -17,6 +17,8 @@
 
 key: DA
 name: Duchy of Andurien
+# sucsCodes:
+#   - DA
 capital: Andurien
 yearsActive:
   - start: 3030

--- a/data/universe/factions/DA.yml
+++ b/data/universe/factions/DA.yml
@@ -17,8 +17,8 @@
 
 key: DA
 name: Duchy of Andurien
-# sucsCodes:
-#   - DA
+sucsCodes:
+  - DA
 capital: Andurien
 yearsActive:
   - start: 3030

--- a/data/universe/factions/DC.yml
+++ b/data/universe/factions/DC.yml
@@ -17,6 +17,8 @@
 
 key: DC
 name: Draconis Combine
+# sucsCodes:
+#   - DC
 capital: New Samarkand
 capitalChanges:
   2619: Luthien

--- a/data/universe/factions/DC.yml
+++ b/data/universe/factions/DC.yml
@@ -17,8 +17,8 @@
 
 key: DC
 name: Draconis Combine
-# sucsCodes:
-#   - DC
+sucsCodes:
+  - DC
 capital: New Samarkand
 capitalChanges:
   2619: Luthien

--- a/data/universe/factions/DGM.yml
+++ b/data/universe/factions/DGM.yml
@@ -17,6 +17,8 @@
 
 key: DGM
 name: Duchy of Graham-Marik
+# sucsCodes:
+#   - DGM
 capital: Loyalty
 yearsActive:
   - start: 3079

--- a/data/universe/factions/DGM.yml
+++ b/data/universe/factions/DGM.yml
@@ -17,8 +17,8 @@
 
 key: DGM
 name: Duchy of Graham-Marik
-# sucsCodes:
-#   - DGM
+sucsCodes:
+  - DGM
 capital: Loyalty
 yearsActive:
   - start: 3079

--- a/data/universe/factions/DIS.yml
+++ b/data/universe/factions/DIS.yml
@@ -17,6 +17,8 @@
 
 key: DIS
 name: Disputed
+# sucsCodes:
+#   - D
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/DIS.yml
+++ b/data/universe/factions/DIS.yml
@@ -17,8 +17,8 @@
 
 key: DIS
 name: Disputed
-# sucsCodes:
-#   - D
+sucsCodes:
+  - D
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/DO.yml
+++ b/data/universe/factions/DO.yml
@@ -17,6 +17,8 @@
 
 key: DO
 name: Duchy of Oriente
+# sucsCodes:
+#   - DO
 capital: Oriente
 yearsActive:
   - start: 3079

--- a/data/universe/factions/DO.yml
+++ b/data/universe/factions/DO.yml
@@ -17,8 +17,8 @@
 
 key: DO
 name: Duchy of Oriente
-# sucsCodes:
-#   - DO
+sucsCodes:
+  - DO
 capital: Oriente
 yearsActive:
   - start: 3079

--- a/data/universe/factions/DP.yml
+++ b/data/universe/factions/DP.yml
@@ -17,6 +17,7 @@
 
 key: DP
 name: Deep Periphery
+# sucsCodes: []  # no SUCS equivalent
 tags:
   - DEEP_PERIPHERY
   - PERIPHERY

--- a/data/universe/factions/DP.yml
+++ b/data/universe/factions/DP.yml
@@ -17,7 +17,7 @@
 
 key: DP
 name: Deep Periphery
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 tags:
   - DEEP_PERIPHERY
   - PERIPHERY

--- a/data/universe/factions/DS.yml
+++ b/data/universe/factions/DS.yml
@@ -17,6 +17,8 @@
 
 key: DS
 name: Duchy of Small
+# sucsCodes:
+#   - DS
 capital: Small World
 yearsActive:
   - start: 3057

--- a/data/universe/factions/DS.yml
+++ b/data/universe/factions/DS.yml
@@ -17,8 +17,8 @@
 
 key: DS
 name: Duchy of Small
-# sucsCodes:
-#   - DS
+sucsCodes:
+  - DS
 capital: Small World
 yearsActive:
   - start: 3057

--- a/data/universe/factions/DT.yml
+++ b/data/universe/factions/DT.yml
@@ -17,6 +17,8 @@
 
 key: DT
 name: Duchy of Tamarind
+# sucsCodes:
+#   - DT
 capital: Tamarind
 successor: DTA
 tags:

--- a/data/universe/factions/DT.yml
+++ b/data/universe/factions/DT.yml
@@ -17,8 +17,8 @@
 
 key: DT
 name: Duchy of Tamarind
-# sucsCodes:
-#   - DT
+sucsCodes:
+  - DT
 capital: Tamarind
 successor: DTA
 tags:

--- a/data/universe/factions/DTA.yml
+++ b/data/universe/factions/DTA.yml
@@ -17,6 +17,8 @@
 
 key: DTA
 name: Duchy of Tamarind-Abbey
+# sucsCodes:
+#   - DTA
 capital: Tamarind
 yearsActive:
   - start: 3071

--- a/data/universe/factions/DTA.yml
+++ b/data/universe/factions/DTA.yml
@@ -17,8 +17,8 @@
 
 key: DTA
 name: Duchy of Tamarind-Abbey
-# sucsCodes:
-#   - DTA
+sucsCodes:
+  - DTA
 capital: Tamarind
 yearsActive:
   - start: 3071

--- a/data/universe/factions/DoL.yml
+++ b/data/universe/factions/DoL.yml
@@ -17,6 +17,8 @@
 
 key: DoL
 name: Duchy of Liao
+# sucsCodes:
+#   - DL
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/DoL.yml
+++ b/data/universe/factions/DoL.yml
@@ -17,8 +17,8 @@
 
 key: DoL
 name: Duchy of Liao
-# sucsCodes:
-#   - DL
+sucsCodes:
+  - DL
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/DoO.yml
+++ b/data/universe/factions/DoO.yml
@@ -17,6 +17,8 @@
 
 key: DoO
 name: Duchy of Orloff
+# sucsCodes:
+#   - DoO
 capital: Vanra
 yearsActive:
   - start: 3079

--- a/data/universe/factions/DoO.yml
+++ b/data/universe/factions/DoO.yml
@@ -17,8 +17,8 @@
 
 key: DoO
 name: Duchy of Orloff
-# sucsCodes:
-#   - DoO
+sucsCodes:
+  - DoO
 capital: Vanra
 yearsActive:
   - start: 3079

--- a/data/universe/factions/EF.yml
+++ b/data/universe/factions/EF.yml
@@ -17,6 +17,8 @@
 
 key: EF
 name: Elysian Fields
+# sucsCodes:
+#   - EF
 capital: Nyserta
 yearsActive:
   - end: 3049

--- a/data/universe/factions/EF.yml
+++ b/data/universe/factions/EF.yml
@@ -17,8 +17,8 @@
 
 key: EF
 name: Elysian Fields
-# sucsCodes:
-#   - EF
+sucsCodes:
+  - EF
 capital: Nyserta
 yearsActive:
   - end: 3049

--- a/data/universe/factions/FC.yml
+++ b/data/universe/factions/FC.yml
@@ -17,6 +17,9 @@
 
 key: FC
 name: Federated Commonwealth
+# sucsCodes:
+#   - FCF
+#   - FCL
 nameChanges:
   3028: Federated Commonwealth Alliance
   3055: Federated Commonwealth

--- a/data/universe/factions/FC.yml
+++ b/data/universe/factions/FC.yml
@@ -17,9 +17,9 @@
 
 key: FC
 name: Federated Commonwealth
-# sucsCodes:
-#   - FCF
-#   - FCL
+sucsCodes:
+  - FCF
+  - FCL
 nameChanges:
   3028: Federated Commonwealth Alliance
   3055: Federated Commonwealth

--- a/data/universe/factions/FCo.yml
+++ b/data/universe/factions/FCo.yml
@@ -17,6 +17,8 @@
 
 key: FCo
 name: Ferris Collective
+# sucsCodes:
+#   - FCo
 capital: Ferris
 tags:
   - MINOR

--- a/data/universe/factions/FCo.yml
+++ b/data/universe/factions/FCo.yml
@@ -17,8 +17,8 @@
 
 key: FCo
 name: Ferris Collective
-# sucsCodes:
-#   - FCo
+sucsCodes:
+  - FCo
 capital: Ferris
 tags:
   - MINOR

--- a/data/universe/factions/FFR.yml
+++ b/data/universe/factions/FFR.yml
@@ -17,6 +17,8 @@
 
 key: FFR
 name: Finmark Free Republic
+# sucsCodes:
+#   - FFR
 capital: Finmark
 tags:
   - MINOR

--- a/data/universe/factions/FFR.yml
+++ b/data/universe/factions/FFR.yml
@@ -17,8 +17,8 @@
 
 key: FFR
 name: Finmark Free Republic
-# sucsCodes:
-#   - FFR
+sucsCodes:
+  - FFR
 capital: Finmark
 tags:
   - MINOR

--- a/data/universe/factions/FID.yml
+++ b/data/universe/factions/FID.yml
@@ -17,6 +17,7 @@
 
 key: FID
 name: Fidelis
+# sucsCodes: []  # no SUCS equivalent
 capital: Wayside
 capitalChanges:
   3078: New Earth

--- a/data/universe/factions/FID.yml
+++ b/data/universe/factions/FID.yml
@@ -17,7 +17,7 @@
 
 key: FID
 name: Fidelis
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Wayside
 capitalChanges:
   3078: New Earth

--- a/data/universe/factions/FOR.yml
+++ b/data/universe/factions/FOR.yml
@@ -17,6 +17,7 @@
 
 key: FOR
 name: Fiefdom of Randis
+# sucsCodes: []  # no SUCS equivalent
 capital: Randis IV (Hope IV 2988-)
 yearsActive:
   - start: 2988

--- a/data/universe/factions/FOR.yml
+++ b/data/universe/factions/FOR.yml
@@ -17,7 +17,7 @@
 
 key: FOR
 name: Fiefdom of Randis
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Randis IV (Hope IV 2988-)
 yearsActive:
   - start: 2988

--- a/data/universe/factions/FR.yml
+++ b/data/universe/factions/FR.yml
@@ -17,6 +17,8 @@
 
 key: FR
 name: Fronc Reaches
+# sucsCodes:
+#   - FrR
 capital: Fronc
 yearsActive:
   - start: 3066

--- a/data/universe/factions/FR.yml
+++ b/data/universe/factions/FR.yml
@@ -17,8 +17,8 @@
 
 key: FR
 name: Fronc Reaches
-# sucsCodes:
-#   - FrR
+sucsCodes:
+  - FrR
 capital: Fronc
 yearsActive:
   - start: 3066

--- a/data/universe/factions/FRR.yml
+++ b/data/universe/factions/FRR.yml
@@ -17,6 +17,8 @@
 
 key: FRR
 name: Free Rasalhague Republic
+# sucsCodes:
+#   - FR
 capital: Rasalhague
 capitalChanges:
   3052: Orestes

--- a/data/universe/factions/FRR.yml
+++ b/data/universe/factions/FRR.yml
@@ -17,8 +17,8 @@
 
 key: FRR
 name: Free Rasalhague Republic
-# sucsCodes:
-#   - FR
+sucsCodes:
+  - FR
 capital: Rasalhague
 capitalChanges:
   3052: Orestes

--- a/data/universe/factions/FS.yml
+++ b/data/universe/factions/FS.yml
@@ -17,6 +17,8 @@
 
 key: FS
 name: Federated Suns
+# sucsCodes:
+#   - FS
 capital: New Avalon
 yearsActive:
   - start: 2317

--- a/data/universe/factions/FS.yml
+++ b/data/universe/factions/FS.yml
@@ -17,8 +17,8 @@
 
 key: FS
 name: Federated Suns
-# sucsCodes:
-#   - FS
+sucsCodes:
+  - FS
 capital: New Avalon
 yearsActive:
   - start: 2317

--- a/data/universe/factions/FVC.yml
+++ b/data/universe/factions/FVC.yml
@@ -17,6 +17,8 @@
 
 key: FVC
 name: Filtvelt Coalition
+# sucsCodes:
+#   - FvC
 capital: Filtvelt
 yearsActive:
   - start: 3072

--- a/data/universe/factions/FVC.yml
+++ b/data/universe/factions/FVC.yml
@@ -17,8 +17,8 @@
 
 key: FVC
 name: Filtvelt Coalition
-# sucsCodes:
-#   - FvC
+sucsCodes:
+  - FvC
 capital: Filtvelt
 yearsActive:
   - start: 3072

--- a/data/universe/factions/FWL.yml
+++ b/data/universe/factions/FWL.yml
@@ -17,6 +17,8 @@
 
 key: FWL
 name: Free Worlds League
+# sucsCodes:
+#   - FWL
 capital: Atreus (FWL)
 yearsActive:
   - start: 2271

--- a/data/universe/factions/FWL.yml
+++ b/data/universe/factions/FWL.yml
@@ -17,8 +17,8 @@
 
 key: FWL
 name: Free Worlds League
-# sucsCodes:
-#   - FWL
+sucsCodes:
+  - FWL
 capital: Atreus (FWL)
 yearsActive:
   - start: 2271

--- a/data/universe/factions/FWLR.yml
+++ b/data/universe/factions/FWLR.yml
@@ -17,6 +17,7 @@
 
 key: FWLR
 name: Free Worlds League Rebels
+# sucsCodes: []  # no SUCS equivalent
 capital: New Delos
 tags:
   - IS

--- a/data/universe/factions/FWLR.yml
+++ b/data/universe/factions/FWLR.yml
@@ -17,7 +17,7 @@
 
 key: FWLR
 name: Free Worlds League Rebels
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: New Delos
 tags:
   - IS

--- a/data/universe/factions/FoO.yml
+++ b/data/universe/factions/FoO.yml
@@ -17,6 +17,8 @@
 
 key: FoO
 name: Federation of Oriente
+# sucsCodes:
+#   - FO
 capital: Oriente
 successor: FWL
 tags:

--- a/data/universe/factions/FoO.yml
+++ b/data/universe/factions/FoO.yml
@@ -17,8 +17,8 @@
 
 key: FoO
 name: Federation of Oriente
-# sucsCodes:
-#   - FO
+sucsCodes:
+  - FO
 capital: Oriente
 successor: FWL
 tags:

--- a/data/universe/factions/FoS.yml
+++ b/data/universe/factions/FoS.yml
@@ -17,6 +17,8 @@
 
 key: FoS
 name: Federation of Skye
+# sucsCodes:
+#   - FoS
 capital: Terra
 successor: LA
 tags:

--- a/data/universe/factions/FoS.yml
+++ b/data/universe/factions/FoS.yml
@@ -17,8 +17,8 @@
 
 key: FoS
 name: Federation of Skye
-# sucsCodes:
-#   - FoS
+sucsCodes:
+  - FoS
 capital: Terra
 successor: LA
 tags:

--- a/data/universe/factions/GDL.yml
+++ b/data/universe/factions/GDL.yml
@@ -17,6 +17,7 @@
 
 key: GDL
 name: Galatean Defense League
+# sucsCodes: []  # no SUCS equivalent
 capital: Galatea
 tags:
   - MINOR

--- a/data/universe/factions/GDL.yml
+++ b/data/universe/factions/GDL.yml
@@ -17,7 +17,7 @@
 
 key: GDL
 name: Galatean Defense League
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Galatea
 tags:
   - MINOR

--- a/data/universe/factions/GL.yml
+++ b/data/universe/factions/GL.yml
@@ -17,6 +17,8 @@
 
 key: GL
 name: Galatean League
+# sucsCodes:
+#   - GL
 capital: Galatea
 yearsActive:
   - start: 3144

--- a/data/universe/factions/GL.yml
+++ b/data/universe/factions/GL.yml
@@ -17,8 +17,8 @@
 
 key: GL
 name: Galatean League
-# sucsCodes:
-#   - GL
+sucsCodes:
+  - GL
 capital: Galatea
 yearsActive:
   - start: 3144

--- a/data/universe/factions/GV.yml
+++ b/data/universe/factions/GV.yml
@@ -17,6 +17,8 @@
 
 key: GV
 name: Greater Valkyrate
+# sucsCodes:
+#   - GV
 capital: Gotterdammerung
 yearsActive:
   - start: 3028

--- a/data/universe/factions/GV.yml
+++ b/data/universe/factions/GV.yml
@@ -17,8 +17,8 @@
 
 key: GV
 name: Greater Valkyrate
-# sucsCodes:
-#   - GV
+sucsCodes:
+  - GV
 capital: Gotterdammerung
 yearsActive:
   - start: 3028

--- a/data/universe/factions/HL.yml
+++ b/data/universe/factions/HL.yml
@@ -17,6 +17,8 @@
 
 key: HL
 name: Hanseatic League
+# sucsCodes:
+#   - HL
 capital: Bremen (HL)
 yearsActive:
   - start: 2891

--- a/data/universe/factions/HL.yml
+++ b/data/universe/factions/HL.yml
@@ -17,8 +17,8 @@
 
 key: HL
 name: Hanseatic League
-# sucsCodes:
-#   - HL
+sucsCodes:
+  - HL
 capital: Bremen (HL)
 yearsActive:
   - start: 2891

--- a/data/universe/factions/IC.yml
+++ b/data/universe/factions/IC.yml
@@ -17,6 +17,8 @@
 
 key: IC
 name: Ingersoll Concordium
+# sucsCodes:
+#   - IC
 capital: Ingersoll
 yearsActive:
   - start: 2200

--- a/data/universe/factions/IC.yml
+++ b/data/universe/factions/IC.yml
@@ -17,8 +17,8 @@
 
 key: IC
 name: Ingersoll Concordium
-# sucsCodes:
-#   - IC
+sucsCodes:
+  - IC
 capital: Ingersoll
 yearsActive:
   - start: 2200

--- a/data/universe/factions/IE.yml
+++ b/data/universe/factions/IE.yml
@@ -17,6 +17,8 @@
 
 key: IE
 name: Interstellar Expeditions
+# sucsCodes:
+#   - IE
 capital: Terra
 tags:
   - PERIPHERY

--- a/data/universe/factions/IE.yml
+++ b/data/universe/factions/IE.yml
@@ -17,8 +17,8 @@
 
 key: IE
 name: Interstellar Expeditions
-# sucsCodes:
-#   - IE
+sucsCodes:
+  - IE
 capital: Terra
 tags:
   - PERIPHERY

--- a/data/universe/factions/IND.yml
+++ b/data/universe/factions/IND.yml
@@ -17,6 +17,8 @@
 
 key: IND
 name: Independent
+# sucsCodes:
+#   - I
 capital: Terra
 tags:
   - IS

--- a/data/universe/factions/IND.yml
+++ b/data/universe/factions/IND.yml
@@ -17,8 +17,8 @@
 
 key: IND
 name: Independent
-# sucsCodes:
-#   - I
+sucsCodes:
+  - I
 capital: Terra
 tags:
   - IS

--- a/data/universe/factions/IP.yml
+++ b/data/universe/factions/IP.yml
@@ -17,6 +17,8 @@
 
 key: IP
 name: Illyrian Palatinate
+# sucsCodes:
+#   - IP
 capital: Illyria
 yearsActive:
   - start: 2350

--- a/data/universe/factions/IP.yml
+++ b/data/universe/factions/IP.yml
@@ -17,8 +17,8 @@
 
 key: IP
 name: Illyrian Palatinate
-# sucsCodes:
-#   - IP
+sucsCodes:
+  - IP
 capital: Illyria
 yearsActive:
   - start: 2350

--- a/data/universe/factions/IS.yml
+++ b/data/universe/factions/IS.yml
@@ -17,6 +17,7 @@
 
 key: IS
 name: Inner Sphere - General
+# sucsCodes: []  # no SUCS equivalent
 tags:
   - IS
   - AGGREGATE

--- a/data/universe/factions/IS.yml
+++ b/data/universe/factions/IS.yml
@@ -17,7 +17,7 @@
 
 key: IS
 name: Inner Sphere - General
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 tags:
   - IS
   - AGGREGATE

--- a/data/universe/factions/IoS.yml
+++ b/data/universe/factions/IoS.yml
@@ -17,6 +17,8 @@
 
 key: IoS
 name: Isle of Skye
+# sucsCodes:
+#   - IoS
 capital: Skye
 yearsActive:
   - start: 3151

--- a/data/universe/factions/IoS.yml
+++ b/data/universe/factions/IoS.yml
@@ -17,8 +17,8 @@
 
 key: IoS
 name: Isle of Skye
-# sucsCodes:
-#   - IoS
+sucsCodes:
+  - IoS
 capital: Skye
 yearsActive:
   - start: 3151

--- a/data/universe/factions/JF.yml
+++ b/data/universe/factions/JF.yml
@@ -17,6 +17,8 @@
 
 key: JF
 name: JàrnFòlk
+# sucsCodes:
+#   - JF
 capital: Trondheim (JF)
 tags:
   - MINOR

--- a/data/universe/factions/JF.yml
+++ b/data/universe/factions/JF.yml
@@ -17,8 +17,8 @@
 
 key: JF
 name: JàrnFòlk
-# sucsCodes:
-#   - JF
+sucsCodes:
+  - JF
 capital: Trondheim (JF)
 tags:
   - MINOR

--- a/data/universe/factions/KE.yml
+++ b/data/universe/factions/KE.yml
@@ -17,6 +17,7 @@
 
 key: KE
 name: Khwarazm Empire
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/KE.yml
+++ b/data/universe/factions/KE.yml
@@ -17,7 +17,7 @@
 
 key: KE
 name: Khwarazm Empire
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/KP.yml
+++ b/data/universe/factions/KP.yml
@@ -17,6 +17,8 @@
 
 key: KP
 name: Kittery Prefecture
+# sucsCodes:
+#   - KP
 capital: Terra
 yearsActive:
   - start: 3072

--- a/data/universe/factions/KP.yml
+++ b/data/universe/factions/KP.yml
@@ -17,8 +17,8 @@
 
 key: KP
 name: Kittery Prefecture
-# sucsCodes:
-#   - KP
+sucsCodes:
+  - KP
 capital: Terra
 yearsActive:
   - start: 3072

--- a/data/universe/factions/LA.yml
+++ b/data/universe/factions/LA.yml
@@ -17,6 +17,9 @@
 
 key: LA
 name: Lyran Commonwealth
+# sucsCodes:
+#   - LA
+#   - LC
 nameChanges:
   3058: Lyran Alliance
   3085: Lyran Commonwealth

--- a/data/universe/factions/LA.yml
+++ b/data/universe/factions/LA.yml
@@ -17,9 +17,9 @@
 
 key: LA
 name: Lyran Commonwealth
-# sucsCodes:
-#   - LA
-#   - LC
+sucsCodes:
+  - LA
+  - LC
 nameChanges:
   3058: Lyran Alliance
   3085: Lyran Commonwealth

--- a/data/universe/factions/LL.yml
+++ b/data/universe/factions/LL.yml
@@ -17,6 +17,8 @@
 
 key: LL
 name: Lothian League
+# sucsCodes:
+#   - LL
 capital: Lothario
 yearsActive:
   - start: 2815

--- a/data/universe/factions/LL.yml
+++ b/data/universe/factions/LL.yml
@@ -17,8 +17,8 @@
 
 key: LL
 name: Lothian League
-# sucsCodes:
-#   - LL
+sucsCodes:
+  - LL
 capital: Lothario
 yearsActive:
   - start: 2815

--- a/data/universe/factions/LR.yml
+++ b/data/universe/factions/LR.yml
@@ -17,6 +17,8 @@
 
 key: LR
 name: Liao Republic
+# sucsCodes:
+#   - LR
 capital: Terra
 tags:
   - IS

--- a/data/universe/factions/LR.yml
+++ b/data/universe/factions/LR.yml
@@ -17,8 +17,8 @@
 
 key: LR
 name: Liao Republic
-# sucsCodes:
-#   - LR
+sucsCodes:
+  - LR
 capital: Terra
 tags:
   - IS

--- a/data/universe/factions/MA.yml
+++ b/data/universe/factions/MA.yml
@@ -17,6 +17,8 @@
 
 key: MA
 name: Mosiro Archipelago
+# sucsCodes:
+#   - MA
 capital: Mosiro
 successor: DA
 tags:

--- a/data/universe/factions/MA.yml
+++ b/data/universe/factions/MA.yml
@@ -17,8 +17,8 @@
 
 key: MA
 name: Mosiro Archipelago
-# sucsCodes:
-#   - MA
+sucsCodes:
+  - MA
 capital: Mosiro
 successor: DA
 tags:

--- a/data/universe/factions/MBA.yml
+++ b/data/universe/factions/MBA.yml
@@ -17,6 +17,7 @@
 
 key: MBA
 name: Mercenary Bonding Authority
+# sucsCodes: []  # no SUCS equivalent
 capital: Twycross
 yearsActive:
   - start: 3133

--- a/data/universe/factions/MBA.yml
+++ b/data/universe/factions/MBA.yml
@@ -17,7 +17,7 @@
 
 key: MBA
 name: Mercenary Bonding Authority
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Twycross
 yearsActive:
   - start: 3133

--- a/data/universe/factions/MC.yml
+++ b/data/universe/factions/MC.yml
@@ -17,6 +17,8 @@
 
 key: MC
 name: Malagrotta Cooperative
+# sucsCodes:
+#   - MC
 capital: Malagrotta
 yearsActive:
   - start: 3073

--- a/data/universe/factions/MC.yml
+++ b/data/universe/factions/MC.yml
@@ -17,8 +17,8 @@
 
 key: MC
 name: Malagrotta Cooperative
-# sucsCodes:
-#   - MC
+sucsCodes:
+  - MC
 capital: Malagrotta
 yearsActive:
   - start: 3073

--- a/data/universe/factions/MCM.yml
+++ b/data/universe/factions/MCM.yml
@@ -17,6 +17,8 @@
 
 key: MCM
 name: Marik Commonwealth
+# sucsCodes:
+#   - MCM
 capital: Marik
 yearsActive:
   - start: 3079

--- a/data/universe/factions/MCM.yml
+++ b/data/universe/factions/MCM.yml
@@ -17,8 +17,8 @@
 
 key: MCM
 name: Marik Commonwealth
-# sucsCodes:
-#   - MCM
+sucsCodes:
+  - MCM
 capital: Marik
 yearsActive:
   - start: 3079

--- a/data/universe/factions/ME.yml
+++ b/data/universe/factions/ME.yml
@@ -17,6 +17,8 @@
 
 key: ME
 name: Muskegon Coalition
+# sucsCodes:
+#   - MuC
 capital: Muskegon
 successor: FS
 tags:

--- a/data/universe/factions/ME.yml
+++ b/data/universe/factions/ME.yml
@@ -17,8 +17,8 @@
 
 key: ME
 name: Muskegon Coalition
-# sucsCodes:
-#   - MuC
+sucsCodes:
+  - MuC
 capital: Muskegon
 successor: FS
 tags:

--- a/data/universe/factions/MERC.yml
+++ b/data/universe/factions/MERC.yml
@@ -17,6 +17,7 @@
 
 key: MERC
 name: Mercenary
+# sucsCodes: []  # no SUCS equivalent
 capital: Solaris
 capitalChanges:
   2789: Galatea

--- a/data/universe/factions/MERC.yml
+++ b/data/universe/factions/MERC.yml
@@ -17,7 +17,7 @@
 
 key: MERC
 name: Mercenary
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Solaris
 capitalChanges:
   2789: Galatea

--- a/data/universe/factions/MG.yml
+++ b/data/universe/factions/MG.yml
@@ -17,6 +17,7 @@
 
 key: MG
 name: Mercenary Guild
+# sucsCodes: []  # no SUCS equivalent
 capital: Solaris
 yearsActive:
   - end: 2789

--- a/data/universe/factions/MG.yml
+++ b/data/universe/factions/MG.yml
@@ -17,7 +17,7 @@
 
 key: MG
 name: Mercenary Guild
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Solaris
 yearsActive:
   - end: 2789

--- a/data/universe/factions/MH.yml
+++ b/data/universe/factions/MH.yml
@@ -17,6 +17,8 @@
 
 key: MH
 name: Marian Hegemony
+# sucsCodes:
+#   - MH
 capital: Alphard (MH)
 yearsActive:
   - start: 2920

--- a/data/universe/factions/MH.yml
+++ b/data/universe/factions/MH.yml
@@ -17,8 +17,8 @@
 
 key: MH
 name: Marian Hegemony
-# sucsCodes:
-#   - MH
+sucsCodes:
+  - MH
 capital: Alphard (MH)
 yearsActive:
   - start: 2920

--- a/data/universe/factions/MM.yml
+++ b/data/universe/factions/MM.yml
@@ -17,6 +17,7 @@
 
 key: MM
 name: Mica Majority
+# sucsCodes: []  # no SUCS equivalent
 capital: Mica II
 yearsActive:
   - start: 2855

--- a/data/universe/factions/MM.yml
+++ b/data/universe/factions/MM.yml
@@ -17,7 +17,7 @@
 
 key: MM
 name: Mica Majority
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Mica II
 yearsActive:
   - start: 2855

--- a/data/universe/factions/MOC.yml
+++ b/data/universe/factions/MOC.yml
@@ -17,6 +17,8 @@
 
 key: MOC
 name: Magistracy of Canopus
+# sucsCodes:
+#   - MOC
 capital: Canopus IV
 yearsActive:
   - start: 2530

--- a/data/universe/factions/MOC.yml
+++ b/data/universe/factions/MOC.yml
@@ -17,8 +17,8 @@
 
 key: MOC
 name: Magistracy of Canopus
-# sucsCodes:
-#   - MOC
+sucsCodes:
+  - MOC
 capital: Canopus IV
 yearsActive:
   - start: 2530

--- a/data/universe/factions/MRB.yml
+++ b/data/universe/factions/MRB.yml
@@ -17,6 +17,7 @@
 
 key: MRB
 name: Mercenary Review Board
+# sucsCodes: []  # no SUCS equivalent
 capital: Galatea
 yearsActive:
   - start: 2789

--- a/data/universe/factions/MRB.yml
+++ b/data/universe/factions/MRB.yml
@@ -17,7 +17,7 @@
 
 key: MRB
 name: Mercenary Review Board
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Galatea
 yearsActive:
   - start: 2789

--- a/data/universe/factions/MRBC.yml
+++ b/data/universe/factions/MRBC.yml
@@ -17,6 +17,7 @@
 
 key: MRBC
 name: Mercenary Review and Bonding Commission
+# sucsCodes: []  # no SUCS equivalent
 capital: Outreach
 capitalChanges:
   3067: Galatea

--- a/data/universe/factions/MRBC.yml
+++ b/data/universe/factions/MRBC.yml
@@ -17,7 +17,7 @@
 
 key: MRBC
 name: Mercenary Review and Bonding Commission
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Outreach
 capitalChanges:
   3067: Galatea

--- a/data/universe/factions/MRep.yml
+++ b/data/universe/factions/MRep.yml
@@ -17,6 +17,8 @@
 
 key: MRep
 name: Marik Republic
+# sucsCodes:
+#   - MR
 capital: Marik
 successor: FWL
 tags:

--- a/data/universe/factions/MRep.yml
+++ b/data/universe/factions/MRep.yml
@@ -17,8 +17,8 @@
 
 key: MRep
 name: Marik Republic
-# sucsCodes:
-#   - MR
+sucsCodes:
+  - MR
 capital: Marik
 successor: FWL
 tags:

--- a/data/universe/factions/MSC.yml
+++ b/data/universe/factions/MSC.yml
@@ -17,6 +17,8 @@
 
 key: MSC
 name: Marik-Stewart Commonwealth
+# sucsCodes:
+#   - MSC
 capital: Marik
 yearsActive:
   - start: 3082

--- a/data/universe/factions/MSC.yml
+++ b/data/universe/factions/MSC.yml
@@ -17,8 +17,8 @@
 
 key: MSC
 name: Marik-Stewart Commonwealth
-# sucsCodes:
-#   - MSC
+sucsCodes:
+  - MSC
 capital: Marik
 yearsActive:
   - start: 3082

--- a/data/universe/factions/MV.yml
+++ b/data/universe/factions/MV.yml
@@ -17,6 +17,8 @@
 
 key: MV
 name: Morgraine's Valkyrate
+# sucsCodes:
+#   - MV
 capital: Gotterdammerung
 yearsActive:
   - start: 3021

--- a/data/universe/factions/MV.yml
+++ b/data/universe/factions/MV.yml
@@ -17,8 +17,8 @@
 
 key: MV
 name: Morgraine's Valkyrate
-# sucsCodes:
-#   - MV
+sucsCodes:
+  - MV
 capital: Gotterdammerung
 yearsActive:
   - start: 3021

--- a/data/universe/factions/MalC.yml
+++ b/data/universe/factions/MalC.yml
@@ -17,6 +17,8 @@
 
 key: MalC
 name: Malthus Confederation
+# sucsCodes:
+#   - MaC
 capital: Dustball
 tags:
   - MINOR

--- a/data/universe/factions/MalC.yml
+++ b/data/universe/factions/MalC.yml
@@ -17,8 +17,8 @@
 
 key: MalC
 name: Malthus Confederation
-# sucsCodes:
-#   - MaC
+sucsCodes:
+  - MaC
 capital: Dustball
 tags:
   - MINOR

--- a/data/universe/factions/MalCon.yml
+++ b/data/universe/factions/MalCon.yml
@@ -17,6 +17,8 @@
 
 key: MalCon
 name: Malthus Confederation
+# sucsCodes:
+#   - MaC
 yearsActive:
   - start: 3151
 tags:

--- a/data/universe/factions/MalCon.yml
+++ b/data/universe/factions/MalCon.yml
@@ -17,8 +17,8 @@
 
 key: MalCon
 name: Malthus Confederation
-# sucsCodes:
-#   - MaC
+sucsCodes:
+  - MaC
 yearsActive:
   - start: 3151
 tags:

--- a/data/universe/factions/Mara.yml
+++ b/data/universe/factions/Mara.yml
@@ -17,6 +17,8 @@
 
 key: Mara
 name: Marlette Association
+# sucsCodes:
+#   - MarA
 capital: Terra
 successor: FS
 tags:

--- a/data/universe/factions/Mara.yml
+++ b/data/universe/factions/Mara.yml
@@ -17,8 +17,8 @@
 
 key: Mara
 name: Marlette Association
-# sucsCodes:
-#   - MarA
+sucsCodes:
+  - MarA
 capital: Terra
 successor: FS
 tags:

--- a/data/universe/factions/MiC.yml
+++ b/data/universe/factions/MiC.yml
@@ -17,6 +17,7 @@
 
 key: MiC
 name: Milton Combine
+# sucsCodes: []  # no SUCS equivalent
 capital: Milton
 yearsActive:
   - start: 3137

--- a/data/universe/factions/MiC.yml
+++ b/data/universe/factions/MiC.yml
@@ -17,7 +17,7 @@
 
 key: MiC
 name: Milton Combine
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Milton
 yearsActive:
   - start: 3137

--- a/data/universe/factions/NC.yml
+++ b/data/universe/factions/NC.yml
@@ -17,6 +17,8 @@
 
 key: NC
 name: Nueva Castile
+# sucsCodes:
+#   - NC
 capital: Asturias
 yearsActive:
   - start: 2392

--- a/data/universe/factions/NC.yml
+++ b/data/universe/factions/NC.yml
@@ -17,8 +17,8 @@
 
 key: NC
 name: Nueva Castile
-# sucsCodes:
-#   - NC
+sucsCodes:
+  - NC
 capital: Asturias
 yearsActive:
   - start: 2392

--- a/data/universe/factions/NCR.yml
+++ b/data/universe/factions/NCR.yml
@@ -17,6 +17,8 @@
 
 key: NCR
 name: New Colony Region
+# sucsCodes:
+#   - NCR
 capital: Fronc
 yearsActive:
   - start: 3060

--- a/data/universe/factions/NCR.yml
+++ b/data/universe/factions/NCR.yml
@@ -17,8 +17,8 @@
 
 key: NCR
 name: New Colony Region
-# sucsCodes:
-#   - NCR
+sucsCodes:
+  - NCR
 capital: Fronc
 yearsActive:
   - start: 3060

--- a/data/universe/factions/NDC.yml
+++ b/data/universe/factions/NDC.yml
@@ -17,6 +17,8 @@
 
 key: NDC
 name: New Delphi Compact
+# sucsCodes:
+#   - NDC
 capital: New Delphi
 tags:
   - DEEP_PERIPHERY

--- a/data/universe/factions/NDC.yml
+++ b/data/universe/factions/NDC.yml
@@ -17,8 +17,8 @@
 
 key: NDC
 name: New Delphi Compact
-# sucsCodes:
-#   - NDC
+sucsCodes:
+  - NDC
 capital: New Delphi
 tags:
   - DEEP_PERIPHERY

--- a/data/universe/factions/NIOPS.yml
+++ b/data/universe/factions/NIOPS.yml
@@ -17,6 +17,7 @@
 
 key: NIOPS
 name: Niops Association
+# sucsCodes: []  # no SUCS equivalent
 capital: "Niops (Niops V, VI, VII)"
 yearsActive:
   - start: 2760

--- a/data/universe/factions/NIOPS.yml
+++ b/data/universe/factions/NIOPS.yml
@@ -17,7 +17,7 @@
 
 key: NIOPS
 name: Niops Association
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: "Niops (Niops V, VI, VII)"
 yearsActive:
   - start: 2760

--- a/data/universe/factions/NOC.yml
+++ b/data/universe/factions/NOC.yml
@@ -17,6 +17,8 @@
 
 key: NOC
 name: New Oberon Confederation
+# sucsCodes:
+#   - NOC
 capital: Oberon VI
 tags:
   - PERIPHERY

--- a/data/universe/factions/NOC.yml
+++ b/data/universe/factions/NOC.yml
@@ -17,8 +17,8 @@
 
 key: NOC
 name: New Oberon Confederation
-# sucsCodes:
-#   - NOC
+sucsCodes:
+  - NOC
 capital: Oberon VI
 tags:
   - PERIPHERY

--- a/data/universe/factions/NONE.yml
+++ b/data/universe/factions/NONE.yml
@@ -17,6 +17,7 @@
 
 key: NONE
 name: Unexplored
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/NONE.yml
+++ b/data/universe/factions/NONE.yml
@@ -17,7 +17,7 @@
 
 key: NONE
 name: Unexplored
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/OA.yml
+++ b/data/universe/factions/OA.yml
@@ -17,6 +17,8 @@
 
 key: OA
 name: Outworlds Alliance
+# sucsCodes:
+#   - OA
 nameChanges:
   3083: Raven Alliance
 capital: Alpheratz

--- a/data/universe/factions/OA.yml
+++ b/data/universe/factions/OA.yml
@@ -17,8 +17,8 @@
 
 key: OA
 name: Outworlds Alliance
-# sucsCodes:
-#   - OA
+sucsCodes:
+  - OA
 nameChanges:
   3083: Raven Alliance
 capital: Alpheratz

--- a/data/universe/factions/OC.yml
+++ b/data/universe/factions/OC.yml
@@ -17,6 +17,8 @@
 
 key: OC
 name: Oberon Confederation
+# sucsCodes:
+#   - OC
 capital: Oberon VI
 yearsActive:
   - start: 2775

--- a/data/universe/factions/OC.yml
+++ b/data/universe/factions/OC.yml
@@ -17,8 +17,8 @@
 
 key: OC
 name: Oberon Confederation
-# sucsCodes:
-#   - OC
+sucsCodes:
+  - OC
 capital: Oberon VI
 yearsActive:
   - start: 2775

--- a/data/universe/factions/OMA.yml
+++ b/data/universe/factions/OMA.yml
@@ -17,6 +17,8 @@
 
 key: OMA
 name: Ozawa Mercantile Association
+# sucsCodes:
+#   - OMA
 capital: Terra
 tags:
   - TRADER

--- a/data/universe/factions/OMA.yml
+++ b/data/universe/factions/OMA.yml
@@ -17,8 +17,8 @@
 
 key: OMA
 name: Ozawa Mercantile Association
-# sucsCodes:
-#   - OMA
+sucsCodes:
+  - OMA
 capital: Terra
 tags:
   - TRADER

--- a/data/universe/factions/OP.yml
+++ b/data/universe/factions/OP.yml
@@ -17,6 +17,8 @@
 
 key: OP
 name: Oriente Protectorate
+# sucsCodes:
+#   - OP
 capital: Oriente
 yearsActive:
   - start: 3086

--- a/data/universe/factions/OP.yml
+++ b/data/universe/factions/OP.yml
@@ -17,8 +17,8 @@
 
 key: OP
 name: Oriente Protectorate
-# sucsCodes:
-#   - OP
+sucsCodes:
+  - OP
 capital: Oriente
 yearsActive:
   - start: 3086

--- a/data/universe/factions/OZP.yml
+++ b/data/universe/factions/OZP.yml
@@ -17,6 +17,8 @@
 
 key: OZP
 name: Ohrensen-Zion Province
+# sucsCodes:
+#   - OZP
 capital: Ohrensen
 yearsActive:
   - start: 3078

--- a/data/universe/factions/OZP.yml
+++ b/data/universe/factions/OZP.yml
@@ -17,8 +17,8 @@
 
 key: OZP
 name: Ohrensen-Zion Province
-# sucsCodes:
-#   - OZP
+sucsCodes:
+  - OZP
 capital: Ohrensen
 yearsActive:
   - start: 3078

--- a/data/universe/factions/PC.yml
+++ b/data/universe/factions/PC.yml
@@ -17,6 +17,7 @@
 
 key: PC
 name: Protectorate Coalition
+# sucsCodes: []  # no SUCS equivalent
 capital: Rochelle
 yearsActive:
   - start: 3136

--- a/data/universe/factions/PC.yml
+++ b/data/universe/factions/PC.yml
@@ -17,7 +17,7 @@
 
 key: PC
 name: Protectorate Coalition
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Rochelle
 yearsActive:
   - start: 3136

--- a/data/universe/factions/PD.yml
+++ b/data/universe/factions/PD.yml
@@ -17,6 +17,8 @@
 
 key: PD
 name: Protectorate of Donegal
+# sucsCodes:
+#   - PD
 capital: Terra
 successor: LA
 tags:

--- a/data/universe/factions/PD.yml
+++ b/data/universe/factions/PD.yml
@@ -17,8 +17,8 @@
 
 key: PD
 name: Protectorate of Donegal
-# sucsCodes:
-#   - PD
+sucsCodes:
+  - PD
 capital: Terra
 successor: LA
 tags:

--- a/data/universe/factions/PG.yml
+++ b/data/universe/factions/PG.yml
@@ -17,6 +17,8 @@
 
 key: PG
 name: Principality of Gibson
+# sucsCodes:
+#   - PG
 capital: Gibson
 yearsActive:
   - start: 3079

--- a/data/universe/factions/PG.yml
+++ b/data/universe/factions/PG.yml
@@ -17,8 +17,8 @@
 
 key: PG
 name: Principality of Gibson
-# sucsCodes:
-#   - PG
+sucsCodes:
+  - PG
 capital: Gibson
 yearsActive:
   - start: 3079

--- a/data/universe/factions/PIR.yml
+++ b/data/universe/factions/PIR.yml
@@ -17,6 +17,7 @@
 
 key: PIR
 name: Pirate
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - PLAYABLE

--- a/data/universe/factions/PIR.yml
+++ b/data/universe/factions/PIR.yml
@@ -17,7 +17,7 @@
 
 key: PIR
 name: Pirate
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - PLAYABLE

--- a/data/universe/factions/PP.yml
+++ b/data/universe/factions/PP.yml
@@ -17,6 +17,7 @@
 
 key: PP
 name: Pentagon Powers
+# sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 2801
     end: 2822

--- a/data/universe/factions/PP.yml
+++ b/data/universe/factions/PP.yml
@@ -17,7 +17,7 @@
 
 key: PP
 name: Pentagon Powers
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 2801
     end: 2822

--- a/data/universe/factions/PR.yml
+++ b/data/universe/factions/PR.yml
@@ -17,6 +17,8 @@
 
 key: PR
 name: Principality of Regulus
+# sucsCodes:
+#   - PR
 capital: Regulus
 yearsActive:
   - start: 3079

--- a/data/universe/factions/PR.yml
+++ b/data/universe/factions/PR.yml
@@ -17,8 +17,8 @@
 
 key: PR
 name: Principality of Regulus
-# sucsCodes:
-#   - PR
+sucsCodes:
+  - PR
 capital: Regulus
 yearsActive:
   - start: 3079

--- a/data/universe/factions/PSI.yml
+++ b/data/universe/factions/PSI.yml
@@ -17,6 +17,7 @@
 
 key: PSI
 name: Piracy Success Index
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - PIRATE

--- a/data/universe/factions/PSI.yml
+++ b/data/universe/factions/PSI.yml
@@ -17,7 +17,7 @@
 
 key: PSI
 name: Piracy Success Index
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - PIRATE

--- a/data/universe/factions/Periphery.yml
+++ b/data/universe/factions/Periphery.yml
@@ -17,6 +17,7 @@
 
 key: Periphery
 name: Periphery
+# sucsCodes: []  # no SUCS equivalent
 tags:
   - PERIPHERY
   - AGGREGATE

--- a/data/universe/factions/Periphery.yml
+++ b/data/universe/factions/Periphery.yml
@@ -17,7 +17,7 @@
 
 key: Periphery
 name: Periphery
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 tags:
   - PERIPHERY
   - AGGREGATE

--- a/data/universe/factions/PoR.yml
+++ b/data/universe/factions/PoR.yml
@@ -17,6 +17,8 @@
 
 key: PoR
 name: Principality of Rasalhague
+# sucsCodes:
+#   - PoR
 capital: Rasalhague
 yearsActive:
   - start: 2260

--- a/data/universe/factions/PoR.yml
+++ b/data/universe/factions/PoR.yml
@@ -17,8 +17,8 @@
 
 key: PoR
 name: Principality of Rasalhague
-# sucsCodes:
-#   - PoR
+sucsCodes:
+  - PoR
 capital: Rasalhague
 yearsActive:
   - start: 2260

--- a/data/universe/factions/RA.yml
+++ b/data/universe/factions/RA.yml
@@ -17,6 +17,8 @@
 
 key: RA
 name: Raven Alliance
+# sucsCodes:
+#   - RA
 capital: Alpheratz
 yearsActive:
   - start: 3083

--- a/data/universe/factions/RA.yml
+++ b/data/universe/factions/RA.yml
@@ -17,8 +17,8 @@
 
 key: RA
 name: Raven Alliance
-# sucsCodes:
-#   - RA
+sucsCodes:
+  - RA
 capital: Alpheratz
 yearsActive:
   - start: 3083

--- a/data/universe/factions/RCM.yml
+++ b/data/universe/factions/RCM.yml
@@ -17,6 +17,8 @@
 
 key: RCM
 name: Rim Commonality
+# sucsCodes:
+#   - RCM
 capital: Lesnovo
 yearsActive:
   - start: 3075

--- a/data/universe/factions/RCM.yml
+++ b/data/universe/factions/RCM.yml
@@ -17,8 +17,8 @@
 
 key: RCM
 name: Rim Commonality
-# sucsCodes:
-#   - RCM
+sucsCodes:
+  - RCM
 capital: Lesnovo
 yearsActive:
   - start: 3075

--- a/data/universe/factions/RD.yml
+++ b/data/universe/factions/RD.yml
@@ -17,6 +17,8 @@
 
 key: RD
 name: Rasalhague Dominion
+# sucsCodes:
+#   - RD
 capital: Rasalhague
 yearsActive:
   - start: 3103

--- a/data/universe/factions/RD.yml
+++ b/data/universe/factions/RD.yml
@@ -17,8 +17,8 @@
 
 key: RD
 name: Rasalhague Dominion
-# sucsCodes:
-#   - RD
+sucsCodes:
+  - RD
 capital: Rasalhague
 yearsActive:
   - start: 3103

--- a/data/universe/factions/REB.yml
+++ b/data/universe/factions/REB.yml
@@ -17,6 +17,7 @@
 
 key: REB
 name: Rebels
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - REBEL

--- a/data/universe/factions/REB.yml
+++ b/data/universe/factions/REB.yml
@@ -17,7 +17,7 @@
 
 key: REB
 name: Rebels
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - REBEL

--- a/data/universe/factions/RF.yml
+++ b/data/universe/factions/RF.yml
@@ -17,6 +17,8 @@
 
 key: RF
 name: Regulan Fiefs
+# sucsCodes:
+#   - RF
 capital: Regulus
 yearsActive:
   - start: 3086

--- a/data/universe/factions/RF.yml
+++ b/data/universe/factions/RF.yml
@@ -17,8 +17,8 @@
 
 key: RF
 name: Regulan Fiefs
-# sucsCodes:
-#   - RF
+sucsCodes:
+  - RF
 capital: Regulus
 yearsActive:
   - start: 3086

--- a/data/universe/factions/RFS.yml
+++ b/data/universe/factions/RFS.yml
@@ -17,6 +17,8 @@
 
 key: RFS
 name: Regulan Free States
+# sucsCodes:
+#   - RFS
 capital: Regulus
 yearsActive:
   - start: 3079

--- a/data/universe/factions/RFS.yml
+++ b/data/universe/factions/RFS.yml
@@ -17,8 +17,8 @@
 
 key: RFS
 name: Regulan Free States
-# sucsCodes:
-#   - RFS
+sucsCodes:
+  - RFS
 capital: Regulus
 yearsActive:
   - start: 3079

--- a/data/universe/factions/RIM.yml
+++ b/data/universe/factions/RIM.yml
@@ -17,6 +17,8 @@
 
 key: RIM
 name: Rim Collection
+# sucsCodes:
+#   - RC
 capital: Gillfillan's Gold
 yearsActive:
   - start: 3048

--- a/data/universe/factions/RIM.yml
+++ b/data/universe/factions/RIM.yml
@@ -17,8 +17,8 @@
 
 key: RIM
 name: Rim Collection
-# sucsCodes:
-#   - RC
+sucsCodes:
+  - RC
 capital: Gillfillan's Gold
 yearsActive:
   - start: 3048

--- a/data/universe/factions/RON.yml
+++ b/data/universe/factions/RON.yml
@@ -17,6 +17,7 @@
 
 key: RON
 name: Ronin
+# sucsCodes: []  # no SUCS equivalent
 capital: Predlitz
 tags:
   - MINOR

--- a/data/universe/factions/RON.yml
+++ b/data/universe/factions/RON.yml
@@ -17,7 +17,7 @@
 
 key: RON
 name: Ronin
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Predlitz
 tags:
   - MINOR

--- a/data/universe/factions/ROS.yml
+++ b/data/universe/factions/ROS.yml
@@ -17,6 +17,8 @@
 
 key: ROS
 name: Republic of the Sphere
+# sucsCodes:
+#   - RS
 capital: Terra
 yearsActive:
   - start: 3081

--- a/data/universe/factions/ROS.yml
+++ b/data/universe/factions/ROS.yml
@@ -17,8 +17,8 @@
 
 key: ROS
 name: Republic of the Sphere
-# sucsCodes:
-#   - RS
+sucsCodes:
+  - RS
 capital: Terra
 yearsActive:
   - start: 3081

--- a/data/universe/factions/RP.yml
+++ b/data/universe/factions/RP.yml
@@ -17,6 +17,7 @@
 
 key: RP
 name: Regulan Principality
+# sucsCodes: []  # no SUCS equivalent
 capital: Regulus
 successor: FWL
 tags:

--- a/data/universe/factions/RP.yml
+++ b/data/universe/factions/RP.yml
@@ -17,7 +17,7 @@
 
 key: RP
 name: Regulan Principality
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Regulus
 successor: FWL
 tags:

--- a/data/universe/factions/RPG.yml
+++ b/data/universe/factions/RPG.yml
@@ -17,6 +17,7 @@
 
 key: RPG
 name: Rim Provisional Government
+# sucsCodes: []  # no SUCS equivalent
 capital: Apollo
 tags:
   - PERIPHERY

--- a/data/universe/factions/RPG.yml
+++ b/data/universe/factions/RPG.yml
@@ -17,7 +17,7 @@
 
 key: RPG
 name: Rim Provisional Government
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Apollo
 tags:
   - PERIPHERY

--- a/data/universe/factions/RR.yml
+++ b/data/universe/factions/RR.yml
@@ -17,6 +17,8 @@
 
 key: RR
 name: Republic Remnant
+# sucsCodes:
+#   - TR
 capital: Callison
 yearsActive:
   - start: 3135

--- a/data/universe/factions/RR.yml
+++ b/data/universe/factions/RR.yml
@@ -17,8 +17,8 @@
 
 key: RR
 name: Republic Remnant
-# sucsCodes:
-#   - TR
+sucsCodes:
+  - TR
 capital: Callison
 yearsActive:
   - start: 3135

--- a/data/universe/factions/RT.yml
+++ b/data/universe/factions/RT.yml
@@ -17,6 +17,8 @@
 
 key: RT
 name: Rim Territories
+# sucsCodes:
+#   - RT
 capital: Pain
 yearsActive:
   - start: 3087

--- a/data/universe/factions/RT.yml
+++ b/data/universe/factions/RT.yml
@@ -17,8 +17,8 @@
 
 key: RT
 name: Rim Territories
-# sucsCodes:
-#   - RT
+sucsCodes:
+  - RT
 capital: Pain
 yearsActive:
   - start: 3087

--- a/data/universe/factions/RTR.yml
+++ b/data/universe/factions/RTR.yml
@@ -17,6 +17,7 @@
 
 key: RTR
 name: Republic Territories
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - IS

--- a/data/universe/factions/RTR.yml
+++ b/data/universe/factions/RTR.yml
@@ -17,7 +17,7 @@
 
 key: RTR
 name: Republic Territories
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - IS

--- a/data/universe/factions/RU.yml
+++ b/data/universe/factions/RU.yml
@@ -17,6 +17,8 @@
 
 key: RU
 name: Ragnarok Union
+# sucsCodes:
+#   - RU
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/RU.yml
+++ b/data/universe/factions/RU.yml
@@ -17,8 +17,8 @@
 
 key: RU
 name: Ragnarok Union
-# sucsCodes:
-#   - RU
+sucsCodes:
+  - RU
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/RWR.yml
+++ b/data/universe/factions/RWR.yml
@@ -17,6 +17,8 @@
 
 key: RWR
 name: Rim Worlds Republic
+# sucsCodes:
+#   - RW
 nameChanges:
   2767: Amaris Empire
 capital: Apollo

--- a/data/universe/factions/RWR.yml
+++ b/data/universe/factions/RWR.yml
@@ -17,8 +17,8 @@
 
 key: RWR
 name: Rim Worlds Republic
-# sucsCodes:
-#   - RW
+sucsCodes:
+  - RW
 nameChanges:
   2767: Amaris Empire
 capital: Apollo

--- a/data/universe/factions/SA.yml
+++ b/data/universe/factions/SA.yml
@@ -17,6 +17,8 @@
 
 key: SA
 name: Senatorial Alliance
+# sucsCodes:
+#   - SA
 capital: Augustine
 yearsActive:
   - start: 3135

--- a/data/universe/factions/SA.yml
+++ b/data/universe/factions/SA.yml
@@ -17,8 +17,8 @@
 
 key: SA
 name: Senatorial Alliance
-# sucsCodes:
-#   - SA
+sucsCodes:
+  - SA
 capital: Augustine
 yearsActive:
   - start: 3135

--- a/data/universe/factions/SC.yml
+++ b/data/universe/factions/SC.yml
@@ -17,6 +17,8 @@
 
 key: SC
 name: Stewart Commonality
+# sucsCodes:
+#   - SC
 capital: Stewart
 yearsActive:
   - start: 3079

--- a/data/universe/factions/SC.yml
+++ b/data/universe/factions/SC.yml
@@ -17,8 +17,8 @@
 
 key: SC
 name: Stewart Commonality
-# sucsCodes:
-#   - SC
+sucsCodes:
+  - SC
 capital: Stewart
 yearsActive:
   - start: 3079

--- a/data/universe/factions/SCW.yml
+++ b/data/universe/factions/SCW.yml
@@ -17,6 +17,8 @@
 
 key: SCW
 name: Sian Commonwealth
+# sucsCodes:
+#   - SCo
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/SCW.yml
+++ b/data/universe/factions/SCW.yml
@@ -17,8 +17,8 @@
 
 key: SCW
 name: Sian Commonwealth
-# sucsCodes:
-#   - SCo
+sucsCodes:
+  - SCo
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/SCon.yml
+++ b/data/universe/factions/SCon.yml
@@ -17,6 +17,7 @@
 
 key: SCon
 name: Stewart Confederation
+# sucsCodes: []  # no SUCS equivalent
 capital: Stewart
 successor: FWL
 tags:

--- a/data/universe/factions/SCon.yml
+++ b/data/universe/factions/SCon.yml
@@ -17,7 +17,7 @@
 
 key: SCon
 name: Stewart Confederation
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Stewart
 successor: FWL
 tags:

--- a/data/universe/factions/SE.yml
+++ b/data/universe/factions/SE.yml
@@ -17,6 +17,8 @@
 
 key: SE
 name: Scorpion Empire
+# sucsCodes:
+#   - SE
 yearsActive:
   - start: 3141
 tags:

--- a/data/universe/factions/SE.yml
+++ b/data/universe/factions/SE.yml
@@ -17,8 +17,8 @@
 
 key: SE
 name: Scorpion Empire
-# sucsCodes:
-#   - SE
+sucsCodes:
+  - SE
 yearsActive:
   - start: 3141
 tags:

--- a/data/universe/factions/SH.yml
+++ b/data/universe/factions/SH.yml
@@ -17,6 +17,8 @@
 
 key: SH
 name: Sirian Holds
+# sucsCodes:
+#   - SH
 yearsActive:
   - start: 3057
     end: 3058

--- a/data/universe/factions/SH.yml
+++ b/data/universe/factions/SH.yml
@@ -17,8 +17,8 @@
 
 key: SH
 name: Sirian Holds
-# sucsCodes:
-#   - SH
+sucsCodes:
+  - SH
 yearsActive:
   - start: 3057
     end: 3058

--- a/data/universe/factions/SHC.yml
+++ b/data/universe/factions/SHC.yml
@@ -17,6 +17,8 @@
 
 key: SHC
 name: Silver Hawk Coalition
+# sucsCodes:
+#   - SHC
 capital: Amity
 yearsActive:
   - start: 3079

--- a/data/universe/factions/SHC.yml
+++ b/data/universe/factions/SHC.yml
@@ -17,8 +17,8 @@
 
 key: SHC
 name: Silver Hawk Coalition
-# sucsCodes:
-#   - SHC
+sucsCodes:
+  - SHC
 capital: Amity
 yearsActive:
   - start: 3079

--- a/data/universe/factions/SIC.yml
+++ b/data/universe/factions/SIC.yml
@@ -17,6 +17,8 @@
 
 key: SIC
 name: St. Ives Compact
+# sucsCodes:
+#   - SIC
 capital: St. Ives
 yearsActive:
   - start: 3029

--- a/data/universe/factions/SIC.yml
+++ b/data/universe/factions/SIC.yml
@@ -17,8 +17,8 @@
 
 key: SIC
 name: St. Ives Compact
-# sucsCodes:
-#   - SIC
+sucsCodes:
+  - SIC
 capital: St. Ives
 yearsActive:
   - start: 3029

--- a/data/universe/factions/SIMA.yml
+++ b/data/universe/factions/SIMA.yml
@@ -17,6 +17,7 @@
 
 key: SIMA
 name: St. Ives Mercantile Association
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/SIMA.yml
+++ b/data/universe/factions/SIMA.yml
@@ -17,7 +17,7 @@
 
 key: SIMA
 name: St. Ives Mercantile Association
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/SIS.yml
+++ b/data/universe/factions/SIS.yml
@@ -17,6 +17,8 @@
 
 key: SIS
 name: Sian Supremacy
+# sucsCodes:
+#   - SiS
 capital: Terra
 successor: CCom
 tags:

--- a/data/universe/factions/SIS.yml
+++ b/data/universe/factions/SIS.yml
@@ -17,8 +17,8 @@
 
 key: SIS
 name: Sian Supremacy
-# sucsCodes:
-#   - SiS
+sucsCodes:
+  - SiS
 capital: Terra
 successor: CCom
 tags:

--- a/data/universe/factions/SKC.yml
+++ b/data/universe/factions/SKC.yml
@@ -17,6 +17,8 @@
 
 key: SKC
 name: Styk Commonality
+# sucsCodes:
+#   - SKC
 nameChanges:
   3063: Styk Protectorate
 capital: Styk

--- a/data/universe/factions/SKC.yml
+++ b/data/universe/factions/SKC.yml
@@ -17,8 +17,8 @@
 
 key: SKC
 name: Styk Commonality
-# sucsCodes:
-#   - SKC
+sucsCodes:
+  - SKC
 nameChanges:
   3063: Styk Protectorate
 capital: Styk

--- a/data/universe/factions/SL.yml
+++ b/data/universe/factions/SL.yml
@@ -17,6 +17,9 @@
 
 key: SL
 name: Star League
+# sucsCodes:
+#   - SL
+#   - SLDF
 capital: Terra
 yearsActive:
   - start: 2571

--- a/data/universe/factions/SL.yml
+++ b/data/universe/factions/SL.yml
@@ -17,9 +17,9 @@
 
 key: SL
 name: Star League
-# sucsCodes:
-#   - SL
-#   - SLDF
+sucsCodes:
+  - SL
+  - SLDF
 capital: Terra
 yearsActive:
   - start: 2571

--- a/data/universe/factions/SL3.yml
+++ b/data/universe/factions/SL3.yml
@@ -17,6 +17,7 @@
 
 key: SL3
 name: Star League (Clan Wolf)
+# sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 3151
 ratingLevels:

--- a/data/universe/factions/SL3.yml
+++ b/data/universe/factions/SL3.yml
@@ -17,7 +17,7 @@
 
 key: SL3
 name: Star League (Clan Wolf)
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 yearsActive:
   - start: 3151
 ratingLevels:

--- a/data/universe/factions/SLIE.yml
+++ b/data/universe/factions/SLIE.yml
@@ -17,6 +17,8 @@
 
 key: SLIE
 name: Exodus Fleet
+# sucsCodes:
+#   - SLIE
 nameChanges:
   2786: Star League-in-Exile
 capital: New Samarkand

--- a/data/universe/factions/SLIE.yml
+++ b/data/universe/factions/SLIE.yml
@@ -17,8 +17,8 @@
 
 key: SLIE
 name: Exodus Fleet
-# sucsCodes:
-#   - SLIE
+sucsCodes:
+  - SLIE
 nameChanges:
   2786: Star League-in-Exile
 capital: New Samarkand

--- a/data/universe/factions/SOC.yml
+++ b/data/universe/factions/SOC.yml
@@ -17,6 +17,7 @@
 
 key: SOC
 name: The Society
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 yearsActive:
   - start: 3072

--- a/data/universe/factions/SOC.yml
+++ b/data/universe/factions/SOC.yml
@@ -17,7 +17,7 @@
 
 key: SOC
 name: The Society
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 yearsActive:
   - start: 3072

--- a/data/universe/factions/SP.yml
+++ b/data/universe/factions/SP.yml
@@ -17,6 +17,7 @@
 
 key: SP
 name: Sarna Protectorate
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/SP.yml
+++ b/data/universe/factions/SP.yml
@@ -17,7 +17,7 @@
 
 key: SP
 name: Sarna Protectorate
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/SSUP.yml
+++ b/data/universe/factions/SSUP.yml
@@ -17,6 +17,8 @@
 
 key: SSUP
 name: Sarna Supremacy
+# sucsCodes:
+#   - SS
 capital: Sarna
 successor: CC
 tags:

--- a/data/universe/factions/SSUP.yml
+++ b/data/universe/factions/SSUP.yml
@@ -17,8 +17,8 @@
 
 key: SSUP
 name: Sarna Supremacy
-# sucsCodes:
-#   - SS
+sucsCodes:
+  - SS
 capital: Sarna
 successor: CC
 tags:

--- a/data/universe/factions/ST.yml
+++ b/data/universe/factions/ST.yml
@@ -17,6 +17,8 @@
 
 key: ST
 name: Saiph Triumvirate
+# sucsCodes:
+#   - ST
 capital: Saiph
 yearsActive:
   - start: 3057

--- a/data/universe/factions/ST.yml
+++ b/data/universe/factions/ST.yml
@@ -17,8 +17,8 @@
 
 key: ST
 name: Saiph Triumvirate
-# sucsCodes:
-#   - ST
+sucsCodes:
+  - ST
 capital: Saiph
 yearsActive:
   - start: 3057

--- a/data/universe/factions/ShA.yml
+++ b/data/universe/factions/ShA.yml
@@ -17,6 +17,7 @@
 
 key: ShA
 name: Shiloh Alliance
+# sucsCodes: []  # no SUCS equivalent
 capital: Shiloh
 yearsActive:
   - start: 3135

--- a/data/universe/factions/ShA.yml
+++ b/data/universe/factions/ShA.yml
@@ -17,7 +17,7 @@
 
 key: ShA
 name: Shiloh Alliance
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Shiloh
 yearsActive:
   - start: 3135

--- a/data/universe/factions/Stone.yml
+++ b/data/universe/factions/Stone.yml
@@ -17,6 +17,8 @@
 
 key: Stone
 name: Stone's Coalition
+# sucsCodes:
+#   - CoF
 capital: Terra
 yearsActive:
   - start: 3073

--- a/data/universe/factions/Stone.yml
+++ b/data/universe/factions/Stone.yml
@@ -17,8 +17,8 @@
 
 key: Stone
 name: Stone's Coalition
-# sucsCodes:
-#   - CoF
+sucsCodes:
+  - CoF
 capital: Terra
 yearsActive:
   - start: 3073

--- a/data/universe/factions/TA.yml
+++ b/data/universe/factions/TA.yml
@@ -17,6 +17,8 @@
 
 key: TA
 name: Terran Alliance
+# sucsCodes:
+#   - TA
 capital: Terra
 yearsActive:
   - start: 2086

--- a/data/universe/factions/TA.yml
+++ b/data/universe/factions/TA.yml
@@ -17,8 +17,8 @@
 
 key: TA
 name: Terran Alliance
-# sucsCodes:
-#   - TA
+sucsCodes:
+  - TA
 capital: Terra
 yearsActive:
   - start: 2086

--- a/data/universe/factions/TB.yml
+++ b/data/universe/factions/TB.yml
@@ -17,6 +17,8 @@
 
 key: TB
 name: Republic of the Barrens
+# sucsCodes:
+#   - RB
 capital: Gustrell
 yearsActive:
   - start: 3100

--- a/data/universe/factions/TB.yml
+++ b/data/universe/factions/TB.yml
@@ -17,8 +17,8 @@
 
 key: TB
 name: Republic of the Barrens
-# sucsCodes:
-#   - RB
+sucsCodes:
+  - RB
 capital: Gustrell
 yearsActive:
   - start: 3100

--- a/data/universe/factions/TC.yml
+++ b/data/universe/factions/TC.yml
@@ -17,6 +17,8 @@
 
 key: TC
 name: Taurian Concordat
+# sucsCodes:
+#   - TC
 capital: Taurus
 yearsActive:
   - start: 2335

--- a/data/universe/factions/TC.yml
+++ b/data/universe/factions/TC.yml
@@ -17,8 +17,8 @@
 
 key: TC
 name: Taurian Concordat
-# sucsCodes:
-#   - TC
+sucsCodes:
+  - TC
 capital: Taurus
 yearsActive:
   - start: 2335

--- a/data/universe/factions/TCC.yml
+++ b/data/universe/factions/TCC.yml
@@ -17,6 +17,8 @@
 
 key: TCC
 name: Terracap Confederation
+# sucsCodes:
+#   - TCC
 capital: Terra Firma
 yearsActive:
   - start: 3057

--- a/data/universe/factions/TCC.yml
+++ b/data/universe/factions/TCC.yml
@@ -17,8 +17,8 @@
 
 key: TCC
 name: Terracap Confederation
-# sucsCodes:
-#   - TCC
+sucsCodes:
+  - TCC
 capital: Terra Firma
 yearsActive:
   - start: 3057

--- a/data/universe/factions/TD.yml
+++ b/data/universe/factions/TD.yml
@@ -17,6 +17,8 @@
 
 key: TD
 name: Tortuga Dominions
+# sucsCodes:
+#   - TD
 capital: Tortuga Prime
 yearsActive:
   - start: 2785

--- a/data/universe/factions/TD.yml
+++ b/data/universe/factions/TD.yml
@@ -17,8 +17,8 @@
 
 key: TD
 name: Tortuga Dominions
-# sucsCodes:
-#   - TD
+sucsCodes:
+  - TD
 capital: Tortuga Prime
 yearsActive:
   - start: 2785

--- a/data/universe/factions/TFR.yml
+++ b/data/universe/factions/TFR.yml
@@ -17,6 +17,8 @@
 
 key: TFR
 name: Tikonov Free Republic
+# sucsCodes:
+#   - TFR
 capital: Tikonov
 yearsActive:
   - start: 3029

--- a/data/universe/factions/TFR.yml
+++ b/data/universe/factions/TFR.yml
@@ -17,8 +17,8 @@
 
 key: TFR
 name: Tikonov Free Republic
-# sucsCodes:
-#   - TFR
+sucsCodes:
+  - TFR
 capital: Tikonov
 yearsActive:
   - start: 3029

--- a/data/universe/factions/TGU.yml
+++ b/data/universe/factions/TGU.yml
@@ -17,6 +17,8 @@
 
 key: TGU
 name: Tikonov Grand Union
+# sucsCodes:
+#   - TGU
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/TGU.yml
+++ b/data/universe/factions/TGU.yml
@@ -17,8 +17,8 @@
 
 key: TGU
 name: Tikonov Grand Union
-# sucsCodes:
-#   - TGU
+sucsCodes:
+  - TGU
 capital: Terra
 successor: CC
 tags:

--- a/data/universe/factions/TH.yml
+++ b/data/universe/factions/TH.yml
@@ -17,6 +17,8 @@
 
 key: TH
 name: Terran Hegemony
+# sucsCodes:
+#   - TH
 capital: Terra
 yearsActive:
   - start: 2315

--- a/data/universe/factions/TH.yml
+++ b/data/universe/factions/TH.yml
@@ -17,8 +17,8 @@
 
 key: TH
 name: Terran Hegemony
-# sucsCodes:
-#   - TH
+sucsCodes:
+  - TH
 capital: Terra
 yearsActive:
   - start: 2315

--- a/data/universe/factions/THW.yml
+++ b/data/universe/factions/THW.yml
@@ -17,6 +17,8 @@
 
 key: THW
 name: Taurian Homeworlds
+# sucsCodes:
+#   - THW
 capital: Taurus
 successor: TC
 tags:

--- a/data/universe/factions/THW.yml
+++ b/data/universe/factions/THW.yml
@@ -17,8 +17,8 @@
 
 key: THW
 name: Taurian Homeworlds
-# sucsCodes:
-#   - THW
+sucsCodes:
+  - THW
 capital: Taurus
 successor: TC
 tags:

--- a/data/universe/factions/THa.yml
+++ b/data/universe/factions/THa.yml
@@ -17,6 +17,8 @@
 
 key: THa
 name: The Havens
+# sucsCodes:
+#   - THa
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/THa.yml
+++ b/data/universe/factions/THa.yml
@@ -17,8 +17,8 @@
 
 key: THa
 name: The Havens
-# sucsCodes:
-#   - THa
+sucsCodes:
+  - THa
 capital: Terra
 tags:
   - MINOR

--- a/data/universe/factions/TP.yml
+++ b/data/universe/factions/TP.yml
@@ -17,6 +17,8 @@
 
 key: TP
 name: The Protectorate
+# sucsCodes:
+#   - TP
 capital: New Delos
 yearsActive:
   - start: 3078

--- a/data/universe/factions/TP.yml
+++ b/data/universe/factions/TP.yml
@@ -17,8 +17,8 @@
 
 key: TP
 name: The Protectorate
-# sucsCodes:
-#   - TP
+sucsCodes:
+  - TP
 capital: New Delos
 yearsActive:
   - start: 3078

--- a/data/universe/factions/TTU.yml
+++ b/data/universe/factions/TTU.yml
@@ -17,6 +17,7 @@
 
 key: TTU
 name: Tall Trees Union
+# sucsCodes: []  # no SUCS equivalent
 capital: Tall Trees
 yearsActive:
   - start: 3136

--- a/data/universe/factions/TTU.yml
+++ b/data/universe/factions/TTU.yml
@@ -17,7 +17,7 @@
 
 key: TTU
 name: Tall Trees Union
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Tall Trees
 yearsActive:
   - start: 3136

--- a/data/universe/factions/TU.yml
+++ b/data/universe/factions/TU.yml
@@ -17,6 +17,7 @@
 
 key: TU
 name: Tikonov Union
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: TGU
 tags:

--- a/data/universe/factions/TU.yml
+++ b/data/universe/factions/TU.yml
@@ -17,7 +17,7 @@
 
 key: TU
 name: Tikonov Union
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: TGU
 tags:

--- a/data/universe/factions/TamP.yml
+++ b/data/universe/factions/TamP.yml
@@ -17,6 +17,8 @@
 
 key: TamP
 name: Tamar Pact
+# sucsCodes:
+#   - TamP
 capital: Tamar
 capitalChanges:
   3151: Arcturus

--- a/data/universe/factions/TamP.yml
+++ b/data/universe/factions/TamP.yml
@@ -17,8 +17,8 @@
 
 key: TamP
 name: Tamar Pact
-# sucsCodes:
-#   - TamP
+sucsCodes:
+  - TamP
 capital: Tamar
 capitalChanges:
   3151: Arcturus

--- a/data/universe/factions/TiC.yml
+++ b/data/universe/factions/TiC.yml
@@ -17,6 +17,8 @@
 
 key: TiC
 name: Timbuktu Collective
+# sucsCodes:
+#   - TiC
 capital: Timbuktu
 tags:
   - MINOR

--- a/data/universe/factions/TiC.yml
+++ b/data/universe/factions/TiC.yml
@@ -17,8 +17,8 @@
 
 key: TiC
 name: Timbuktu Collective
-# sucsCodes:
-#   - TiC
+sucsCodes:
+  - TiC
 capital: Timbuktu
 tags:
   - MINOR

--- a/data/universe/factions/UC.yml
+++ b/data/universe/factions/UC.yml
@@ -17,6 +17,8 @@
 
 key: UC
 name: Umayyad Caliphate
+# sucsCodes:
+#   - UC
 capital: Granada
 yearsActive:
   - start: 2830

--- a/data/universe/factions/UC.yml
+++ b/data/universe/factions/UC.yml
@@ -17,8 +17,8 @@
 
 key: UC
 name: Umayyad Caliphate
-# sucsCodes:
-#   - UC
+sucsCodes:
+  - UC
 capital: Granada
 yearsActive:
   - start: 2830

--- a/data/universe/factions/UHC.yml
+++ b/data/universe/factions/UHC.yml
@@ -17,6 +17,8 @@
 
 key: UHC
 name: United Hindu Collective
+# sucsCodes:
+#   - UHC
 capital: Basantapur
 yearsActive:
   - start: 2240

--- a/data/universe/factions/UHC.yml
+++ b/data/universe/factions/UHC.yml
@@ -17,8 +17,8 @@
 
 key: UHC
 name: United Hindu Collective
-# sucsCodes:
-#   - UHC
+sucsCodes:
+  - UHC
 capital: Basantapur
 yearsActive:
   - start: 2240

--- a/data/universe/factions/UND.yml
+++ b/data/universe/factions/UND.yml
@@ -17,6 +17,8 @@
 
 key: UND
 name: Undiscovered
+# sucsCodes:
+#   - U
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/UND.yml
+++ b/data/universe/factions/UND.yml
@@ -17,8 +17,8 @@
 
 key: UND
 name: Undiscovered
-# sucsCodes:
-#   - U
+sucsCodes:
+  - U
 capital: Terra
 tags:
   - SPECIAL

--- a/data/universe/factions/VSM.yml
+++ b/data/universe/factions/VSM.yml
@@ -17,6 +17,8 @@
 
 key: VSM
 name: Vesper Marches
+# sucsCodes:
+#   - VM
 capital: Melissia
 tags:
   - MINOR

--- a/data/universe/factions/VSM.yml
+++ b/data/universe/factions/VSM.yml
@@ -17,8 +17,8 @@
 
 key: VSM
 name: Vesper Marches
-# sucsCodes:
-#   - VM
+sucsCodes:
+  - VM
 capital: Melissia
 tags:
   - MINOR

--- a/data/universe/factions/VesMar.yml
+++ b/data/universe/factions/VesMar.yml
@@ -17,6 +17,8 @@
 
 key: VesMar
 name: Vesper Marches
+# sucsCodes:
+#   - VM
 yearsActive:
   - start: 3151
 tags:

--- a/data/universe/factions/VesMar.yml
+++ b/data/universe/factions/VesMar.yml
@@ -17,8 +17,8 @@
 
 key: VesMar
 name: Vesper Marches
-# sucsCodes:
-#   - VM
+sucsCodes:
+  - VM
 yearsActive:
   - start: 3151
 tags:

--- a/data/universe/factions/WA.yml
+++ b/data/universe/factions/WA.yml
@@ -17,6 +17,7 @@
 
 key: WA
 name: Western Alliance
+# sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: TA
 tags:

--- a/data/universe/factions/WA.yml
+++ b/data/universe/factions/WA.yml
@@ -17,7 +17,7 @@
 
 key: WA
 name: Western Alliance
-# sucsCodes: []  # no SUCS equivalent
+sucsCodes: []  # no SUCS equivalent
 capital: Terra
 successor: TA
 tags:

--- a/data/universe/factions/WOB.yml
+++ b/data/universe/factions/WOB.yml
@@ -17,6 +17,8 @@
 
 key: WOB
 name: Word of Blake
+# sucsCodes:
+#   - WB
 capital: Terra
 yearsActive:
   - start: 3052

--- a/data/universe/factions/WOB.yml
+++ b/data/universe/factions/WOB.yml
@@ -17,8 +17,8 @@
 
 key: WOB
 name: Word of Blake
-# sucsCodes:
-#   - WB
+sucsCodes:
+  - WB
 capital: Terra
 yearsActive:
   - start: 3052

--- a/data/universe/planetary_systems/canon_systems/AlHillah.yml
+++ b/data/universe/planetary_systems/canon_systems/AlHillah.yml
@@ -386,7 +386,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: D-D-C-D-D
       - date: '3047-01-01'

--- a/data/universe/planetary_systems/canon_systems/Alleghe.yml
+++ b/data/universe/planetary_systems/canon_systems/Alleghe.yml
@@ -209,7 +209,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial: B-C-A-C-A
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Altenmarkt.yml
+++ b/data/universe/planetary_systems/canon_systems/Altenmarkt.yml
@@ -346,7 +346,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3044-01-01'
         socioIndustrial: B-C-A-D-A
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Balsta.yml
+++ b/data/universe/planetary_systems/canon_systems/Balsta.yml
@@ -174,7 +174,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3045-01-01'
         socioIndustrial: C-C-A-C-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Basiliano.yml
+++ b/data/universe/planetary_systems/canon_systems/Basiliano.yml
@@ -263,7 +263,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 285793351.0
       - date: '3050-08-04'
@@ -282,7 +282,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Bruben.yml
+++ b/data/universe/planetary_systems/canon_systems/Bruben.yml
@@ -168,7 +168,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: C-D-A-D-B
       - date: '3050-01-01'
@@ -189,7 +189,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-09-30'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Carse.yml
+++ b/data/universe/planetary_systems/canon_systems/Carse.yml
@@ -378,7 +378,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: C-C-A-C-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Casere.yml
+++ b/data/universe/planetary_systems/canon_systems/Casere.yml
@@ -317,7 +317,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial: C-C-C-B-C
       - date: '3050-01-01'
@@ -332,7 +332,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Csesztreg.yml
+++ b/data/universe/planetary_systems/canon_systems/Csesztreg.yml
@@ -323,7 +323,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Damian.yml
+++ b/data/universe/planetary_systems/canon_systems/Damian.yml
@@ -201,7 +201,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: D-D-C-C-F
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Dawn.yml
+++ b/data/universe/planetary_systems/canon_systems/Dawn.yml
@@ -164,7 +164,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 132050170.0
       - date: '3050-07-22'
@@ -183,7 +183,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Dehgolan.yml
+++ b/data/universe/planetary_systems/canon_systems/Dehgolan.yml
@@ -331,7 +331,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3049-01-01'
         socioIndustrial: B-C-C-B-A
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Diosd.yml
+++ b/data/universe/planetary_systems/canon_systems/Diosd.yml
@@ -258,7 +258,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 442416005.0
       - date: '3052-02-10'

--- a/data/universe/planetary_systems/canon_systems/Engadin.yml
+++ b/data/universe/planetary_systems/canon_systems/Engadin.yml
@@ -226,7 +226,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: C-B-A-B-D
       - date: '3050-01-01'
@@ -247,7 +247,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Feltre.yml
+++ b/data/universe/planetary_systems/canon_systems/Feltre.yml
@@ -277,7 +277,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3049-01-01'
         socioIndustrial: A-C-D-B-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Ferleiten.yml
+++ b/data/universe/planetary_systems/canon_systems/Ferleiten.yml
@@ -205,7 +205,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial: C-D-B-D-D
       - date: '3050-01-01'
@@ -220,7 +220,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Galuzzo.yml
+++ b/data/universe/planetary_systems/canon_systems/Galuzzo.yml
@@ -217,7 +217,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: B-B-C-A-D
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Goito.yml
+++ b/data/universe/planetary_systems/canon_systems/Goito.yml
@@ -258,7 +258,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3044-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Grumium.yml
+++ b/data/universe/planetary_systems/canon_systems/Grumium.yml
@@ -383,7 +383,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 1015155234.0
       - date: '3060-01-01'

--- a/data/universe/planetary_systems/canon_systems/Gunzburg.yml
+++ b/data/universe/planetary_systems/canon_systems/Gunzburg.yml
@@ -182,7 +182,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: C-C-C-A-D
       - date: '3050-01-01'
@@ -197,7 +197,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Hainfeld.yml
+++ b/data/universe/planetary_systems/canon_systems/Hainfeld.yml
@@ -272,7 +272,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 460916742.0
       - date: '3051-12-09'
@@ -285,7 +285,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Halesowen.yml
+++ b/data/universe/planetary_systems/canon_systems/Halesowen.yml
@@ -304,7 +304,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: A-B-C-B-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Harvest.yml
+++ b/data/universe/planetary_systems/canon_systems/Harvest.yml
@@ -273,7 +273,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: C-C-A-D-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Heiligendreuz.yml
+++ b/data/universe/planetary_systems/canon_systems/Heiligendreuz.yml
@@ -230,7 +230,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: A-C-B-B-A
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Hermagor.yml
+++ b/data/universe/planetary_systems/canon_systems/Hermagor.yml
@@ -187,7 +187,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: D-C-C-C-B
       - date: '3050-01-01'
@@ -202,7 +202,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-09-30'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Hohenems.yml
+++ b/data/universe/planetary_systems/canon_systems/Hohenems.yml
@@ -258,7 +258,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: A-C-C-C-A
       - date: '3050-01-01'
@@ -279,7 +279,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Holmsbu.yml
+++ b/data/universe/planetary_systems/canon_systems/Holmsbu.yml
@@ -300,7 +300,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 798300351.0
       - date: '3050-03-15'

--- a/data/universe/planetary_systems/canon_systems/Hyperion.yml
+++ b/data/universe/planetary_systems/canon_systems/Hyperion.yml
@@ -233,7 +233,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: C-C-A-C-C
       - date: '3050-01-01'
@@ -248,7 +248,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Jabuka.yml
+++ b/data/universe/planetary_systems/canon_systems/Jabuka.yml
@@ -218,7 +218,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: A-A-F-B-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Jezersko.yml
+++ b/data/universe/planetary_systems/canon_systems/Jezersko.yml
@@ -250,7 +250,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial: D-D-C-D-F
       - date: '3050-01-01'
@@ -265,7 +265,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Kandis.yml
+++ b/data/universe/planetary_systems/canon_systems/Kandis.yml
@@ -212,7 +212,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: C-D-B-C-D
       - date: '3050-01-01'
@@ -233,7 +233,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Karbala.yml
+++ b/data/universe/planetary_systems/canon_systems/Karbala.yml
@@ -401,7 +401,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial: B-B-C-B-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Karston.yml
+++ b/data/universe/planetary_systems/canon_systems/Karston.yml
@@ -259,7 +259,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: B-C-A-D-B
       - date: '3050-01-01'
@@ -274,7 +274,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Kempten.yml
+++ b/data/universe/planetary_systems/canon_systems/Kempten.yml
@@ -206,7 +206,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 1372010153.0
       - date: '3051-12-01'
@@ -219,7 +219,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Kirchbach.yml
+++ b/data/universe/planetary_systems/canon_systems/Kirchbach.yml
@@ -352,7 +352,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial:
           source: canon
@@ -369,7 +369,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-09-30'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Kufstein.yml
+++ b/data/universe/planetary_systems/canon_systems/Kufstein.yml
@@ -185,7 +185,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3044-01-01'
         socioIndustrial: C-D-A-D-D
       - date: '3050-01-01'
@@ -206,7 +206,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/LastFrontier.yml
+++ b/data/universe/planetary_systems/canon_systems/LastFrontier.yml
@@ -205,7 +205,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial: B-B-C-A-C
       - date: '3050-01-01'
@@ -226,7 +226,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-09-30'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Leoben.yml
+++ b/data/universe/planetary_systems/canon_systems/Leoben.yml
@@ -231,7 +231,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial: D-C-C-D-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Liezen.yml
+++ b/data/universe/planetary_systems/canon_systems/Liezen.yml
@@ -223,7 +223,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: A-C-B-B-A
       - date: '3050-01-01'
@@ -244,7 +244,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-09-30'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Lothan.yml
+++ b/data/universe/planetary_systems/canon_systems/Lothan.yml
@@ -209,7 +209,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: B-B-D-A-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Lovinac.yml
+++ b/data/universe/planetary_systems/canon_systems/Lovinac.yml
@@ -244,7 +244,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial: B-B-B-B-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Maule.yml
+++ b/data/universe/planetary_systems/canon_systems/Maule.yml
@@ -282,7 +282,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: B-A-D-B-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Memmingen.yml
+++ b/data/universe/planetary_systems/canon_systems/Memmingen.yml
@@ -248,7 +248,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: B-C-B-D-C
       - date: '3050-01-01'
@@ -269,7 +269,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Moritz.yml
+++ b/data/universe/planetary_systems/canon_systems/Moritz.yml
@@ -279,7 +279,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: B-C-D-C-B
       - date: '3049-01-01'

--- a/data/universe/planetary_systems/canon_systems/Mozirje.yml
+++ b/data/universe/planetary_systems/canon_systems/Mozirje.yml
@@ -217,7 +217,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: D-D-B-F-D
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/NewBergen.yml
+++ b/data/universe/planetary_systems/canon_systems/NewBergen.yml
@@ -336,7 +336,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: D-D-A-C-D
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/NewCaledonia.yml
+++ b/data/universe/planetary_systems/canon_systems/NewCaledonia.yml
@@ -367,7 +367,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: D-C-B-C-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/NewOslo.yml
+++ b/data/universe/planetary_systems/canon_systems/NewOslo.yml
@@ -329,7 +329,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 239716686.0
       - date: '3050-07-29'
@@ -348,7 +348,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Nox.yml
+++ b/data/universe/planetary_systems/canon_systems/Nox.yml
@@ -429,7 +429,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3049-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Orestes.yml
+++ b/data/universe/planetary_systems/canon_systems/Orestes.yml
@@ -413,7 +413,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Outpost.yml
+++ b/data/universe/planetary_systems/canon_systems/Outpost.yml
@@ -319,7 +319,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 109477006.0
       - date: '3050-03-08'

--- a/data/universe/planetary_systems/canon_systems/Pinnacle.yml
+++ b/data/universe/planetary_systems/canon_systems/Pinnacle.yml
@@ -215,7 +215,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3050-01-01'
         population: 77406429.0
       - date: '3050-03-15'

--- a/data/universe/planetary_systems/canon_systems/PommeDeTerre.yml
+++ b/data/universe/planetary_systems/canon_systems/PommeDeTerre.yml
@@ -169,7 +169,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial: C-D-A-F-D
       - date: '3050-01-01'
@@ -184,7 +184,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Predlitz.yml
+++ b/data/universe/planetary_systems/canon_systems/Predlitz.yml
@@ -292,7 +292,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3045-01-01'
         socioIndustrial: A-A-D-B-C
       - date: '3050-01-01'
@@ -307,7 +307,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Quarell.yml
+++ b/data/universe/planetary_systems/canon_systems/Quarell.yml
@@ -317,7 +317,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: C-C-C-C-B
       - date: '3050-01-01'
@@ -338,7 +338,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Radlje.yml
+++ b/data/universe/planetary_systems/canon_systems/Radlje.yml
@@ -179,7 +179,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: F-F-C-D-F
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Radstadt.yml
+++ b/data/universe/planetary_systems/canon_systems/Radstadt.yml
@@ -335,7 +335,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Ramsau.yml
+++ b/data/universe/planetary_systems/canon_systems/Ramsau.yml
@@ -258,7 +258,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3049-01-01'
         socioIndustrial: B-B-A-C-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Rasalhague.yml
+++ b/data/universe/planetary_systems/canon_systems/Rasalhague.yml
@@ -441,7 +441,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Rodigo.yml
+++ b/data/universe/planetary_systems/canon_systems/Rodigo.yml
@@ -447,7 +447,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: C-D-A-D-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Satalice.yml
+++ b/data/universe/planetary_systems/canon_systems/Satalice.yml
@@ -400,7 +400,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial:
           source: canon
@@ -418,7 +418,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-01-06'
         faction:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Skallevoll.yml
+++ b/data/universe/planetary_systems/canon_systems/Skallevoll.yml
@@ -325,7 +325,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: C-C-A-C-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Skandia.yml
+++ b/data/universe/planetary_systems/canon_systems/Skandia.yml
@@ -358,7 +358,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Skokie.yml
+++ b/data/universe/planetary_systems/canon_systems/Skokie.yml
@@ -205,7 +205,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3048-01-01'
         socioIndustrial: C-C-A-C-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Spittal.yml
+++ b/data/universe/planetary_systems/canon_systems/Spittal.yml
@@ -182,7 +182,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial:
           source: canon
@@ -199,7 +199,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/StJohn.yml
+++ b/data/universe/planetary_systems/canon_systems/StJohn.yml
@@ -274,7 +274,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3045-01-01'
         socioIndustrial: A-A-B-B-A
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Stanzach.yml
+++ b/data/universe/planetary_systems/canon_systems/Stanzach.yml
@@ -265,7 +265,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: B-C-B-B-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Susquehanna.yml
+++ b/data/universe/planetary_systems/canon_systems/Susquehanna.yml
@@ -243,7 +243,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3044-01-01'
         socioIndustrial: C-D-B-D-B
       - date: '3047-01-01'

--- a/data/universe/planetary_systems/canon_systems/Svelvik.yml
+++ b/data/universe/planetary_systems/canon_systems/Svelvik.yml
@@ -324,7 +324,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3045-01-01'
         socioIndustrial: C-C-A-C-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Thannhausen.yml
+++ b/data/universe/planetary_systems/canon_systems/Thannhausen.yml
@@ -192,7 +192,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3043-01-01'
         socioIndustrial: C-C-A-C-C
       - date: '3050-01-01'
@@ -213,7 +213,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/TheEdge.yml
+++ b/data/universe/planetary_systems/canon_systems/TheEdge.yml
@@ -270,7 +270,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: C-D-A-D-C
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Thule.yml
+++ b/data/universe/planetary_systems/canon_systems/Thule.yml
@@ -367,7 +367,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Thun.yml
+++ b/data/universe/planetary_systems/canon_systems/Thun.yml
@@ -301,7 +301,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: C-C-B-B-C
       - date: '3050-01-01'
@@ -322,7 +322,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/TrondheimDc.yml
+++ b/data/universe/planetary_systems/canon_systems/TrondheimDc.yml
@@ -366,7 +366,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial:
           source: canon

--- a/data/universe/planetary_systems/canon_systems/Tukayyid.yml
+++ b/data/universe/planetary_systems/canon_systems/Tukayyid.yml
@@ -312,7 +312,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3044-01-01'
         socioIndustrial: A-C-B-B-B
       - date: '3050-01-01'
@@ -338,7 +338,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3060-01-01'
         population: 442478673.0
       - date: '3068-12-31'

--- a/data/universe/planetary_systems/canon_systems/Ueda.yml
+++ b/data/universe/planetary_systems/canon_systems/Ueda.yml
@@ -210,7 +210,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3045-01-01'
         socioIndustrial: B-C-A-C-B
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/Unzmarkt.yml
+++ b/data/universe/planetary_systems/canon_systems/Unzmarkt.yml
@@ -284,7 +284,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3049-01-01'
         socioIndustrial: C-D-C-C-D
       - date: '3050-01-01'
@@ -305,7 +305,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Utrecht.yml
+++ b/data/universe/planetary_systems/canon_systems/Utrecht.yml
@@ -358,7 +358,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3046-01-01'
         socioIndustrial: C-D-B-C-D
       - date: '3050-01-01'

--- a/data/universe/planetary_systems/canon_systems/VerthandiNorn.yml
+++ b/data/universe/planetary_systems/canon_systems/VerthandiNorn.yml
@@ -211,7 +211,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: C-D-C-C-C
       - date: '3044-01-01'

--- a/data/universe/planetary_systems/canon_systems/Vipaava.yml
+++ b/data/universe/planetary_systems/canon_systems/Vipaava.yml
@@ -293,7 +293,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial: C-D-B-C-D
       - date: '3050-01-01'
@@ -308,7 +308,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3051-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Volders.yml
+++ b/data/universe/planetary_systems/canon_systems/Volders.yml
@@ -332,7 +332,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3042-01-01'
         socioIndustrial: A-A-C-A-C
       - date: '3050-01-01'
@@ -347,7 +347,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Vorarlberg.yml
+++ b/data/universe/planetary_systems/canon_systems/Vorarlberg.yml
@@ -296,7 +296,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3041-01-01'
         socioIndustrial: B-B-D-B-B
       - date: '3050-01-01'
@@ -311,7 +311,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Weingarten.yml
+++ b/data/universe/planetary_systems/canon_systems/Weingarten.yml
@@ -306,7 +306,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3044-01-01'
         socioIndustrial:
           source: canon
@@ -323,7 +323,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS

--- a/data/universe/planetary_systems/canon_systems/Wheel.yml
+++ b/data/universe/planetary_systems/canon_systems/Wheel.yml
@@ -270,7 +270,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3047-01-01'
         socioIndustrial: B-A-D-B-B
       - date: '3050-01-01'
@@ -285,7 +285,7 @@ planet:
           source: SUCS
           version: 2026.03.02
           value:
-            - FR
+            - FRR
       - date: '3052-12-31'
         faction:
           source: SUCS


### PR DESCRIPTION
## Root Cause

Commit ac56ece (the SUCS planetary data import) wrote `FR` instead of `FRR` for Free Rasalhague Republic worlds in SUCS-source value blocks. In MegaMek's faction codes, `FR.yml` is **Fronc Reaches** and `FRR.yml` is **Free Rasalhague Republic** — so 119 FRR-era entries across 84 planet files were rendering FRR territory as Fronc Reaches.

The SUCS export file (`SUCS Systems March 2026 - MekHQ Factions.xlsx`) and hand-curated correspondence sheet were both correct (mapping SUCS `FR` → MekHQ `FRR`); the import script missed the translation for that one entry.

## Changes

1. **84 planet yml files** under `data/universe/planetary_systems/canon_systems/`: 119 `- FR` → `- FRR` corrections inside SUCS-source value blocks. Each correction was validated per-planet per-date against the SUCS export file. The 12 legitimate Fronc Reaches entries were left unchanged.
2. **196 faction yml files** under `data/universe/factions/`: added commented-out `# sucsCodes:` block right after `name:`. Maps each MekHQ faction to its SUCS code(s):
   - 45 explicit renames from `faction correspondence SUCS_MekhQ.xlsx`
   - 96 clean identity matches (same code, same name in both)
   - 4 historical-successor cases get both codes: `LA: [LA, LC]`, `SL: [SL, SLDF]`, `CDS: [CDS, CSF]`, `CGB: [CGB, GBD]`
   - 5 same-code-different-name approved as identity: `CS, OZP, SA, SHC, SLIE`
   - `FR.yml` gets `[FrR]` only (must NOT include `FR` — the bug-prevention case)
   - 50 MekHQ-only factions get `# sucsCodes: []  # no SUCS equivalent`

The `sucsCodes` field is **commented out** to keep deserialization safe until a corresponding `Faction2.java` change lands in megamek to recognize the field. Once the megamek PR merges, uncomment with a one-liner sed pass.

## Files Changed

- 84 files in `data/universe/planetary_systems/canon_systems/` — FR→FRR data corrections
- 196 files in `data/universe/factions/` — commented `sucsCodes` field added

Total: 280 files, +466/-119

## 12 entries intentionally left as `- FR` (correctly Fronc Reaches)

Fronc, Cygnus, Herotitus, Independence, Mandalas, McEvansSacrifice, Portland, Rockwellawan, Spencer, UrCruinne, Appian/Polybius, HuanghuadianTincalunas3130

## Testing

- Per-entry verification against the SUCS export file
- Manual visual inspection at year 3040 (full FRR pre-Clan-Invasion) and year 3067 (Fronc Reaches founded April 9, 3066)
- All FRR worlds (Tukayyid, Rasalhague, Orestes, Skandia, Trondheim DC, Verthandi/Norn, Susquehanna, etc.) now correctly attributed
- Fronc.yml entry for Fronc Reaches founding date (3066-04-09) verified intact

Fixes #320