### PR TITLE
Fix #353, Added Air Cav & Conv Aircraft Courses to Military Academy; Removed Extraneous Text

### DIFF
--- a/data/universe/academies/Local Academies.xml
+++ b/data/universe/academies/Local Academies.xml
@@ -187,7 +187,7 @@
         <ageMin>16</ageMin>
         <qualification>General Studies</qualification>
         <curriculum>Interest/Other</curriculum>
-        <qualificationStartYear>2300</qualificationStartYear>Sure, here are the elements sorted alphabetically, keeping the tags in the same order:
+        <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Biology</qualification>
         <curriculum>Science/Biology</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
@@ -398,7 +398,7 @@
         <qualification>Naval Bootcamp</qualification>
         <curriculum>Gunnery/Vehicle, Piloting/Naval</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
-        <qualification>Flight School</qualification>
+        <qualification>Flight A</qualification>
         <curriculum>Gunnery/Aircraft, Piloting/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Infantry Bootcamp</qualification>
@@ -445,6 +445,12 @@
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Naval Academy</qualification>
         <curriculum>Gunnery/Vehicle, Piloting/Naval, Sensor Operations</curriculum>
+        <qualificationStartYear>2300</qualificationStartYear>
+        <qualification>Air Cavalry Academy</qualification>
+        <curriculum>Gunnery/Vehicle, Piloting/VTOL, Sensor Operations</curriculum>
+        <qualificationStartYear>2300</qualificationStartYear>
+        <qualification>Flight Academy</qualification>
+        <curriculum>Gunnery/Aircraft, Piloting/Aircraft, Sensor Operations</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
     </academy>
     <academy>

--- a/data/universe/academies/Local Academies.xml
+++ b/data/universe/academies/Local Academies.xml
@@ -398,7 +398,7 @@
         <qualification>Naval Bootcamp</qualification>
         <curriculum>Gunnery/Vehicle, Piloting/Naval</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
-        <qualification>Flight A</qualification>
+        <qualification>Flight School</qualification>
         <curriculum>Gunnery/Aircraft, Piloting/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Infantry Bootcamp</qualification>


### PR DESCRIPTION
Fix #353
Fix #349

- Removed extraneous text.
- Added Air Cav Academy to Military Academy  (Gunnery/Vehicle, Piloting/VTOL, Sensor Operations)
- Added Conv. Aircraft Academy to Military Academy (Gunnery/Aircraft, Piloting/Aircraft, Sensor Operations)