### PR TITLE
Added Missing SPA to defaultspa.xml; Updated Oblique Attacker

### DIFF
--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -95,6 +95,15 @@
         </skillPrereq>
     </ability>
     <ability>
+        <lookupName>hvy_lifter</lookupName>
+        <xpCost>100</xpCost>
+        <originOnly>false</originOnly>
+        <weight>1</weight>
+        <skillPrereq>
+            <skill>Piloting/Mek::Regular</skill>
+        </skillPrereq>
+    </ability>
+    <ability>
         <lookupName>maneuvering_ace</lookupName>
         <xpCost>100</xpCost>
         <originOnly>false</originOnly>
@@ -354,7 +363,7 @@
         <xpCost>100</xpCost>
         <originOnly>false</originOnly>
         <weight>3</weight>
-        <invalidAbilities>oblique_attacker::sandblaster</invalidAbilities>
+        <invalidAbilities>cluster_hitter</invalidAbilities>
         <skillPrereq>
             <skill>Gunnery/Mek::Regular</skill>
             <skill>Gunnery/ProtoMek::Regular</skill>


### PR DESCRIPTION
Fix #350 
FIx #351

- Added missing Heavy Lifter SPA, making it available to MekHQ
- Updated Invalids for Oblique Attacker to match ATOW:Companion

Addendum, a number of SPAs has RP skills as requirements, it could be possible to add these skills as requirements at a later date. The last time SPAs were updated predated the introduction of the RP skills.