### PR TITLE
Mark national military academies as faction-restricted (Fixes #335)

### DIFF
--- a/data/universe/academies/Prestigious Academies.xml
+++ b/data/universe/academies/Prestigious Academies.xml
@@ -570,6 +570,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
         <closureYear>2779</closureYear>
         <tuition>7350</tuition>
@@ -600,6 +602,8 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
         <closureYear>2779</closureYear>
         <tuition>12600</tuition>
@@ -912,6 +916,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Blackjack School of Conflict is a private military academy within the Lyran Commonwealth known for its unorthodox curriculum. Founded by tutors who failed entrance exams at other academies, it offers courses that include unofficial lessons on the shadier aspects of military life.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Blackjack</locationSystem>
         <constructionYear>2714</constructionYear>
         <destructionYear>3050</destructionYear>
@@ -1596,6 +1602,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The École Militaire stands as the most renowned academy in the Taurian Concordat, offering courses covering almost every form of modern warfare. Renowned for producing elite MekWarriors, armor, and infantry units, the academy admits foreign applicants with a preference for Taurians.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>2500</constructionYear>
         <destructionYear>3078</destructionYear>
@@ -1633,6 +1641,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Devastated during the Jihad, the Ecole Militaire now relies on wounded troops as temporary instructors, reminding cadets of its loss. Renowned for producing elite MekWarriors, armor, and infantry units, the academy admits foreign applicants with a preference for Taurians. Rigorous basic training precedes specialization in armor, infantry, or MekWarrior tracks, emphasizing leadership and offering Officer Candidate School slots upon graduation.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>9625</tuition>
@@ -2053,6 +2063,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV becomes the new location for the college. With significant financial backing from the Federated Suns, the college focuses on training a new generation of leaders for various military roles.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kentares IV</locationSystem>
         <constructionYear>3085</constructionYear>
         <tuition>7500</tuition>
@@ -2089,6 +2101,8 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV becomes the new location for the college. With significant financial backing from the Federated Suns, the college focuses on training a new generation of leaders for various military roles.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kentares IV</locationSystem>
         <constructionYear>3085</constructionYear>
         <tuition>14063</tuition>
@@ -2473,6 +2487,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The esteemed Gershwin Academy of Combat, a private institution founded by the Gershwin Mining Collective, specializes in honing the skills of MekWarrior and armored cavalry. Graduates emerge well-equipped for diverse combat scenarios, instilled with discipline and strategic prowess. Aspiring warriors flock to GAC for its distinguished legacy and commitment to producing elite combat personnel.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Zollikofen</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>15750</tuition>
@@ -2820,6 +2836,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace, hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing mental and physical tests.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>4375</tuition>
@@ -2838,6 +2856,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace, hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing mental and physical tests.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>4375</tuition>
@@ -2862,6 +2882,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Illiushin Taurian Academy is a small academy within the Taurian Concordat that trains conventional troops, alongside a program of IndustrialMek training.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Illiushin</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>8750</tuition>
@@ -3564,6 +3586,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Lyons School of Combat Preparedness is a publicly funded training institution renowned for its diverse student body, hailing from the Draconis Combine, Free Worlds League, and beyond.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Lyons</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>14583</tuition>
@@ -3742,6 +3766,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators, cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates are well-versed in both maintaining order and engaging in combat within the Reaches.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Fronc</locationSystem>
         <constructionYear>3075</constructionYear>
         <tuition>13125</tuition>
@@ -3760,6 +3786,8 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators, cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates are well-versed in both maintaining order and engaging in combat within the Reaches.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Fronc</locationSystem>
         <constructionYear>3075</constructionYear>
         <tuition>13125</tuition>
@@ -6543,6 +6571,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna March, the academy opened its doors to all, becoming known as an independent school for mercenaries.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sarna</locationSystem>
         <constructionYear>3057</constructionYear>
         <closureYear>3070</closureYear>
@@ -6624,6 +6654,8 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns. Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Rockwellawan</locationSystem>
         <constructionYear>3081</constructionYear>
         <destructionYear>3088</destructionYear>
@@ -6661,6 +6693,8 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns. Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions. In 3088, the academy was devastated by a pirate attack, but plans for reconstruction were immediate, underscoring its importance in local defense and officer training.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Rockwellawan</locationSystem>
         <constructionYear>3095</constructionYear>
         <tuition>10938</tuition>
@@ -8388,6 +8422,8 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Warner MekWarrior Academy on Solaris VII is a small and informal training school for aspiring MekWarriors, founded by the second-rate arena fighter and con man Clease Vanderholf. Training is conducted using four poorly maintained Chameleons.</description>
+        <factionDiscount>0</factionDiscount>
+        <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Solaris</locationSystem>
         <constructionYear>3000</constructionYear>
         <destructionYear>3068</destructionYear>


### PR DESCRIPTION
## Summary

Adds `<isFactionRestricted>true</isFactionRestricted>` (plus the matching `<factionDiscount>0</factionDiscount>` field) to 18 academies tagged `<isMilitary>true</isMilitary>` that were missing it. These appeared in the academy picker for any character regardless of origin faction — including pirates, mercenaries, and meta-faction characters — which is canonically wrong for state-affiliated national military academies.

Surfaced during testing of [mm-data#334](https://github.com/MegaMek/mm-data/pull/334) (Star League academy lineage). When that PR's MERC-control test ran, the only 4 academies appearing for a Mercenary-origin character were those misconfigured as unrestricted (Annapolis Naval Academy, Blackjack School of Conflict, Ecole Militaire, Raina University on Skye). The lineage logic was correctly filtering everything else; these slipped through because of incorrect data.

## Bug Fixed

Annapolis Naval Academy on Terra (the canonical U.S. Navy officer commissioning school analogue) appeared for any character. Sister academies like West Point Military Academy and Sandhurst Royal Military College are correctly restricted; Annapolis was the visible inconsistency that triggered the broader audit.

## Changes Made

Eighteen entries flipped to faction-restricted:

**Terra:** Annapolis Naval Academy + (Officer)

**National state academies:**
- Blackjack School of Conflict (Blackjack — FedSuns)
- Ecole Militaire + [3130] (Taurus — Taurian Concordat)
- Focht War College + (Officer) [Kentares IV] (ComStar — named for Anastasius Focht)
- Gershwin Academy of Combat (Zollikofen — Lyran)
- Humphreys Training Academy + (Semester One) [3079] (Andurien)
- Illiushin Taurian Academy (Illiushin — TC)
- Lyons School of Combat Preparedness (Lyons — Skye/LA)
- Marshalry Academy + (Officer) (Fronc — Fronc Reaches)
- Sarna Martial Academy [3057] (Sarna — Sarna Supremacy/CC)
- Sentinelry Academy + [3095] (Rockwellawan — TC area)
- Warner MekWarrior Academy (Solaris)

The matching `<factionDiscount>0</factionDiscount>` field is also added per the existing convention used by other restricted academies (Sandhurst, West Point, etc.).

For the Annapolis pair specifically: the existing `Annapolis Naval Academy [ComStar]` variant (constructionYear 2779+) is already correctly restricted, so the unrestricted entries appear to have been intended as the pre-ComStar TH/SL-era versions. Restricting them now means SL-era characters access via the lineage relationships established in mm-data#334 (built on mekhq#8933).

## Files Changed

- `data/universe/academies/Prestigious Academies.xml` — 36 lines added (one `<factionDiscount>` + one `<isFactionRestricted>` per entry)

## Intentionally NOT changed

Thirteen academies tagged `isMilitary=true` were left unrestricted because they're commercial mercenary training establishments that accept students from anywhere by their business model:

- Brotherhood Monastery (Randis IV — mercenary order)
- Gunslinger Program [3062] (Tukayyid)
- Hero Training Institute (6 worlds — commercial chain)
- Outreach Mercenary Training Command (4 grade tiers — Wolf's Dragoons commercial)
- Tri-M Mercenary Academy (Outreach)

Plus one borderline entry (`Raina University on Skye` — civilian university with military programs) which was also left unrestricted.

## Testing

- XML parses cleanly via Python ElementTree (262 academies total intact)
- Restricted-academy count: was 211, now 229 (+18)
- No code change needed — existing access logic handles the field correctly

## How to verify in-game once merged

1. Create a Mercenary-origin character at any era
2. Open the academy picker with a wide jump radius (200ly+ around Terra)
3. **Before this PR**: Annapolis Naval Academy appeared in the dropdown
4. **After this PR**: Annapolis no longer appears for MERC origin (only the truly-open commercial mercenary academies + civilian universities remain)

Same scenario before: SL-origin character at 2700-era — Annapolis now correctly shows via SL→TH bidirectional lineage (Terra was TH-owned during SL era), instead of showing for everyone.