### PR TITLE
Fixed Two Instances Where `Gunnery/Battlesuit` Was Incorrectly Cited Instead of `Gunnery/BattleArmor`

### DIFF
--- a/data/campaignPresets/1 - New Player Preset.xml
+++ b/data/campaignPresets/1 - New Player Preset.xml
@@ -2793,6 +2793,7 @@
             <removeAbilities></removeAbilities>
             <skillPrereq>
                 <skill>Small Arms::Regular</skill>
+                <skill>Gunnery/BattleArmor::Regular</skill>
             </skillPrereq>
         </ability>
         <ability>
@@ -3308,6 +3309,7 @@
                 <skill>Gunnery/Spacecraft::Veteran</skill>
                 <skill>Gunnery/Aerospace::Veteran</skill>
                 <skill>Gunnery/Vehicle::Veteran</skill>
+                <skill>Gunnery/BattleArmor::Veteran</skill>
             </skillPrereq>
         </ability>
         <ability>

--- a/data/campaignPresets/2 - Veteran Player Preset.xml
+++ b/data/campaignPresets/2 - Veteran Player Preset.xml
@@ -2772,6 +2772,7 @@
             <removeAbilities></removeAbilities>
             <skillPrereq>
                 <skill>Small Arms::Regular</skill>
+                <skill>Gunnery/BattleArmor::Regular</skill>
             </skillPrereq>
         </ability>
         <ability>
@@ -3287,6 +3288,7 @@
                 <skill>Gunnery/Spacecraft::Veteran</skill>
                 <skill>Gunnery/Aerospace::Veteran</skill>
                 <skill>Gunnery/Vehicle::Veteran</skill>
+                <skill>Gunnery/BattleArmor::Veteran</skill>
             </skillPrereq>
         </ability>
         <ability>

--- a/data/campaignPresets/3 - Arcade Mode Preset.xml
+++ b/data/campaignPresets/3 - Arcade Mode Preset.xml
@@ -2563,6 +2563,7 @@
                 <skill>Gunnery/Spacecraft::Veteran</skill>
                 <skill>Gunnery/Aerospace::Veteran</skill>
                 <skill>Gunnery/Vehicle::Veteran</skill>
+                <skill>Gunnery/BattleArmor::Veteran</skill>
             </skillPrereq>
         </ability>
         <ability>
@@ -2714,6 +2715,7 @@
             <removeAbilities></removeAbilities>
             <skillPrereq>
                 <skill>Small Arms::Regular</skill>
+                <skill>Gunnery/BattleArmor::Regular</skill>
             </skillPrereq>
         </ability>
         <ability>

--- a/data/campaignPresets/4 - Campaign Operations Preset.xml
+++ b/data/campaignPresets/4 - Campaign Operations Preset.xml
@@ -2554,6 +2554,7 @@
                 <skill>Gunnery/Spacecraft::Veteran</skill>
                 <skill>Gunnery/Aerospace::Veteran</skill>
                 <skill>Gunnery/Vehicle::Veteran</skill>
+                <skill>Gunnery/BattleArmor::Veteran</skill>
             </skillPrereq>
         </ability>
         <ability>
@@ -2746,6 +2747,7 @@
             <removeAbilities></removeAbilities>
             <skillPrereq>
                 <skill>Small Arms::Regular</skill>
+                <skill>Gunnery/BattleArmor::Regular</skill>
             </skillPrereq>
         </ability>
         <ability>

--- a/data/universe/defaultspa.xml
+++ b/data/universe/defaultspa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -367,7 +367,7 @@
             <skill>Gunnery/Aircraft::Veteran</skill>
             <skill>Gunnery/Vehicle::Veteran</skill>
             <skill>Gunnery/Spacecraft::Veteran</skill>
-            <skill>Gunnery/Battlesuit::Veteran</skill>
+            <skill>Gunnery/BattleArmor::Veteran</skill>
             <skill>Gunnery/ProtoMek::Veteran</skill>
         </skillPrereq>
     </ability>
@@ -1412,7 +1412,7 @@ Furthermore, the character reduces the target number of all Sensor Operations ch
         <weight>3</weight>
         <skillPrereq>
             <skill>Small Arms::Regular</skill>
-            <skill>Gunnery/Battlesuit::Regular</skill>
+            <skill>Gunnery/BattleArmor::Regular</skill>
         </skillPrereq>
     </ability>
 


### PR DESCRIPTION
`Gunnery/Battlesuit` -> `Gunnery/BattleArmor`