### PR TITLE
Fix: Remove Unused Ground Combat Vehicle Hit Location Table Footnotes and Update Critical Hits Table Title

### DIFF
--- a/data/images/recordsheets/templates_iso/tables_tank.svg
+++ b/data/images/recordsheets/templates_iso/tables_tank.svg
@@ -715,7 +715,7 @@
              style="font-style:normal;font-weight:bold;font-size:10.6px;font-family:Eurostile"
              textLength="213.991"
              lengthAdjust="spacingAndGlyphs"
-             id="text109">GROUND COMBAT VEHICLE CRITICALS TABLE</text>
+             id="text109">GROUND COMBAT VEHICLE CRITICAL HITS TABLE</text>
         </g>
       </g>
       <g

--- a/data/images/recordsheets/templates_iso/tables_tank_tacops_vehicle_effectiveness_rules.svg
+++ b/data/images/recordsheets/templates_iso/tables_tank_tacops_vehicle_effectiveness_rules.svg
@@ -722,7 +722,7 @@
              style="font-style:normal;font-weight:bold;font-size:10.6px;font-family:Eurostile"
              textLength="213.991"
              lengthAdjust="spacingAndGlyphs"
-             id="text109">GROUND COMBAT VEHICLE CRITICALS TABLE</text>
+             id="text109">GROUND COMBAT VEHICLE CRITICAL HITS TABLE</text>
         </g>
       </g>
       <g

--- a/data/images/recordsheets/templates_iso/tables_tank_tacops_vehicle_effectiveness_rules.svg
+++ b/data/images/recordsheets/templates_iso/tables_tank_tacops_vehicle_effectiveness_rules.svg
@@ -303,7 +303,7 @@
            style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile"
            textLength="301.63"
            lengthAdjust="spacingAndGlyphs"
-           id="text51">* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the vehicle. For each result of 2 or</text>
+           id="text51">* A result of 2 or 12 may inflict a critical hit on the vehicle. For each result of 2 or 12, apply damage normally to the armor in that section.</text>
         <text
            x="6"
            y="14"
@@ -312,18 +312,10 @@
            style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile"
            textLength="301.63"
            lengthAdjust="spacingAndGlyphs"
-           id="text52">12 (or 8 for side attacks), apply damage normally to the armor in that section. The attacking player then automatically rolls</text>
+           id="text52">The attacking player then automatically rolls once on the Ground Combat Vehicle Critical Hits
+            Table below (see Combat, p. 192, in</text>
         <text
            x="6"
-           y="21"
-           fill="#000000"
-           text-anchor="start"
-           style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile"
-           textLength="200.326"
-           lengthAdjust="spacingAndGlyphs"
-           id="text53">once on the Ground Combat Vehicle Critical Hits Table below (see Combat, p. 192, in</text>
-        <text
-           x="206.326"
            y="21"
            fill="#000000"
            text-anchor="start"
@@ -332,7 +324,7 @@
            lengthAdjust="spacingAndGlyphs"
            id="text54">Total Warfare</text>
         <text
-           x="242.595"
+           x="42"
            y="21"
            fill="#000000"
            text-anchor="start"

--- a/data/images/recordsheets/templates_us/tables_tank.svg
+++ b/data/images/recordsheets/templates_us/tables_tank.svg
@@ -715,7 +715,7 @@
              style="font-style:normal;font-weight:bold;font-size:10.6px;font-family:Eurostile"
              textLength="213.991"
              lengthAdjust="spacingAndGlyphs"
-             id="text109">GROUND COMBAT VEHICLE CRITICALS TABLE</text>
+             id="text109">GROUND COMBAT VEHICLE CRITICAL HITS TABLE</text>
         </g>
       </g>
       <g

--- a/data/images/recordsheets/templates_us/tables_tank_tacops_vehicle_effectiveness_rules.svg
+++ b/data/images/recordsheets/templates_us/tables_tank_tacops_vehicle_effectiveness_rules.svg
@@ -724,7 +724,7 @@
              style="font-style:normal;font-weight:bold;font-size:10.6px;font-family:Eurostile"
              textLength="213.991"
              lengthAdjust="spacingAndGlyphs"
-             id="text109">GROUND COMBAT VEHICLE CRITICALS TABLE</text>
+             id="text109">GROUND COMBAT VEHICLE CRITICAL HITS TABLE</text>
         </g>
       </g>
       <g

--- a/data/images/recordsheets/templates_us/tables_tank_tacops_vehicle_effectiveness_rules.svg
+++ b/data/images/recordsheets/templates_us/tables_tank_tacops_vehicle_effectiveness_rules.svg
@@ -303,7 +303,7 @@
            style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile"
            textLength="311.32001"
            lengthAdjust="spacingAndGlyphs"
-           id="text51">* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the vehicle. For each result of 2 or</text>
+           id="text51">* A result of 2 or 12 may inflict a critical hit on the vehicle. For each result of 2 or 12, apply damage normally to the armor in that section.</text>
         <text
            x="6"
            y="14"
@@ -312,18 +312,10 @@
            style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile"
            textLength="311.32001"
            lengthAdjust="spacingAndGlyphs"
-           id="text52">12 (or 8 for side attacks), apply damage normally to the armor in that section. The attacking player then automatically rolls</text>
+           id="text52">The attacking player then automatically rolls once on the Ground Combat Vehicle Critical Hits
+            Table below (see Combat, p. 192, in</text>
         <text
            x="6"
-           y="21"
-           fill="#000000"
-           text-anchor="start"
-           style="font-style:normal;font-weight:normal;font-size:5.7px;font-family:Eurostile"
-           textLength="200.326"
-           lengthAdjust="spacingAndGlyphs"
-           id="text53">once on the Ground Combat Vehicle Critical Hits Table below (see Combat, p. 192, in</text>
-        <text
-           x="206.326"
            y="21"
            fill="#000000"
            text-anchor="start"
@@ -332,7 +324,7 @@
            lengthAdjust="spacingAndGlyphs"
            id="text54">Total Warfare</text>
         <text
-           x="242.595"
+           x="42"
            y="21"
            fill="#000000"
            text-anchor="start"


### PR DESCRIPTION
Remove unused critical hit on result 8 for side text in Ground Combat Vehicle Hit Location footnotes for Vehicle Effectiveness rules and update Ground Combat Vehicle Criticals Table title to Ground Combat Vehicle Critical Hits Table.

Ref TechManual 6th printing, page 327
<img width="553" height="50" alt="Screenshot 2026-07-01 at 11 31 55 PM" src="https://github.com/user-attachments/assets/12ee20cf-00ed-4d01-ac3a-763b531238b2" />