### PR TITLE
Close #371: Added Disclaimer to Recon Scenarios Advising of Use of Double-Blind, Decreased Scenario Durations, Increased Scenario Map Size

### DIFF
--- a/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -20,7 +20,9 @@
 <ScenarioTemplate>
     <name>Heavy Recon Evasion</name>
     <shortBriefing>Evade patrols while scanning enemy heavies.</shortBriefing>
-    <detailedBriefing><![CDATA[You are to advance toward an overwhelming enemy position and gather intelligence on their strength. This is a high-risk reconnaissance mission, and direct engagement is not an option. Stealth, speed, and deception will be your greatest assets.
+    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+
+You are to advance toward an overwhelming enemy position and gather intelligence on their strength. This is a high-risk reconnaissance mission, and direct engagement is not an option. Stealth, speed, and deception will be your greatest assets.
 
 If you are compromised, expect a swift and overwhelming response. Avoid unnecessary confrontations and prioritize evasion over combat. At least one of your units must survive.
 
@@ -129,7 +131,7 @@ The enemy will control the field at the end of the engagement, meaning there wil
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>5</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>

--- a/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -39,7 +39,7 @@ The enemy will control the field at the end of the engagement, meaning there wil
         <mapLocation>AllGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>0</additionalMapSheetWide>
+        <additionalMapSheetWide>1</additionalMapSheetWide>
         <widthScalingIncrement>10</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>

--- a/data/scenariotemplates/Recon Evasion.xml
+++ b/data/scenariotemplates/Recon Evasion.xml
@@ -20,7 +20,9 @@
 <ScenarioTemplate>
     <name>Recon Evasion</name>
     <shortBriefing>Evade patrols until scan is complete.</shortBriefing>
-    <detailedBriefing><![CDATA[We have a rare opportunity to gather critical intelligence on enemy operations by monitoring their movements. Your mission is to remain in position for the required duration, observing and collecting data on enemy activity while avoiding direct engagement. The information you gather will be far more valuable than any destruction you could inflict.
+    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+
+We have a rare opportunity to gather critical intelligence on enemy operations by monitoring their movements. Your mission is to remain in position for the required duration, observing and collecting data on enemy activity while avoiding direct engagement. The information you gather will be far more valuable than any destruction you could inflict.
 
 The enemy is unaware of our presence, but if discovered, they will respond with overwhelming force. Stealth and discretion are paramount—engage only if absolutely necessary, and prioritize survival over combat. Avoid unnecessary detection, maintain a low profile, and ensure you remain operational for the duration of the mission.
 
@@ -134,7 +136,7 @@ The enemy will control the field at the end of the engagement, meaning there wil
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>5</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>

--- a/data/scenariotemplates/Recon Evasion.xml
+++ b/data/scenariotemplates/Recon Evasion.xml
@@ -39,7 +39,7 @@ The enemy will control the field at the end of the engagement, meaning there wil
         <mapLocation>AllGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>0</additionalMapSheetWide>
+        <additionalMapSheetWide>1</additionalMapSheetWide>
         <widthScalingIncrement>10</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>

--- a/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -39,7 +39,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>AllGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>0</additionalMapSheetWide>
+        <additionalMapSheetWide>1</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>

--- a/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -20,7 +20,9 @@
 <ScenarioTemplate>
     <name>Reconnaissance Interdiction</name>
     <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+
+Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
 
 Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
 
@@ -132,7 +134,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             <objectiveCriterion>Destroy</objectiveCriterion>
             <percentage>95</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>


### PR DESCRIPTION
Close #371

- All recon scenarios (offensive and defensive) now advise the player to use Double Blind
- All recon scenarios have had their duration halved
- All recon scenarios have had their map width increased by one map