### PR TITLE
Fix #368: Stopped Enemy Commanders From Turning up in Industrial Meks

### DIFF
--- a/data/scenariomodifiers/AlliedOfficerMek.xml
+++ b/data/scenariomodifiers/AlliedOfficerMek.xml
@@ -51,8 +51,5 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
-        <roleChoices>
-            <forceRole>COMMAND</forceRole>
-        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/data/scenariomodifiers/EnemyCommanderMek.xml
+++ b/data/scenariomodifiers/EnemyCommanderMek.xml
@@ -51,8 +51,5 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>OpFor</syncedForceName>
         <useArtillery>false</useArtillery>
-        <roleChoices>
-            <forceRole>COMMAND</forceRole>
-        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/data/scenariomodifiers/EnemyOfficerMek.xml
+++ b/data/scenariomodifiers/EnemyOfficerMek.xml
@@ -51,8 +51,5 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>OpFor</syncedForceName>
         <useArtillery>false</useArtillery>
-        <roleChoices>
-            <forceRole>COMMAND</forceRole>
-        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/data/scenariomodifiers/FacilityAlliedEvac.xml
+++ b/data/scenariomodifiers/FacilityAlliedEvac.xml
@@ -48,8 +48,12 @@
         <useArtillery>false</useArtillery>
         <roleChoices>
             <forceRole>CIVILIAN</forceRole>
-            <forceRole>CARGO</forceRole>
             <forceRole>SUPPORT</forceRole>
+            <forceRole>SUPPORT</forceRole>
+            <forceRole>CARGO</forceRole>
+            <forceRole>CARGO</forceRole>
+            <forceRole>CARGO</forceRole>
+            <forceRole>APC</forceRole>
             <forceRole>APC</forceRole>
         </roleChoices>
     </forceDefinition>

--- a/data/scenariomodifiers/FacilityHostilePreventEvac.xml
+++ b/data/scenariomodifiers/FacilityHostilePreventEvac.xml
@@ -49,8 +49,12 @@
         <useArtillery>false</useArtillery>
         <roleChoices>
             <forceRole>CIVILIAN</forceRole>
-            <forceRole>CARGO</forceRole>
             <forceRole>SUPPORT</forceRole>
+            <forceRole>SUPPORT</forceRole>
+            <forceRole>CARGO</forceRole>
+            <forceRole>CARGO</forceRole>
+            <forceRole>CARGO</forceRole>
+            <forceRole>APC</forceRole>
             <forceRole>APC</forceRole>
         </roleChoices>
     </forceDefinition>

--- a/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/data/scenariomodifiers/HouseOfficerGround.xml
@@ -52,8 +52,5 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
-        <roleChoices>
-            <forceRole>COMMAND</forceRole>
-        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/data/scenariomodifiers/LiaisonGround.xml
+++ b/data/scenariomodifiers/LiaisonGround.xml
@@ -52,8 +52,5 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
-        <roleChoices>
-            <forceRole>COMMAND</forceRole>
-        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/data/scenariotemplates/Assassination.xml
+++ b/data/scenariotemplates/Assassination.xml
@@ -124,9 +124,6 @@ We expect a fierce but contained battle. Your forces will be operating behind en
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
-                <roleChoices>
-                    <forceRole>APC</forceRole>
-                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Assassination.xml
+++ b/data/scenariotemplates/Assassination.xml
@@ -125,7 +125,6 @@ We expect a fierce but contained battle. Your forces will be operating behind en
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>COMMAND</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/data/scenariotemplates/Convoy Escort.xml
+++ b/data/scenariotemplates/Convoy Escort.xml
@@ -137,7 +137,6 @@ We will control the field at the conclusion of the battle. This means you have f
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>CIVILIAN</forceRole>
                     <forceRole>SUPPORT</forceRole>
                     <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>

--- a/data/scenariotemplates/Convoy Interdiction.xml
+++ b/data/scenariotemplates/Convoy Interdiction.xml
@@ -129,7 +129,6 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>CIVILIAN</forceRole>
                     <forceRole>SUPPORT</forceRole>
                     <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>

--- a/data/scenariotemplates/Convoy Raid.xml
+++ b/data/scenariotemplates/Convoy Raid.xml
@@ -129,8 +129,12 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>CIVILIAN</forceRole>
+                    <forceRole>SUPPORT</forceRole>
+                    <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>APC</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/data/scenariotemplates/Critical Convoy Escort.xml
@@ -137,7 +137,6 @@ We will control the field at the end of the battle, giving you full authority to
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>CIVILIAN</forceRole>
                     <forceRole>SUPPORT</forceRole>
                     <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>

--- a/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -171,7 +171,12 @@ We will control the battlefield at the end of this engagement, allowing us to re
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
+                    <forceRole>SUPPORT</forceRole>
+                    <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>APC</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/data/scenariotemplates/VIP Ambush.xml
+++ b/data/scenariotemplates/VIP Ambush.xml
@@ -131,8 +131,6 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>APC</forceRole>
-                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/VIP Ambush.xml
+++ b/data/scenariotemplates/VIP Ambush.xml
@@ -131,7 +131,6 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>COMMAND</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/data/scenariotemplates/VIP Defense.xml
+++ b/data/scenariotemplates/VIP Defense.xml
@@ -98,7 +98,6 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>COMMAND</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/data/scenariotemplates/VIP Defense.xml
+++ b/data/scenariotemplates/VIP Defense.xml
@@ -97,9 +97,6 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
-                <roleChoices>
-                    <forceRole>APC</forceRole>
-                </roleChoices>
             </value>
         </entry>
         <entry>


### PR DESCRIPTION
Fix #368

This bug was caused by several support units also having the 'COMMAND' tag, resulting in some rather... _interesting_ choices...