### PR TITLE
Added 120 New Call Signs (by radar651)

### DIFF
--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -1798,7 +1798,6 @@ Derpy,1
 Dervish,1
 Desert,1
 Desire,1
-Desislava,1
 Desk Jockey,1
 Desolate,1
 Despair,1
@@ -2327,7 +2326,7 @@ Fine-line,1
 Fingers,1
 Finish Line,1
 Finn,1
-Finnback,1
+Finback,1
 Fire,1
 Fire Cat,1
 Firearm,1
@@ -2361,7 +2360,7 @@ Fishcan,1
 Fisher,1
 Fisherman,1
 Fisticuffs,1
-Five ton,1
+Five Ton,1
 Fix-It,1
 Fixer,1
 Fizz,1
@@ -2388,7 +2387,7 @@ Flash,1
 Flash Fried,1
 Flashback,1
 Flashbang,1
-Flashdrive,1
+Flash Drive,1
 Flashfire,1
 Flashlight,1
 Flashpoint,1
@@ -2416,7 +2415,7 @@ Flipflop,1
 Flipper,1
 Float,1
 Flood,1
-Floor tack,1
+Floor Tack,1
 Floorboard,1
 Floppy,1
 Flora,1
@@ -2635,7 +2634,6 @@ Gentleman,1
 Gentry,1
 Geode,1
 Geoduck,1
-Gepard,1
 Geranium,1
 Gerbil,1
 Geronimo,1
@@ -3055,7 +3053,7 @@ Hermes,1
 Hermit,1
 Hero,1
 Herringbone,1
-Hesh,1
+HESH,1
 Hewer,1
 Hex,1
 Hexbolt,1
@@ -3074,7 +3072,7 @@ High Life,1
 High Noon,1
 High Roller,1
 High Score,1
-High speed,1
+High Speed,1
 High Voltage,1
 Highball,1
 Highbrow,1
@@ -5789,7 +5787,6 @@ Shieldbreaker,1
 Shieldmaiden,1
 Shifter,1
 Shifty,1
-Shilka,1
 Shill,1
 Shimmer,1
 Shindig,1
@@ -6131,7 +6128,7 @@ South,1
 Southpaw,1
 Souvlaki,1
 Sovereign,1
-Spaag,1
+SPAAG,1
 Spacer,1
 Spaceship,1
 Spacey,1
@@ -6366,7 +6363,6 @@ Stream,1
 Street Rat,1
 Streetlamp,1
 Streetwise,1
-Strella,1
 Strength,1
 Stress,1
 Stretch,1
@@ -7209,7 +7205,7 @@ Weightless,1
 Weld,1
 Welder,1
 Welfare,1
-Well done,1
+Well Done,1
 Wellspring,1
 Werewolf,1
 West,1

--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -162,6 +162,7 @@ Anecdote,1
 Anemone,1
 Angel,1
 Anger,1
+Anger Management,1
 Angora,1
 Angry,1
 Angst,1
@@ -331,6 +332,7 @@ Babs,1
 Baby,1
 Bacchus,1
 Back Alley,1
+Backdoor,1
 Backdraft,1
 Backfire,1
 Backfist,1
@@ -374,6 +376,7 @@ Ballistic,1
 Balloon,1
 Ballroom,1
 Balm,1
+Baloney,1
 Bam Bam,1
 Bambi,1
 Bamboo,1
@@ -540,6 +543,7 @@ Big Brain,1
 Big Country,1
 Big Dog,1
 Big Gulp,1
+Big Iron,1
 Big League,1
 Big Mac,1
 Big McLargeHuge,1
@@ -589,6 +593,7 @@ Bjorn,1
 Black,1
 Black Cat,1
 Black Hole,1
+Black Ice,1
 Black Knight,1
 Black Magic,1
 Black Powder,1
@@ -599,8 +604,10 @@ Blackbeard,1
 Blackberry,1
 Blackbird,1
 Blackboard,1
+Blackbox,1
 Blackdog,1
 Blackflame,1
+Blackhawk,1
 Blackhole,1
 Blackjack,1
 Blacklist,1
@@ -708,8 +715,10 @@ Bollard,1
 Bolo,1
 Bolt,1
 Bomb,1
+Bombardier,1
 Bomber,1
 Bombshell,1
+Bombsight,1
 Bonanza,1
 Bond,1
 Bone,1
@@ -766,6 +775,7 @@ Boudica,1
 Boulder,1
 Boulevard,1
 Bouncer,1
+Bouncing Betty,1
 Bounty,1
 Bouquet,1
 Bowler,1
@@ -773,6 +783,7 @@ Bowline,1
 Bowling Ball,1
 Bowtie,1
 Boxcar,1
+Boxcutter,1
 Boxer,1
 Boysenberry,1
 Bozo,1
@@ -911,6 +922,7 @@ Bunyip,1
 Buoy,1
 Buraq,1
 Burger,1
+Burger Demon,1
 Burglar,1
 Burlap,1
 Burlesque,1
@@ -926,6 +938,7 @@ Bushel,1
 Bushido,1
 Bushwacker,1
 Busker,1
+Busky,1
 Buster,1
 Bustle,1
 Busybee,1
@@ -934,8 +947,10 @@ Butch,1
 Butcher,1
 Butler,1
 Butter,1
+Butter Bars,1
 Buttercream,1
 Buttercup,1
+Butterfingers,1
 Butterfly,1
 Butterscotch,1
 Button,1
@@ -981,6 +996,7 @@ Caliper,1
 Caller,1
 Calliope,1
 Callisto,1
+Callsign,1
 Calm,1
 Caltrop,1
 Calypso,1
@@ -1010,6 +1026,8 @@ Candy Corn,1
 Candyman,1
 Canine,1
 Canis,1
+Canister,1
+Canister Shot,1
 Cannibal,1
 Cannon,1
 Cannonball,1
@@ -1055,6 +1073,7 @@ Carpet,1
 Carrack,1
 Carrion,1
 Carrot,1
+Carryall,1
 Carte Blanche,1
 Cartel,1
 Cartographer,1
@@ -1125,6 +1144,7 @@ Cerulean,1
 Cesspool,1
 Cetus,1
 Chain,1
+Chain Gang,1
 Chainlink,1
 Chainsaw,1
 Chairman,1
@@ -1301,6 +1321,7 @@ Cliff,1
 Climax,1
 Clip,1
 Clipper,1
+Clippy,1
 Cloak,1
 Cloakfang,1
 Clobber,1
@@ -1338,6 +1359,7 @@ Cobra,1
 Cobweb,1
 Cockatrice,1
 Cockroach,1
+Cocktail,1
 Coco,1
 Cocoa,1
 Coconut,1
@@ -1422,6 +1444,7 @@ Cookies,1
 Cool Hand,1
 Coolant,1
 Cooler,1
+Coop,1
 Cooper,1
 Copper,1
 Copperhead,1
@@ -1466,6 +1489,7 @@ Cotton Candy,1
 Cottonball,1
 Cottontail,1
 Couch,1
+Couch Potato,1
 Cougar,1
 Council,1
 Count,1
@@ -1485,6 +1509,7 @@ Cow,1
 Coward,1
 Cowbell,1
 Cowboy,1
+Cowgirl,1
 Coyote,1
 Crab,1
 Crabapple,1
@@ -1641,6 +1666,7 @@ Dainsleif,1
 Dairy,1
 Daisy,1
 Daisy Chain,1
+Daisy Cutter,1
 Daito,1
 Dallas,1
 Dalmatian,1
@@ -1772,6 +1798,7 @@ Derpy,1
 Dervish,1
 Desert,1
 Desire,1
+Desislava,1
 Desk Jockey,1
 Desolate,1
 Despair,1
@@ -1866,6 +1893,7 @@ Djinn,1
 DNA,1
 Do Or Die,1
 DOA,1
+Doberman,1
 Doc,1
 Dockhand,1
 Dockside,1
@@ -1979,6 +2007,7 @@ Droopy,1
 Dropkick,1
 Dropout,1
 Dropship,1
+Dropzone,1
 Drought,1
 Drudge,1
 Druglord,1
@@ -2107,6 +2136,7 @@ Energy,1
 Enforcer,1
 Engage,1
 Engine,1
+Engineer,1
 Enigma,1
 Enkidu,1
 Enterprise,1
@@ -2196,6 +2226,7 @@ Face-Off,1
 Faceless,1
 Facepalm,1
 Faceplant,1
+Faceplate,1
 Faction,1
 Factoid,1
 Factory,1
@@ -2261,6 +2292,7 @@ Feldspar,1
 Feline,1
 Felis,1
 Felix,1
+Felon,1
 Fencer,1
 Fender,1
 Fennel,1
@@ -2295,6 +2327,7 @@ Fine-line,1
 Fingers,1
 Finish Line,1
 Finn,1
+Finnback,1
 Fire,1
 Fire Cat,1
 Firearm,1
@@ -2324,9 +2357,11 @@ First Degree,1
 Fish,1
 Fish Fry,1
 Fish Sticks,1
+Fishcan,1
 Fisher,1
 Fisherman,1
 Fisticuffs,1
+Five ton,1
 Fix-It,1
 Fixer,1
 Fizz,1
@@ -2350,8 +2385,10 @@ Flapper,1
 Flare,1
 Flaregun,1
 Flash,1
+Flash Fried,1
 Flashback,1
 Flashbang,1
+Flashdrive,1
 Flashfire,1
 Flashlight,1
 Flashpoint,1
@@ -2379,6 +2416,7 @@ Flipflop,1
 Flipper,1
 Float,1
 Flood,1
+Floor tack,1
 Floorboard,1
 Floppy,1
 Flora,1
@@ -2439,6 +2477,7 @@ Foul,1
 Fountain,1
 Four Eyes,1
 Fox,1
+Foxbat,1
 Foxfire,1
 Foxglove,1
 Foxhole,1
@@ -2464,6 +2503,7 @@ Freebooter,1
 Freedom,1
 Freefall,1
 Freeloader,1
+Freeman,1
 Freestyle,1
 Freeway,1
 Freeze Frame,1
@@ -2484,7 +2524,10 @@ Friendly,1
 Frigate,1
 Frigid,1
 Frisky,1
+Fritz,1
+Frizzle,1
 Frog,1
+Frogfoot,1
 Froggy,1
 Frolic,1
 Frontkick,1
@@ -2592,6 +2635,7 @@ Gentleman,1
 Gentry,1
 Geode,1
 Geoduck,1
+Gepard,1
 Geranium,1
 Gerbil,1
 Geronimo,1
@@ -2681,6 +2725,7 @@ Gold Digger,1
 Gold Leaf,1
 Gold Rush,1
 Golden,1
+Goldeneye,1
 Goldenrod,1
 Goldfinch,1
 Goldfish,1
@@ -2695,6 +2740,7 @@ Gongjin,1
 Gonzo,1
 Goober,1
 Good Night,1
+Goodness,1
 Goody,1
 Goof-Off,1
 Goofball,1
@@ -2715,6 +2761,7 @@ Graceland,1
 Grackle,1
 Gradient,1
 Graffiti,1
+Grail,1
 Gram,1
 Grammar,1
 Grand,1
@@ -2783,6 +2830,7 @@ Grotesque,1
 Grouch,1
 Grounder,1
 Groundhog,1
+Grouse,1
 Growl,1
 Grub,1
 Grudge,1
@@ -2821,6 +2869,7 @@ Gungnir,1
 Gunhog,1
 Gunmetal,1
 Gunner,1
+Gunny,1
 Gunport,1
 Gunpowder,1
 Gunrunner,1
@@ -2926,6 +2975,7 @@ Haunt,1
 Haunted,1
 Haven,1
 Havoc,1
+Havoc Bringer,1
 Havok,1
 Hawk,1
 Hawkeye,1
@@ -2935,6 +2985,7 @@ Hayseed,1
 Haystack,1
 Haywire,1
 Hazard,1
+Hazard Pay,1
 Haze,1
 Hazelnut,1
 Hazmat,1
@@ -2961,12 +3012,14 @@ Heather,1
 Heatsink,1
 Heaven,1
 Heavy,1
+Heavy Arms,1
 Heavy Duty,1
 Heavyweight,1
 Hecate,1
 Hectic,1
 Hector,1
 Hedge,1
+Hedge Trimmer,1
 Hedgehog,1
 Hefty,1
 Heifer,1
@@ -2977,6 +3030,7 @@ Helios,1
 Helius,1
 Helix,1
 Hell Cat,1
+Hell March,1
 Hellbender,1
 Hellborn,1
 Hellburner,1
@@ -3001,6 +3055,7 @@ Hermes,1
 Hermit,1
 Hero,1
 Herringbone,1
+Hesh,1
 Hewer,1
 Hex,1
 Hexbolt,1
@@ -3019,6 +3074,7 @@ High Life,1
 High Noon,1
 High Roller,1
 High Score,1
+High speed,1
 High Voltage,1
 Highball,1
 Highbrow,1
@@ -3030,6 +3086,7 @@ Hightide,1
 Hightower,1
 Highwater,1
 Highway,1
+Highwayman,1
 Highwire,1
 Hijack,1
 Hijinks,1
@@ -3046,6 +3103,7 @@ Hipshot,1
 Hissy Fit,1
 History,1
 Hit n Run,1
+Hitbox,1
 Hitch,1
 Hitchhiker,1
 Hitman,1
@@ -3121,6 +3179,7 @@ Hot Fudge,1
 Hot Sauce,1
 Hot Tamale,1
 Hotbox,1
+Hotchkiss,1
 Hotel,1
 Hothead,1
 Hotpot,1
@@ -3146,6 +3205,7 @@ Huckleberry,1
 Hudson,1
 Huevos,1
 Huggy,1
+Huginn,1
 Hula,1
 Hula Hoop,1
 Hulk,1
@@ -3271,6 +3331,7 @@ Intendant,1
 Interceptor,1
 Interrobang,1
 Intersection,1
+Intervention,1
 Intrigue,1
 Inuksuk,1
 Invader,1
@@ -3413,6 +3474,7 @@ Jubokko,1
 Judge,1
 Judgement,1
 Judo,1
+Jug,1
 Juggernaut,1
 Juggler,1
 Juice,1
@@ -3665,6 +3727,7 @@ Lever,1
 Leviathan,1
 Lexicon,1
 Lexus,1
+Liaison,1
 Liberator,1
 Liberty,1
 Libra,1
@@ -3755,6 +3818,7 @@ Longbow,1
 Longhorn,1
 Longshadow,1
 Longshot,1
+Longsword,1
 Loofah,1
 Looking Glass,1
 Lookout,1
@@ -3824,6 +3888,7 @@ Machine,1
 Macho,1
 Mack,1
 Macro,1
+Mad Bomber,1
 Mad Dog,1
 Mad Fox,1
 Mad Wolf,1
@@ -3908,6 +3973,7 @@ March,1
 Mardi Gras,1
 Mariachi,1
 Marigold,1
+Marinara,1
 Marine,1
 Mariner,1
 Mark,1
@@ -3964,6 +4030,7 @@ Meadow,1
 Meadow Breeze,1
 Meadowlark,1
 Meat,1
+Meat Chopper,1
 Meatball,1
 Meathead,1
 Meathook,1
@@ -4073,6 +4140,7 @@ Miracle,1
 Mirage,1
 Mire,1
 Mirror,1
+Mirv,1
 Mischief,1
 Miserable,1
 Misery,1
@@ -4083,6 +4151,7 @@ Mishmash,1
 Miso,1
 Miss-A-Lot,1
 Missile,1
+Missile Crisis,1
 Missionary,1
 Mist,1
 Mistake,1
@@ -4135,6 +4204,7 @@ Monster Mash,1
 Monument,1
 Moo-Moo,1
 Mooch,1
+Mood Killer,1
 Mood Swing,1
 Moon,1
 Moon Rabbit,1
@@ -4213,6 +4283,7 @@ Mummy,1
 Munch,1
 Muncher,1
 Munchkin,1
+Muninn,1
 Mural,1
 Muramasa,1
 Murderer,1
@@ -4363,6 +4434,7 @@ Noodle,1
 Noodles,1
 Nook,1
 Noose,1
+Noot Noot,1
 North,1
 Northman,1
 Northwind,1
@@ -4424,6 +4496,8 @@ Offbeat,1
 Offroad,1
 Ogre,1
 Ohm,1
+Oil Can,1
+Oil Drum,1
 Oil Slick,1
 Oiler,1
 Ol' Blue,1
@@ -4604,6 +4678,7 @@ Particle,1
 Partisan,1
 Partner,1
 Partridge,1
+Parts Bin,1
 Partytime,1
 Passenger,1
 Passion,1
@@ -4617,6 +4692,7 @@ Pastry,1
 Patch,1
 Patch-Eye,1
 Patches,1
+Patcheye,1
 Patchwork,1
 Pathfinder,1
 Pathogen,1
@@ -4645,6 +4721,7 @@ Peanut,1
 Peanut Butter,1
 Pearl,1
 Peasant,1
+Peashooter,1
 Pebble,1
 Pecan,1
 Peddler,1
@@ -4661,6 +4738,7 @@ Pencil,1
 Pendant,1
 Pendragon,1
 Penghou,1
+Pengu,1
 Penguin,1
 Penny,1
 Pennywise,1
@@ -4717,6 +4795,7 @@ Piehole,1
 Pierce,1
 Pig,1
 Pig Iron,1
+Pig Pen,1
 Pigeon,1
 Piglet,1
 Pigpen,1
@@ -4824,6 +4903,7 @@ Pointman,1
 Poison,1
 Poison Ivy,1
 Poker,1
+Poker Face,1
 Polar,1
 Polar Bear,1
 Polaris,1
@@ -4951,7 +5031,6 @@ Prowler,1
 Proxima,1
 Prudent,1
 Psalm,1
-Psi,1
 Psych Out,1
 Psyche,1
 Psychic,1
@@ -4978,6 +5057,7 @@ Pulseblade,1
 Puma,1
 Pummel,1
 Pumpernickel,1
+Pumpernickle,1
 Pumpkin,1
 Pun,1
 Punchcard,1
@@ -5032,6 +5112,7 @@ Quench,1
 Quest,1
 Question,1
 Quick,1
+Quick Scope,1
 Quickdraw,1
 Quicksand,1
 Quickshot,1
@@ -5296,6 +5377,7 @@ Ripstop,1
 Riptide,1
 Risky,1
 Ritual,1
+Ritz,1
 Rival,1
 River,1
 Rivet,1
@@ -5464,6 +5546,7 @@ Salt Lick,1
 Salt Shaker,1
 Salt Water,1
 Saltfang,1
+Saltine,1
 Salty Dog,1
 Salvage,1
 Salvager,1
@@ -5482,6 +5565,7 @@ Sandbar,1
 Sandcastle,1
 Sandhog,1
 Sandman,1
+Sandrock,1
 Sandstorm,1
 Sandwich,1
 Sandy,1
@@ -5491,6 +5575,7 @@ Sapper,1
 Sapphire,1
 Sardine,1
 Sardonic,1
+Sarge,1
 Saros,1
 Sasquatch,1
 Sassafras,1
@@ -5672,6 +5757,8 @@ Shantytown,1
 Shaolin,1
 Shard,1
 Shark,1
+Shark Bait,1
+Shark Tooth,1
 Sharkeye,1
 Sharp,1
 Sharp Stick,1
@@ -5694,6 +5781,7 @@ Shepherd,1
 Sherbet,1
 Sheriff,1
 Sherlock,1
+Sherman,1
 Sherpa,1
 Shibboleth,1
 Shield,1
@@ -5701,6 +5789,7 @@ Shieldbreaker,1
 Shieldmaiden,1
 Shifter,1
 Shifty,1
+Shilka,1
 Shill,1
 Shimmer,1
 Shindig,1
@@ -5714,6 +5803,7 @@ Shiver,1
 Shivers,1
 Shoal,1
 Shock,1
+Shock Hazard,1
 Shock Jock,1
 Shocker,1
 Shockwave,1
@@ -5727,12 +5817,15 @@ Shooter,1
 Shooting Star,1
 Shopping Cart,1
 Shore,1
+Shore Leave,1
 Shoreline,1
 Short Fuse,1
 Short Straw,1
+Shortbow,1
 Shortbread,1
 Shortlist,1
 Shortstop,1
+Shortsword,1
 Shortwave,1
 Shortwire,1
 Shorty,1
@@ -5767,6 +5860,7 @@ Sidearm,1
 Sidecar,1
 Sidekick,1
 Sideshow,1
+Sideslip,1
 Sideswipe,1
 Sidetrack,1
 Sidewalk,1
@@ -5825,6 +5919,7 @@ Skidmark,1
 Skidoo,1
 Skids,1
 Skiff,1
+Skill Issue,1
 Skimmer,1
 Skinner,1
 Skinny,1
@@ -5838,6 +5933,7 @@ Skulls,1
 Skully,1
 Skunk,1
 Sky,1
+Sky Crane,1
 Skydancer,1
 Skye,1
 Skyfall,1
@@ -5845,6 +5941,7 @@ Skyhawk,1
 Skylark,1
 Skyline,1
 Skyscraper,1
+Skysweeper,1
 Skyward,1
 Slab,1
 Slab Bulkhead,1
@@ -5953,6 +6050,7 @@ Snickers,1
 Snip,1
 Sniper,1
 Snippy,1
+Snips,1
 Snitch,1
 Snocone,1
 Snoop,1
@@ -6033,12 +6131,14 @@ South,1
 Southpaw,1
 Souvlaki,1
 Sovereign,1
+Spaag,1
 Spacer,1
 Spaceship,1
 Spacey,1
 Spade,1
 Spaghetti,1
 Spam,1
+Spam Can,1
 Spaniel,1
 Spanner,1
 Spar,1
@@ -6068,6 +6168,7 @@ Spectacle,1
 Specter,1
 Spectra,1
 Spectrum,1
+Speed Demon,1
 Speedbird,1
 Speedster,1
 Speedy,1
@@ -6183,6 +6284,7 @@ Starlord,1
 Starman,1
 Starpath,1
 Starry,1
+Starstreak,1
 Starstruck,1
 Startup,1
 Starward,1
@@ -6264,6 +6366,7 @@ Stream,1
 Street Rat,1
 Streetlamp,1
 Streetwise,1
+Strella,1
 Strength,1
 Stress,1
 Stretch,1
@@ -6285,6 +6388,7 @@ Stronghold,1
 Strudel,1
 Strut,1
 Stubborn,1
+Stuck Up,1
 Stuffed Shirt,1
 Stuka,1
 Stumpy,1
@@ -6464,6 +6568,7 @@ Tartan,1
 Tartar Sauce,1
 Tartarus,1
 Tarzan,1
+Task Manager,1
 Taskmaster,1
 Tasteless,1
 Tasty,1
@@ -6496,6 +6601,8 @@ Teeth,1
 Teflon,1
 Telegraph,1
 Telepath,1
+Telephone,1
+Telephone Pole,1
 Telescope,1
 Telltale,1
 Tempest,1
@@ -6646,6 +6753,7 @@ Toga,1
 Toggle,1
 Toilet,1
 Token,1
+Tollbooth,1
 Tomahawk,1
 Tomato,1
 Tomb,1
@@ -6703,6 +6811,8 @@ Tragic,1
 Trail Boss,1
 Trailblaze,1
 Trailblazer,1
+Trailer Park,1
+Trailer Trash,1
 Train,1
 Trainer,1
 Traitor,1
@@ -6719,6 +6829,7 @@ Trapeze,1
 Trapline,1
 Trapper,1
 Trash,1
+Trash Panda,1
 Trashcan,1
 Trashfire,1
 Trashtalk,1
@@ -6756,6 +6867,7 @@ Trilogy,1
 Trinity,1
 Trinket,1
 Trip,1
+Triple A,1
 Tripod,1
 Tripwire,1
 Triton,1
@@ -6797,6 +6909,8 @@ Tumbleweed,1
 Tumor,1
 Tuna,1
 Tundra,1
+Tungsten,1
+Tunguska,1
 Tunnel,1
 Tunnel Rat,1
 Tunnels,1
@@ -6827,6 +6941,7 @@ Twisted,1
 Twister,1
 Twitch,1
 Two Face,1
+Two Strike,1
 Two Tap,1
 Two Times,1
 Two-Dog,1
@@ -6854,6 +6969,7 @@ Unbroken,1
 Unchained,1
 Uncle,1
 Underboss,1
+Undercooked,1
 Undercover,1
 Underdog,1
 Underground,1
@@ -7064,6 +7180,7 @@ Watchman,1
 Watchtower,1
 Water Balloon,1
 Water Bottle,1
+Water Wings,1
 Waterfall,1
 Waterloo,1
 Watermelon,1
@@ -7086,11 +7203,13 @@ Wedding Day,1
 Wedge,1
 Weed,1
 Weed Killer,1
+Weed Wacker,1
 Weevil,1
 Weightless,1
 Weld,1
 Welder,1
 Welfare,1
+Well done,1
 Wellspring,1
 Werewolf,1
 West,1
@@ -7150,7 +7269,6 @@ Wild,1
 Wild Goose,1
 Wild Thing,1
 Wildcat,1
-Wildchild,1
 Wildebeest,1
 Wildfire,1
 Wildman,1
@@ -7171,8 +7289,10 @@ Windstorm,1
 Windswept,1
 Windy,1
 Wineglass,1
+Wing Clipper,1
 Winger,1
 Wingman,1
+Wingmaster,1
 Wingnut,1
 Wings,1
 Wingspan,1
@@ -7204,6 +7324,7 @@ Wombat,1
 Wonder,1
 Wonderboy,1
 Woodhen,1
+Woodpecker,1
 Woodsman,1
 Woody,1
 Woohoo,1
@@ -7273,6 +7394,7 @@ Yuanrang,1
 Yuki-Onna,1
 Yukon,1
 Yunchang,1
+Zako,1
 Zamboni,1
 Zanzibar,1
 Zap,1
@@ -7283,6 +7405,7 @@ Zebra,1
 Zebrafinch,1
 Zebroid,1
 Zebu,1
+Zeitgeist,1
 Zen,1
 Zenith,1
 Zephyr,1


### PR DESCRIPTION
1. Anger Management
2. Backdoor
3. Baloney
4. Big Iron
5. Black Ice
6. Blackbox
7. Bombardier
8. Bombsight
9. Bouncing Betty
10. Boxcutter
11. Burger Demon
12. Busky
13. Butter Bars
14. Butterfingers
15. Callsign
16. Canister
17. Canister Shot
18. Carryall
19. Chain Gang
20. Clippy
21. Cocktail
22. Coop
23. Couch Potato
24. Cowgirl
25. Daisy Cutter
26. Doberman
27. Dropzone
28. Engineer
29. Faceplate
30. Felon
31. Finback
32. Fishcan
33. Five Ton
34. Flash Fried
35. Flash Drive
36. Floor Tack
37. Foxbat
38. Freeman
39. Fritz
40. Frizzle
41. Forefoot
42. Goldeneye
43. Goodness
44. Grail
45. Grouse
46. Gunny
47. Havoc Bringer
48. Hazard Pay
49. Heavy Arms
50. Hedge Trimmer
51. Hell March
52. HESH
53. High Speed
54. Highwayman
55. Hitbox
56. Hotchkiss
57. Huginn
58. Intervention
59. Jug
60. Liaison
61. Longsword
62. Mad Bomber
63. Marinara
64. Meat Chopper
65. Mirv
66. Missile Crisis
67. Mood Killer
68. Mininn
69. Noot Noot
70. Oil Can
71. Oil Drum
72. Parts Bin
73. Patchy
74. Peashooter
75. Pengu
76. Pig Pen
77. Poker Face
78. Pumpernickle
79. Quick Scope
80. Ritz
81. Saltine
82. Sandrock
83. Sarge
84. Shark Bait
85. Shark Tooth
86. Sherman
87. Shock Hazard
88. Shore Leave
89. Shortbow
90. Shortsword
91. Sideslip
92. Skill Issue
93. Sky Crane
94. Skysweeper
95. Snips
96. SPAAG
97. Spam Can
98. Speed Demon
99. Starstreak
100. Stuck Up
101. Task Manager
102. Telephone
103. Telephone Pole
104. Tollbooth
105. Trailer Park
106. Trailer Trash
107. Trash Panda
108. Triple A
109. Tungsten
110. Tunguska
111. Two Strike
112. Undercooked
113. Water Wings
114. Weed Wacker
115. Well Done
116. Wing Clipper
117. Wingmaster
118. Woodpecker
119. Zako
120. Zeitgeist