### PR TITLE
Removed destroy metadata from sensor 4

### DIFF
--- a/data/images/recordsheets/templates_us/naval_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/naval_dualturret_standard.svg
@@ -359,7 +359,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/naval_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/naval_dualturret_superheavy.svg
@@ -784,7 +784,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/naval_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/naval_noturret_standard.svg
@@ -783,7 +783,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/naval_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/naval_noturret_superheavy.svg
@@ -782,7 +782,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/naval_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/naval_turret_standard.svg
@@ -807,7 +807,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/naval_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/naval_turret_superheavy.svg
@@ -781,7 +781,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/submarine_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/submarine_dualturret_standard.svg
@@ -1699,7 +1699,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.32001"

--- a/data/images/recordsheets/templates_us/submarine_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/submarine_dualturret_superheavy.svg
@@ -3505,7 +3505,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.32001"

--- a/data/images/recordsheets/templates_us/submarine_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/submarine_noturret_standard.svg
@@ -3645,7 +3645,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.32001"

--- a/data/images/recordsheets/templates_us/submarine_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/submarine_noturret_superheavy.svg
@@ -3528,7 +3528,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.32001"

--- a/data/images/recordsheets/templates_us/submarine_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/submarine_turret_standard.svg
@@ -3617,7 +3617,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.32001"

--- a/data/images/recordsheets/templates_us/submarine_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/submarine_turret_superheavy.svg
@@ -781,7 +781,7 @@
         <text x="106.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text253">+2</text>
         <path fill="none" d="M 113.32,1.315 C 113.32,0.589 113.909,0 114.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 121.32,7.411 120.731,8 120.005,8 h -5.37 C 113.909,8 113.32,7.411 113.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_3" />
         <text x="117.32" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="4.8000002" lengthAdjust="spacingAndGlyphs" id="text254">+3</text>
-        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" destroy="1" id="sensor_hit_4" />
+        <path fill="none" d="M 124.32,1.315 C 124.32,0.589 124.909,0 125.635,0 h 5.37 c 0.726,0 1.315,0.589 1.315,1.315 v 5.37 C 132.32,7.411 131.731,8 131.005,8 h -5.37 C 124.909,8 124.32,7.411 124.32,6.685 Z" stroke-width="0.96" stroke-linejoin="round" stroke="#000000" id="sensor_hit_4" />
         <text x="128.32001" y="6" fill="#000000" text-anchor="middle" style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile" textLength="3.7160001" lengthAdjust="spacingAndGlyphs" id="text255">D</text>
       </g>
       <g transform="translate(6,43.017)" id="g259">

--- a/data/images/recordsheets/templates_us/vehicle_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/vehicle_dualturret_standard.svg
@@ -1698,7 +1698,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vehicle_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/vehicle_dualturret_superheavy.svg
@@ -1698,7 +1698,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vehicle_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/vehicle_noturret_standard.svg
@@ -1653,7 +1653,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vehicle_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/vehicle_noturret_superheavy.svg
@@ -1653,7 +1653,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vehicle_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/vehicle_turret_standard.svg
@@ -1673,7 +1673,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vehicle_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/vehicle_turret_superheavy.svg
@@ -1673,7 +1673,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vtol_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/vtol_noturret_standard.svg
@@ -1682,7 +1682,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/vtol_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/vtol_turret_standard.svg
@@ -1702,7 +1702,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/wige_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/wige_dualturret_standard.svg
@@ -1698,7 +1698,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/wige_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/wige_noturret_standard.svg
@@ -1653,7 +1653,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"

--- a/data/images/recordsheets/templates_us/wige_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/wige_turret_standard.svg
@@ -1673,7 +1673,6 @@
            stroke-width="0.96"
            stroke-linejoin="round"
            stroke="#000000"
-           destroy="1"
            id="sensor_hit_4" />
         <text
            x="128.320"


### PR DESCRIPTION
This PR removes the attr destroy=1 from the sensor 4 checkbox.


(PR is slightly dirty because is built on https://github.com/MegaMek/mm-data/pull/421 )