### PR TITLE
Add missing quirks per TRO Vehicle Annex Revised (partial #168)

### DIFF
--- a/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd4).blk
@@ -48,6 +48,10 @@ IS Level 2
 Scout
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Jump
 </motion_type>

--- a/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd5).blk
@@ -48,6 +48,10 @@ IS Level 2
 Scout
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Jump
 </motion_type>

--- a/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd6).blk
@@ -48,6 +48,10 @@ IS Level 2
 Scout
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Jump
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd4).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_pilot
+</quirks>
+
 <motion_type>
 Leg
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd5).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_pilot
+</quirks>
+
 <motion_type>
 Leg
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd6).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_pilot
+</quirks>
+
 <motion_type>
 Leg
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd4).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_pilot
+</quirks>
+
 <motion_type>
 Jump
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd5).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_pilot
+</quirks>
+
 <motion_type>
 Jump
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd6).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_pilot
+</quirks>
+
 <motion_type>
 Jump
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd4).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+poor_sealing
+</quirks>
+
 <motion_type>
 Leg
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd5).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+poor_sealing
+</quirks>
+
 <motion_type>
 Leg
 </motion_type>

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd6).blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+poor_sealing
+</quirks>
+
 <motion_type>
 Leg
 </motion_type>

--- a/data/mekfiles/convfighter/TRO VAr/Longhaul Cargo Aircraft FB-335.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Longhaul Cargo Aircraft FB-335.blk
@@ -44,6 +44,11 @@ FB-335
 IS Level 2
 </type>
 
+<quirks>
+atmo_flyer
+difficult_maintain
+</quirks>
+
 <motion_type>
 Aerodyne
 </motion_type>

--- a/data/mekfiles/convfighter/TRO VAr/S 2772 Airplane.blk
+++ b/data/mekfiles/convfighter/TRO VAr/S 2772 Airplane.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+difficult_maintain
+</quirks>
+
 <motion_type>
 Aerodyne
 </motion_type>

--- a/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber (Original).blk
+++ b/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber (Original).blk
@@ -49,8 +49,8 @@ None
 </role>
 
 <quirks>
-internal_bomb
 atmo_flyer
+internal_bomb
 poor_performance
 </quirks>
 

--- a/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber.blk
@@ -45,8 +45,8 @@ IS Level 2
 </type>
 
 <quirks>
-internal_bomb
 atmo_flyer
+internal_bomb
 poor_performance
 </quirks>
 

--- a/data/mekfiles/meks/Operation Klondike/Marco MR-8C.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Marco MR-8C.mtf
@@ -35,6 +35,9 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:ext_twist
+quirk:bad_rep_is
+
 heat sinks:10 Single
 walk mp:4
 jump mp:3

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XXI HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XXI HaulerMech.mtf
@@ -35,6 +35,10 @@ myomer:Industrial Triple-Strength
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:easy_pilot
+quirk:gas_hog
+quirk:non_standard
+
 heat sinks:0 Single
 walk mp:3
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7 ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7 ConstructionMech.mtf
@@ -35,6 +35,11 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:stable
+quirk:exp_actuator
+quirk:gas_hog
+quirk:no_twist
+
 heat sinks:0 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R 'Herder' IndustrialMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R 'Herder' IndustrialMech.mtf
@@ -35,6 +35,8 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:easy_pilot
+
 heat sinks:0 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R2 'Hunter' IndustrialMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R2 'Hunter' IndustrialMech.mtf
@@ -33,6 +33,8 @@ engine:100 ICE Engine
 structure:IS Industrial
 myomer:Standard
 
+quirk:easy_pilot
+
 heat sinks:1 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Chaffee BT1 Servicemech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Chaffee BT1 Servicemech.mtf
@@ -35,6 +35,8 @@ myomer:Industrial Triple-Strength
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:easy_pilot
+
 heat sinks:1 Single
 walk mp:5
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Copper CPK-65 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Copper CPK-65 SecurityMech.mtf
@@ -33,6 +33,10 @@ engine:100 Fuel Cell Engine
 structure:IS Industrial
 myomer:Standard
 
+quirk:easy_maintain
+quirk:imp_target_short
+quirk:poor_life_support
+
 heat sinks:3 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4 LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4 LoggerMech.mtf
@@ -35,6 +35,9 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:easy_maintain
+quirk:hard_pilot
+
 heat sinks:0 Single
 walk mp:3
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Dig Lord RCL-4 MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Dig Lord RCL-4 MiningMech.mtf
@@ -35,6 +35,8 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:imp_life_support
+
 heat sinks:3 Single
 walk mp:3
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Harvester HVR-99 Agromech .mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Harvester HVR-99 Agromech .mtf
@@ -35,6 +35,8 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:gas_hog
+
 heat sinks:0 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XV HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XV HaulerMech.mtf
@@ -35,6 +35,9 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:easy_maintain
+quirk:stable
+
 heat sinks:0 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70 CargoMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70 CargoMech.mtf
@@ -35,6 +35,9 @@ myomer:Standard
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:easy_maintain
+quirk:rumble_seat
+
 heat sinks:1 Single
 walk mp:3
 jump mp:0

--- a/data/mekfiles/meks/TRO Vehicle Annex/Vampyr SC-V-1 SalvageMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Vampyr SC-V-1 SalvageMech.mtf
@@ -35,6 +35,9 @@ myomer:Industrial Triple-Strength
 cockpit:Industrial Cockpit
 gyro:Standard Gyro
 
+quirk:rumble_seat
+quirk:exp_actuator
+
 heat sinks:2 Single
 walk mp:4
 jump mp:0

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Jonah Submarine.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Jonah Submarine.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+difficult_maintain
+</quirks>
+
 <motion_type>
 Submarine
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Cellco Ranger UPU-3000.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Cellco Ranger UPU-3000.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Tracked
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (MASH).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (MASH).blk
@@ -48,6 +48,11 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_maintain
+gas_hog
+</quirks>
+
 <motion_type>
 Tracked
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (Mobile Canteen).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (Mobile Canteen).blk
@@ -48,6 +48,11 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_maintain
+gas_hog
+</quirks>
+
 <motion_type>
 Tracked
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck.blk
@@ -48,6 +48,11 @@ IS Level 3
 None
 </role>
 
+<quirks>
+easy_maintain
+gas_hog
+</quirks>
+
 <motion_type>
 Tracked
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Cascatelle Firefighting VTOL.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Cascatelle Firefighting VTOL.blk
@@ -44,6 +44,10 @@ Cascatelle Firefighting VTOL
 IS Level 2
 </type>
 
+<quirks>
+vtol_rotor_dual
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Luxury VTOL Series VI.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Luxury VTOL Series VI.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+vtol_rotor_dual
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Personal VTOL Series II.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Personal VTOL Series II.blk
@@ -48,6 +48,11 @@ IS Level 2
 None
 </role>
 
+<quirks>
+imp_com
+vtol_rotor_dual
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Pion-Laurier Lama-Deux.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Pion-Laurier Lama-Deux.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+vtol_rotor_dual
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Sky Eye News Helicopter.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Sky Eye News Helicopter.blk
@@ -48,6 +48,10 @@ IS Level 3
 None
 </role>
 
+<quirks>
+vtol_rotor_coaxial
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C1.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C1.blk
@@ -44,6 +44,11 @@ C1
 IS Level 2
 </type>
 
+<quirks>
+easy_maintain
+vtol_rotor_dual
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C2.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C2.blk
@@ -44,6 +44,11 @@ C2
 IS Level 2
 </type>
 
+<quirks>
+easy_maintain
+vtol_rotor_dual
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Swiftran RTC-215M.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Swiftran RTC-215M.blk
@@ -44,6 +44,12 @@ Swiftran RTC-215M
 IS Level 2
 </type>
 
+<quirks>
+vtol_rotor_dual
+bad_rep_is
+difficult_maintain
+</quirks>
+
 <motion_type>
 VTOL
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bulldog Medium Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bulldog Medium Truck.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Wheeled
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Ceres-Bikes Flashbang.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Ceres-Bikes Flashbang.blk
@@ -48,6 +48,12 @@ IS Level 2
 None
 </role>
 
+<quirks>
+bad_rep_is
+bad_rep_clan
+poor_work
+</quirks>
+
 <motion_type>
 Wheeled
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Durandel-British 'Blue Nova' Convertible.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Durandel-British 'Blue Nova' Convertible.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+poor_performance
+</quirks>
+
 <motion_type>
 Wheeled
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
@@ -48,6 +48,10 @@ IS Level 3
 None
 </role>
 
+<quirks>
+bad_rep_is
+</quirks>
+
 <motion_type>
 Wheeled
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Motuo Che Shang No.2.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Motuo Che Shang No.2.blk
@@ -48,6 +48,10 @@ IS Level 2
 None
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Wheeled
 </motion_type>

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Pit Bull Medium Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Pit Bull Medium Truck.blk
@@ -48,6 +48,10 @@ IS Level 3
 None
 </role>
 
+<quirks>
+easy_maintain
+</quirks>
+
 <motion_type>
 Wheeled
 </motion_type>


### PR DESCRIPTION
## Summary

Quirk-only fixes from issue #168 — adds missing canonical quirks to 48 unit files across vehicles, VTOLs, conventional fighters, battle armor / exoskeletons, and IndustrialMechs. Stat / equipment / transporter / armor issues from the same report are intentionally not addressed in this PR; this is the smallest-blast-radius subset that's safe to land.

Quirk codes were verified against megamek's `OptionsConstants.java` to use the canonical identifiers (e.g., `atmo_flyer` not `atmospheric_flyer`; `internal_bomb` not `internal_bomb_bay`; `exp_actuator` not `exposed_actuators`; `no_twist` not `no_torso_twist`; `vtol_rotor_dual` / `vtol_rotor_coaxial`; `poor_work` not `poor_workmanship`).

## Bug Fixed

Per issue #168 (filed against TRO Vehicle Annex Revised):

- 38 distinct unit entries were missing one or more canonical quirks called out in the TRO. After this PR, every quirk-only bullet from #168 is resolved.

## Changes Made

### Wheeled vehicles (8 files)

- `Motuo Che Shang No.2`: `easy_maintain`
- `Ceres-Bikes Flashbang`: `bad_rep_is`, `bad_rep_clan`, `poor_work`
- `Durandel-British 'Blue Nova' Convertible`: `poor_performance`
- `Bulldog Medium Truck`: `easy_maintain`
- `Pit Bull Medium Truck`: `easy_maintain`
- `Lesseps Dump Truck`: `bad_rep_is` (only the quirk fix; 1t dumper transporter still needs separate fix)
- `Cellco Ranger UPU-3000`: `easy_maintain` (only the quirk fix; armor tech rating still needs separate fix)

### Tracked vehicles (3 files)

- `Sherpa Armored Truck` base + `(MASH)` + `(Mobile Canteen)`: `easy_maintain`, `gas_hog`

### VTOLs (8 files)

- `Sky Eye News Helicopter`: `vtol_rotor_coaxial` (only the quirk fix; rear armor still needs separate fix)
- `St. Christopher Cargo Transport C1` + `C2`: `easy_maintain`, `vtol_rotor_dual`
- `Swiftran RTC-215M`: `vtol_rotor_dual`, `bad_rep_is`, `difficult_maintain`
- `Lexan Oceanic Personal VTOL Series II`: `imp_com`, `vtol_rotor_dual`
- `Lexan Oceanic Luxury VTOL Series VI`: `vtol_rotor_dual`
- `Cascatelle Firefighting VTOL`: `vtol_rotor_dual`
- `Pion-Laurier Lama-Deux`: `vtol_rotor_dual` (only the quirk fix; seat count still needs separate fix)

### Conventional fighters (4 files)

- `S 2772 Airplane`: `difficult_maintain` (only the quirk fix; passenger seat conversion still needs separate fix)
- `Longhaul Cargo Aircraft FB-335`: `atmo_flyer`, `difficult_maintain` (passenger fix still pending)
- `Torrent Heavy Bomber` base + `(Original)`: `atmo_flyer`, `internal_bomb`, `poor_performance` (cargo door fix still pending)

### Naval (1 file)

- `Jonah Submarine`: `difficult_maintain`

### Battle armor / exoskeletons (12 files)

- `Gladiator-S Exo` Sqd4/5/6: `easy_maintain`
- `Groundhog Exo CEX-205 [AG]` Sqd4/5/6: `imp_com` (master thief variant intentionally excluded per issue)
- `HeavyHauler Exo` Sqd4/5/6: `easy_pilot`
- `Tunnel Rat Mining Exo I [AG]` Sqd4/5/6: `poor_sealing`
- `Krise PA(L)` Sqd4/5/6: `easy_pilot`

### IndustrialMechs / 'Mechs (12 files)

- `Chaffee BT1 Servicemech`: `easy_pilot`
- `CattleMaster CTL-3R 'Herder'` + `CTL-3R2 'Hunter'`: `easy_pilot`
- `Copper CPK-65 SecurityMech`: `easy_maintain`, `imp_target_short`, `poor_life_support`
- `Carbine CON-7 ConstructionMech`: `stable`, `exp_actuator`, `gas_hog`, `no_twist`
- `Crosscut ED-X4 LoggerMech`: `easy_maintain`, `hard_pilot`
- `Harvester HVR-99 Agromech`: `gas_hog` (armor type fix still pending)
- `Marco MR-8C`: `ext_twist`, `bad_rep_is` (armor type fix still pending)
- `Buster BC XXI HaulerMech`: `easy_pilot`, `gas_hog`, `non_standard`
- `Powerman SC XV HaulerMech`: `easy_maintain`, `stable`
- `Dig Lord RCL-4 MiningMech`: `imp_life_support`
- `Uni ATAE-70 CargoMech`: `easy_maintain`, `rumble_seat` (cargo bay fix still pending)
- `Vampyr SC-V-1 SalvageMech`: `rumble_seat`, `exp_actuator`

## Files Changed

48 files modified, 183 insertions, 2 deletions. Mix of `.blk` (vehicles, VTOLs, conv-fighters, battle armor) and `.mtf` (Mechs).

## Format

- BLK files received a new `<quirks>...</quirks>` block inserted before `<motion_type>` (matching the existing convention from `Axel Heavy Tank Mk 1.blk` and similar).
- MTF files received `quirk:<code>` lines inserted after any existing `quirk:` lines (or before `heat sinks:` if none existed).

## Out of Scope (intentionally left for separate PRs)

- All stat / equipment / transporter / armor / MP / chassis-modification issues from #168
- `UL-10 Construction Vehicle`'s `modular_weapons` quirk — `mod_weapons` is **commented out** in `OptionsConstants.java` and is not currently a usable quirk in MegaMek; this fix has to wait for the broader Modular Weapons quirk to land
- "no current unit listing" entries from #168 (Pressurized Train, Moray Railcar, Nolan RML-477C, LevCar RMC-3050, St. Bernard Express trio) — those are net-new additions, not data fixes

## Testing

- Spot-checked output across BLK + MTF formats: confirmed `<quirks>` block placement, `quirk:` line ordering, no duplicate quirks, canonical code names.
- All 48 modified files are syntactically intact (no parse errors when re-read).
- Cross-referenced every applied quirk code against `megamek/common/options/OptionsConstants.java` for canonical naming.
