### PR TITLE
Change Brunel and Lesseps cargo to correct type

### DIFF
--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Brunel Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Brunel Dump Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Brunel Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Brunel Dump Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.01-nightly-2026-06-13 on 2026-06-15
 <UnitType>
 LargeSupportTank
 </UnitType>
@@ -36,10 +36,6 @@ Brunel Dump Truck
 2637
 </year>
 
-<originalBuildYear>
-2637
-</originalBuildYear>
-
 <type>
 IS Level 3
 </type>
@@ -51,10 +47,6 @@ None
 <motion_type>
 Wheeled
 </motion_type>
-
-<transporters>
-cargobay:50.0:1:0::-1:0
-</transporters>
 
 <cruiseMP>
 3
@@ -107,6 +99,7 @@ Backhoe
 
 <Rear Equipment>
 Dumper (Rear)
+Cargo:SIZE:50.0
 </Rear Equipment>
 
 <barrating>
@@ -121,31 +114,13 @@ Dumper (Rear)
 3
 </engine_tech_rating>
 
-
-<source>
-TR:VAr
-</source>
-
-<tonnage>
-150.0
-</tonnage>
-
-<fuel>
-4.0
-</fuel>
-
-<fuelType>
-PETROCHEMICALS
-</fuelType>
-
-# Fluff Date: 2026-02-28 17:47:08
-<overview>
-<p>The Brunel Dump Truck is a massive large-wheeled support vehicle produced by Achernar Heavy Industries, first designed in 2637 to serve the ore extraction industry. Built around the demands of heavy strip-mining operations, the Brunel hauls enormous loads of raw ore and debris from extraction sites to processing facilities, handling work that would otherwise require multiple smaller vehicles. Although it competes against Earthwerks Incorporated's lighter Lesseps in overlapping markets, the Brunel's greater carrying capacity and economies of scale make it the preferred choice wherever mining volumes justify the investment in a larger machine. A distinctive subculture of heavy truck enthusiasts has grown up around the Brunel across the Inner Sphere, with racing and pulling competitions drawing drivers who modify their rigs well beyond factory specifications, a practice the manufacturer notes in its warranty documentation with conspicuous displeasure.</p>
-</overview>
-
 <capabilities>
 <p>At one hundred fifty tons, the Brunel represents the heavy end of wheeled support vehicle design. Its petrochemical internal combustion engine delivers a maximum speed of fifty kilometers per hour, modest for its class but adequate for the roads and rough terrain typical of active mining sites. The vehicle mounts four tons of commercial-grade armor at a barrier armor rating of six, providing basic protection against incidental hazards without the weight penalty of military-grade materials. This level of protection is sufficient for the industrial environments the Brunel is designed to operate in, but offers little meaningful resistance to any organized weapons fire.</p><p>The Brunel's most significant specification is its cargo capacity, with a standard load rating of fifty tons in its rear dump box. Its off-road chassis and controls modification allows it to navigate the ungraded terrain common to active extraction operations, and a forward-mounted backhoe enables the vehicle to load ore and debris without relying on separate equipment. The combination of heavy carrying capacity, integrated loading capability, and off-road mobility makes the Brunel the dominant tool in large-scale surface extraction, though its slow speed and thin armor make it entirely unsuitable for any combat role.</p>
 </capabilities>
+
+<overview>
+<p>The Brunel Dump Truck is a massive large-wheeled support vehicle produced by Achernar Heavy Industries, first designed in 2637 to serve the ore extraction industry. Built around the demands of heavy strip-mining operations, the Brunel hauls enormous loads of raw ore and debris from extraction sites to processing facilities, handling work that would otherwise require multiple smaller vehicles. Although it competes against Earthwerks Incorporated's lighter Lesseps in overlapping markets, the Brunel's greater carrying capacity and economies of scale make it the preferred choice wherever mining volumes justify the investment in a larger machine. A distinctive subculture of heavy truck enthusiasts has grown up around the Brunel across the Inner Sphere, with racing and pulling competitions drawing drivers who modify their rigs well beyond factory specifications, a practice the manufacturer notes in its warranty documentation with conspicuous displeasure.</p>
+</overview>
 
 <deployment>
 <p>The standard Brunel serves throughout the Inner Sphere wherever heavy surface mining operations are conducted, particularly at strip mines extracting heavy metals and industrial ores. Planetary defense forces and militia units have occasionally pressed Brunels into logistics service to move heavy equipment or supplies, taking advantage of their commercial availability and robust construction. The widespread subculture of competitive truck modification has also produced numerous performance variants tuned for racing and pulling competitions, though these fall well outside normal operational specifications.</p>
@@ -180,4 +155,21 @@ JUMP_JET:N/A
 COMMUNICATIONS:Unknown
 TARGETING:Unknown
 </systemModels>
+
+<source>
+TR:VAr
+</source>
+
+<tonnage>
+150.0
+</tonnage>
+
+<fuel>
+4.0
+</fuel>
+
+<fuelType>
+PETROCHEMICALS
+</fuelType>
+
 

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -15,7 +15,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 
-#Saved from version 0.50.12 on 2026-02-26
+#Saved from version 0.51.01-nightly-2026-06-13 on 2026-06-15
 <UnitType>
 SupportTank
 </UnitType>
@@ -36,10 +36,6 @@ Lesseps Dump Truck
 2523
 </year>
 
-<originalBuildYear>
-2523
-</originalBuildYear>
-
 <type>
 IS Level 3
 </type>
@@ -55,10 +51,6 @@ bad_rep_is
 <motion_type>
 Wheeled
 </motion_type>
-
-<transporters>
-cargobay:20.0:1:0::-1:0
-</transporters>
 
 <cruiseMP>
 3
@@ -103,6 +95,7 @@ Backhoe
 
 <Rear Equipment>
 Dumper (Rear)
+Cargo:SIZE:20.0
 </Rear Equipment>
 
 <barrating>
@@ -117,26 +110,13 @@ Dumper (Rear)
 3
 </engine_tech_rating>
 
-<source>
-TR:VAr
-</source>
-
-<tonnage>
-50.0
-</tonnage>
-
-<fuel>
-4.0
-</fuel>
-
-# Fluff Date: 2026-02-28 17:47:08
-<overview>
-<p>The Lesseps Dump Truck is a medium wheeled support vehicle produced by Earthwerks Incorporated, introduced in 2523 to serve the construction and mining industries across the Inner Sphere. At fifty tons, the Lesseps occupies a far more accessible market segment than heavier industrial vehicles, offering sufficient cargo capacity and off-road capability for typical construction operations at a price point that keeps it common across industrial sites throughout settled space. Earthwerks distributes the Lesseps through a network of production facilities scattered across the Inner Sphere, and the design has been a staple of planetary construction and mining firms since its introduction, despite a commercial reputation that has not always been kind to its manufacturer.</p>
-</overview>
-
 <capabilities>
 <p>The Lesseps operates on an electric battery power plant, providing a published range of over thirteen hundred kilometers on a single charge and a continuous operational window of approximately twenty-four hours before recharging is required. Its off-road chassis and controls modification, combined with an all-wheel drive system, allows the vehicle to operate effectively on ungraded terrain typical of active construction and mining sites. The rear dump bed carries up to twenty tons of cargo, and a forward-mounted backhoe provides integrated loading capability. These features make the Lesseps a practical and self-sufficient tool for sites that lack dedicated loading infrastructure.</p><p>Protection is limited to two and a half tons of commercial armor at a barrier armor rating of five, leaving the vehicle vulnerable to even modest weapons fire. It carries no armament and relies entirely on distance from hostile forces or armed escort for survivability. The vehicle carries the Bad Reputation design quirk as a formal acknowledgment of documented quality failures that became widely known across the Inner Sphere market, a mechanical and commercial liability that buyers factor into procurement decisions.</p>
 </capabilities>
+
+<overview>
+<p>The Lesseps Dump Truck is a medium wheeled support vehicle produced by Earthwerks Incorporated, introduced in 2523 to serve the construction and mining industries across the Inner Sphere. At fifty tons, the Lesseps occupies a far more accessible market segment than heavier industrial vehicles, offering sufficient cargo capacity and off-road capability for typical construction operations at a price point that keeps it common across industrial sites throughout settled space. Earthwerks distributes the Lesseps through a network of production facilities scattered across the Inner Sphere, and the design has been a staple of planetary construction and mining firms since its introduction, despite a commercial reputation that has not always been kind to its manufacturer.</p>
+</overview>
 
 <deployment>
 <p>The Lesseps is deployed across the Inner Sphere at construction sites, open-pit mines, and light industrial facilities wherever a medium-duty dump vehicle is required. Its affordability and widespread availability through Earthwerks' multi-site distribution network make it the default choice for smaller operations that cannot justify heavier equipment. Military forces have occasionally requisitioned available Lesseps vehicles for logistics support in low-intensity operations, particularly for debris clearing and supply movement in rear areas where its limited protection is less of a liability.</p>
@@ -171,4 +151,17 @@ JUMP_JET:N/A
 COMMUNICATIONS:Unknown
 TARGETING:Unknown
 </systemModels>
+
+<source>
+TR:VAr
+</source>
+
+<tonnage>
+50.0
+</tonnage>
+
+<fuel>
+4.0
+</fuel>
+
 


### PR DESCRIPTION
Changes the cargo on the Brunel and Lesseps support vehicles from a transport bay to standard vehicle cargo appropriately attached to the dumper. This allows the dumper's weight to be properly calculated and eliminates excess tonnage on the vehicles.  Other changes are just updates due to version differences. 

Closes #407. 