### PR TITLE
Fix: MML #2211 Fix VTOL Hit Location and Critical Hits Table Content

### DIFF
--- a/data/images/recordsheets/templates_iso/tables_vtol.svg
+++ b/data/images/recordsheets/templates_iso/tables_vtol.svg
@@ -930,7 +930,7 @@
              id="tspan134">No Critical Hit</tspan><tspan
              x="115.71"
              y="16"
-             id="tspan135">Copilot Hit</tspan><tspan
+             id="tspan135">Co-Pilot Hit</tspan><tspan
              x="192.85001"
              y="16"
              id="tspan136">Weapon Malfunction</tspan><tspan
@@ -1008,13 +1008,13 @@
              id="tspan160">Weapon Destroyed</tspan><tspan
              x="192.85001"
              y="56"
-             id="tspan161">RotorsDestroyed</tspan><tspan
+             id="tspan161">Ammunition**</tspan><tspan
              x="292.03"
              y="56"
-             id="tspan162">Ammunition**</tspan><tspan
+             id="tspan162">Engine Hit</tspan><tspan
              x="391.20999"
              y="56"
-             id="tspan163">Engine Hit</tspan><tspan
+             id="tspan163">Rotors Destroyed</tspan><tspan
              x="468.35001"
              y="56"
              id="tspan164">Ammunition**</tspan><tspan
@@ -1029,7 +1029,7 @@
              id="tspan167">Fuel Tank*</tspan><tspan
              x="391.20999"
              y="64"
-             id="tspan168">RotorsDestroyed</tspan><tspan
+             id="tspan168">Rotors Destroyed</tspan><tspan
              x="468.35001"
              y="64"
              id="tspan169">Turret Blown Off</tspan></text>

--- a/data/images/recordsheets/templates_iso/tables_vtol.svg
+++ b/data/images/recordsheets/templates_iso/tables_vtol.svg
@@ -284,13 +284,13 @@
              id="tspan47">Rotors†</tspan><tspan
              x="93.189003"
              y="77"
-             id="tspan48">Rotors (critical)*†</tspan><tspan
+             id="tspan48">Rotors (critical)†</tspan><tspan
              x="170.847"
              y="77"
-             id="tspan49">Rotors (critical)*†</tspan><tspan
+             id="tspan49">Rotors (critical)†</tspan><tspan
              x="248.504"
              y="77"
-             id="tspan50">Rotors (critical)*†</tspan></text>
+             id="tspan50">Rotors (critical)†</tspan></text>
       </g>
       <g
          transform="translate(0,140.6)"

--- a/data/images/recordsheets/templates_us/tables_vtol.svg
+++ b/data/images/recordsheets/templates_us/tables_vtol.svg
@@ -930,7 +930,7 @@
              id="tspan134">No Critical Hit</tspan><tspan
              x="119.28"
              y="16"
-             id="tspan135">Copilot Hit</tspan><tspan
+             id="tspan135">Co-Pilot Hit</tspan><tspan
              x="198.8"
              y="16"
              id="tspan136">Weapon Malfunction</tspan><tspan
@@ -1008,13 +1008,13 @@
              id="tspan160">Weapon Destroyed</tspan><tspan
              x="198.8"
              y="56"
-             id="tspan161">RotorsDestroyed</tspan><tspan
+             id="tspan161">Ammunition**</tspan><tspan
              x="301.04001"
              y="56"
-             id="tspan162">Ammunition**</tspan><tspan
+             id="tspan162">Engine Hit</tspan><tspan
              x="403.28"
              y="56"
-             id="tspan163">Engine Hit</tspan><tspan
+             id="tspan163">Rotors Destroyed</tspan><tspan
              x="482.79999"
              y="56"
              id="tspan164">Ammunition**</tspan><tspan
@@ -1029,7 +1029,7 @@
              id="tspan167">Fuel Tank*</tspan><tspan
              x="403.28"
              y="64"
-             id="tspan168">RotorsDestroyed</tspan><tspan
+             id="tspan168">Rotors Destroyed</tspan><tspan
              x="482.79999"
              y="64"
              id="tspan169">Turret Blown Off</tspan></text>

--- a/data/images/recordsheets/templates_us/tables_vtol.svg
+++ b/data/images/recordsheets/templates_us/tables_vtol.svg
@@ -284,13 +284,13 @@
              id="tspan47">Rotors†</tspan><tspan
              x="96.096001"
              y="77"
-             id="tspan48">Rotors (critical)*†</tspan><tspan
+             id="tspan48">Rotors (critical)†</tspan><tspan
              x="176.17599"
              y="77"
-             id="tspan49">Rotors (critical)*†</tspan><tspan
+             id="tspan49">Rotors (critical)†</tspan><tspan
              x="256.25601"
              y="77"
-             id="tspan50">Rotors (critical)*†</tspan></text>
+             id="tspan50">Rotors (critical)†</tspan></text>
       </g>
       <g
          transform="translate(0,125.6)"


### PR DESCRIPTION
Fix MML [#2221](https://github.com/MegaMek/megameklab/issues/2211)

Also remove extra asterisks from Hit Location Table row 12.

Note for Reviewer: REVIEW AND MERGE AFTER PR https://github.com/MegaMek/mm-data/pull/428

Ref TechManual 6th Printing, page 328:
<img width="1000" height="649" alt="Screenshot 2026-06-30 at 1 53 19 PM" src="https://github.com/user-attachments/assets/5aafedf1-4af0-42b9-ad37-1181672271c3" />
