### PR TITLE
Add SL member-state fallBackFactions for academy lineage (Fixes #93)

### DIFF
--- a/data/universe/factions/SL.yml
+++ b/data/universe/factions/SL.yml
@@ -24,6 +24,17 @@ capital: Terra
 yearsActive:
   - start: 2571
     end: 2780
+fallBackFactions:
+  - TH
+  - LA
+  - FS
+  - CC
+  - FWL
+  - DC
+  - MOC
+  - OA
+  - RWR
+  - TC
 tags:
   - PLAYABLE
   - IS

--- a/data/universe/factions/SL.yml
+++ b/data/universe/factions/SL.yml
@@ -24,8 +24,12 @@ capital: Terra
 yearsActive:
   - start: 2571
     end: 2780
+# NOTE: TH (Terran Hegemony) is intentionally NOT listed here. TH.fallBackFactions
+# already contains SL, so adding TH here would create a SL <-> TH cycle that crashes
+# RATGenerator.findModelAvailabilityRecord with StackOverflowError. The bidirectional
+# Faction.isLineageCompatible check used by Academy.java still resolves TH <-> SL
+# correctly via the existing TH -> SL relationship.
 fallBackFactions:
-  - TH
   - LA
   - FS
   - CC


### PR DESCRIPTION
## ⚠️ Hard dependency: requires [mekhq#8933](https://github.com/MegaMek/mekhq/pull/8933) (academy faction lineage)

This is a data-side companion to [mekhq#8933](https://github.com/MegaMek/mekhq/pull/8933). **This PR alone does nothing** — the lineage check that consumes `fallBackFactions` for academy access is added in mekhq#8933. **Both PRs must be merged together** (or this PR after mekhq#8933) for the fix to take effect.

## Summary

Resolves #93 (Star League characters can't apply to the Nagelring on Tharkad despite the Nagelring being a canon SLDF academy). Pure data-side fix — adds SL <-> member-state lineage so MekHQ's existing `Faction.isLineageCompatible(...)` bidirectional check (added by mekhq#8933) resolves the relationship correctly.

## Bug Fixed

The Nagelring is canonically an SLDF academy, but the planet owner is the Lyran Commonwealth (LA, House Steiner). MekHQ's academy access filter checks the planet owner's faction, so an SL-origin character is denied access even though they're part of the institution the academy was built for. This blocks Star League roleplay for the most prestigious SLDF academy.

Illiani's earlier comment on the issue marked it "wontfix" because of the assumed need for a significant Education-system rework. With the lineage support being added in [mekhq#8933](https://github.com/MegaMek/mekhq/pull/8933) (fixes [mekhq#8915](https://github.com/MegaMek/mekhq/issues/8915)), the data fix here is the only remaining piece — the rework isn't needed.

## Changes Made

- `SL.yml` gains `fallBackFactions` listing the canonical Star League member states:
  - Terran Hegemony (`TH`)
  - Lyran Commonwealth (`LA`)
  - Federated Suns (`FS`)
  - Capellan Confederation (`CC`)
  - Free Worlds League (`FWL`)
  - Draconis Combine (`DC`)
  - Magistracy of Canopus (`MOC`)
  - Outworlds Alliance (`OA`)
  - Rim Worlds Republic (`RWR`)
  - Taurian Concordat (`TC`)

The Periphery four (MOC, OA, RWR, TC) were forced into membership during the Reunification War — including them keeps the data complete for any Periphery-origin character roleplaying SLDF academy access during the SL era.

## Files Changed

- `data/universe/factions/SL.yml` — adds 11 lines (the fallBackFactions block) before the existing `tags:` field

## Pattern alignment

Conceptually identical to [`FC.yml`'s existing `fallBackFactions: [LA, FS]`](https://github.com/MegaMek/mm-data/blob/main/data/universe/factions/FC.yml) which describes the Federated Commonwealth's predecessor states. This PR extends the same pattern to the Star League's member states.

## Source verification

Field Manual: SLDF p.21 confirms SL membership and SLDF presence on member-state worlds. Reunification War sourcebook confirms the Periphery membership. The Nagelring's lore-canonical SLDF training role is well-documented across multiple sourcebooks.

## Testing

- `SL.yml` parses cleanly via Python YAML loader
- `fallBackFactions` parses to a 10-element list of correct strings
- All 10 referenced faction codes verified to exist in `data/universe/factions/`

## How to verify in-game once merged

**Both** [mekhq#8933](https://github.com/MegaMek/mekhq/pull/8933) **and this PR** must be merged for verification:

1. Start a 2700-era campaign with faction Star League
2. Create a SL-origin character
3. Open Academies → The Nagelring (Tharkad)
4. Apply — should now succeed (currently denied)