### PR TITLE
Added yet more callsigns

### DIFF
--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -31,6 +31,7 @@ Acme,1
 Acne,1
 Acolyte,1
 Acorn,1
+Acrid,1
 Acrobat,1
 Acronym,1
 Active,1
@@ -48,6 +49,7 @@ Admiral,1
 Adonis,1
 Adrenaline,1
 Adventure,1
+Adze,1
 Aegis,1
 Aeneas,1
 Aerial,1
@@ -93,6 +95,7 @@ Airwave,1
 Ajax,1
 Alabaster,1
 Aladdin,1
+Alamo,1
 Alarm Clock,1
 Albatross,1
 Albino,1
@@ -105,6 +108,7 @@ Alias,1
 Alibi,1
 Alien,1
 Alimony,1
+Alkali,1
 All Day,1
 All In,1
 All Star,1
@@ -145,6 +149,7 @@ Ammut,1
 Amnesty,1
 Amok,1
 Amore,1
+Amos,1
 Amphibian,1
 Amphitrite,1
 Amulet,1
@@ -188,6 +193,7 @@ Ape,1
 Apex,1
 Apex Jackal,1
 Aphelion,1
+Aphid,1
 Aphrodite,1
 Apocalypse,1
 Apogee,1
@@ -265,6 +271,7 @@ Asgard,1
 Ash,1
 Ashen,1
 Ashfall,1
+Ashigaru,1
 Ashtray,1
 Asi,1
 Askew,1
@@ -279,6 +286,7 @@ Astro,1
 Astroturf,1
 Aswang,1
 Asylum,1
+Async,1
 Atalanta,1
 Athena,1
 Athens,1
@@ -286,11 +294,13 @@ Athlete,1
 Athos,1
 Atlantis,1
 Atlas,1
+Atoll,1
 Atom,1
 Atomic,1
 Attila,1
 Attitude,1
 Auction,1
+Audacity,1
 Auger,1
 Augur,1
 Auntie,1
@@ -312,14 +322,17 @@ Avril,1
 Awakening,1
 Award,1
 Awe,1
+Awl,1
 AWOL,1
 Axe,1
+Axehead,1
 Axekick,1
 Axel,1
 Axeman,1
 Axiom,1
 Axle,1
 Axon,1
+Ayyubid,1
 Azeban,1
 Azrael,1
 Azure,1
@@ -348,6 +361,7 @@ Backtrack,1
 Backup,1
 Bacon,1
 Baconator,1
+Bad Boy,1
 Bad Luck,1
 Badge,1
 Badger,1
@@ -490,6 +504,7 @@ Beauty,1
 Beaver,1
 Bedhead,1
 Bedlam,1
+Bedouin,1
 Bedrock,1
 Bee Sting,1
 Beef,1
@@ -547,6 +562,7 @@ Big Iron,1
 Big League,1
 Big Mac,1
 Big McLargeHuge,1
+Big Momma,1
 Big Money,1
 Big Nasty,1
 Big Nose,1
@@ -597,6 +613,7 @@ Black Ice,1
 Black Knight,1
 Black Magic,1
 Black Powder,1
+Black Rider,1
 Black Sheep,1
 Black Swan,1
 Black Widow,1
@@ -936,6 +953,7 @@ Bus Stop,1
 Bush,1
 Bushel,1
 Bushido,1
+Bushmaster,1
 Bushwacker,1
 Busker,1
 Busky,1
@@ -1047,6 +1065,7 @@ Capstone,1
 Captain,1
 Capybara,1
 Car Bomb,1
+Carabinier,1
 Caracal,1
 Carafe,1
 Caramel,1
@@ -1090,6 +1109,7 @@ Cash,1
 Cashew,1
 Cashflow,1
 Cashier,1
+Cashier,1
 Cashmere,1
 Casino,1
 Casket,1
@@ -1115,6 +1135,7 @@ Catnip,1
 Cattail,1
 Cauldron,1
 Causeway,1
+Caustic,1
 Cavalier,1
 Cavalry,1
 Caveman,1
@@ -1328,6 +1349,7 @@ Clobber,1
 Clock,1
 Clockwise,1
 Clockwork,1
+Cloggie,1
 Clogs,1
 Clone,1
 Close Shave,1
@@ -1377,6 +1399,7 @@ Cola,1
 Colby,1
 Cold Snap,1
 Coldface,1
+Coldheart,1
 Coldstart,1
 Coldsteel,1
 Collapse,1
@@ -1938,6 +1961,7 @@ Dorothy,1
 Dot,1
 Double,1
 Double Tap,1
+Double Trouble,1
 Doubledown,1
 Doubleshot,1
 Doubloon,1
@@ -2003,6 +2027,7 @@ Droid,1
 Dromedary,1
 Drone,1
 Droopy,1
+Drop Bear,1
 Dropkick,1
 Dropout,1
 Dropship,1
@@ -2206,6 +2231,7 @@ Exotic,1
 Expedition,1
 Experience,1
 Experiment,1
+Expert,1
 Exploit,1
 Explorer,1
 Express,1
@@ -2439,6 +2465,7 @@ Fly Trap,1
 Flyboy,1
 Flycatcher,1
 Flynn,1
+Flyswatter,1
 Flytrap,1
 Focus,1
 Fog,1
@@ -2538,6 +2565,7 @@ Frostfire,1
 Frosting,1
 Frosty,1
 Fruit Punch,1
+Fry-up,1
 Fudge,1
 Fujin,1
 Fulcrum,1
@@ -2561,9 +2589,11 @@ Futon,1
 Future,1
 Fuzz,1
 Fuzzy,1
+Gadfly,1
 Gadget,1
 Gaggle,1
 Gaia,1
+Gainful,1
 Gala,1
 Galahad,1
 Galatea,1
@@ -2574,6 +2604,7 @@ Gallant,1
 Galleon,1
 Galley,1
 Gallows,1
+Galosh,1
 Gambit,1
 Gamble,1
 Gambler,1
@@ -2581,6 +2612,8 @@ Game Time,1
 Gamer,1
 Gameshow,1
 Gamma,1
+Gammon,1
+Ganef,1
 Gangster,1
 Ganymede,1
 Garbage,1
@@ -2596,6 +2629,7 @@ Gas Hog,1
 Gasbag,1
 Gash,1
 Gasket,1
+Gaskin,1
 Gaslight,1
 Gaspipe,1
 Gassy,1
@@ -2607,12 +2641,14 @@ Gator,1
 Gatsby,1
 Gaucho,1
 Gauge,1
+Gauloise,1
 Gauntlet,1
 Gauss,1
 Gavel,1
 Gazelle,1
 Gear,1
 Gearbox,1
+Gearhead,1
 Gearshift,1
 Gecko,1
 Geek,1
@@ -2621,6 +2657,7 @@ Geist,1
 Gemini,1
 Gemstone,1
 Genbu,1
+Gendarme,1
 General,1
 Generator,1
 Generic,1
@@ -2656,6 +2693,7 @@ Giggles,1
 Gilded,1
 Gilgamesh,1
 Gillarg,1
+Gimlet,1
 Gimmick,1
 Gin,1
 Ginger,1
@@ -2708,6 +2746,7 @@ Gnome,1
 Goad,1
 Goalie,1
 Goat,1
+Goblet,1
 Goblin,1
 Gobstopper,1
 Godan,1
@@ -2751,6 +2790,7 @@ Gore,1
 Gorge,1
 Gorgon,1
 Gorilla,1
+Goshawk,1
 Gossamer,1
 Gossip,1
 Gourmand,1
@@ -2793,6 +2833,7 @@ Grease Fire,1
 Greaseball,1
 Greasy,1
 Great Wall,1
+Great White,1
 Greedy,1
 Green,1
 Green Light,1
@@ -2830,6 +2871,7 @@ Grounder,1
 Groundhog,1
 Grouse,1
 Growl,1
+Growler,1
 Grub,1
 Grudge,1
 Grumbles,1
@@ -2845,6 +2887,7 @@ Guerrilla,1
 Guidance,1
 Guideline,1
 Guidestar,1
+Guild,1
 Guile,1
 Guillotine,1
 Guilty,1
@@ -2932,6 +2975,7 @@ Hangover,1
 Hannibal,1
 Happy,1
 Happy Hour,1
+Harasser,1
 Harassment,1
 Harbinger,1
 Harbor,1
@@ -2978,6 +3022,7 @@ Havok,1
 Hawk,1
 Hawkeye,1
 Hawkstrike,1
+Hawkwood,1
 Haymaker,1
 Hayseed,1
 Haystack,1
@@ -3456,6 +3501,7 @@ Joan,1
 Jock,1
 Jockey,1
 Johnson,1
+Jojo
 Joker,1
 Jolly,1
 Jolly Roger,1
@@ -3527,6 +3573,7 @@ Kato,1
 Katyusha,1
 Kayak,1
 Kazoo,1
+Kedge,1
 Keelhaul,1
 Keeper,1
 Keepsake,1
@@ -3534,6 +3581,7 @@ Kellhound,1
 Kelp,1
 Kelpie,1
 Kenjutsu,1
+Kennel,1
 Kepler,1
 Kerberos,1
 Keresh,1
@@ -3550,7 +3598,9 @@ Keymaster,1
 Keystone,1
 Keystroke,1
 Keytar,1
+Khalifa,1
 Khan,1
+Khazar,1
 Khepri,1
 Khopesh,1
 Ki-rian,1
@@ -3572,6 +3622,7 @@ Kilo,1
 Kilobyte,1
 Kiloton,1
 Kilroy,1
+Kilter,1
 Kindle,1
 Kindling,1
 Kinetic,1
@@ -3585,16 +3636,19 @@ Kingwood,1
 Kinky,1
 Kinship,1
 Kintsugi,1
+Kipper,1
 Kipup,1
 Kishi,1
 Kismet,1
 Kitbash,1
+Kitchen,1
 Kitchen Sink,1
 Kite,1
 Kitsune,1
 Kitten,1
 Kitty,1
 Kitty Hawk,1
+Kitty Kat,1
 Kiwi,1
 Klepto,1
 Knave,1
@@ -3618,6 +3672,7 @@ Kojak,1
 Komodo,1
 Kong,1
 Kongming,1
+Kookaburra,1
 Koschei,1
 Kpinga,1
 Krakatoa,1
@@ -3629,6 +3684,7 @@ Krieger,1
 Krill,1
 Kronos,1
 Krunch,1
+Krypton,1
 Kukri,1
 Kumiho,1
 Kumquat,1
@@ -3672,6 +3728,7 @@ Larva,1
 Laser,1
 Lash,1
 Lasher,1
+Lassie,1
 Lasso,1
 Lastshot,1
 Latch,1
@@ -3883,6 +3940,7 @@ MacGuyver,1
 Mach,1
 Machete,1
 Machine,1
+Machinegun,1
 Macho,1
 Mack,1
 Macro,1
@@ -3890,6 +3948,7 @@ Mad Bomber,1
 Mad Dog,1
 Mad Fox,1
 Mad Wolf,1
+Madball,1
 Madcap,1
 Madhat,1
 Madman,1
@@ -3940,6 +3999,7 @@ Mambo,1
 Mammoth,1
 Man o' War,1
 Man Trap,1
+Man-At-Arms,1
 Mana,1
 Manacle,1
 Manatee,1
@@ -3987,10 +4047,12 @@ Marrow,1
 Mars,1
 Marshal,1
 Marshmallow,1
+Martian,1
 Martini,1
 Martyr,1
 Marvel,1
 Marvin,1
+Marxist,1
 Masamune,1
 Mascara,1
 Mascot,1
@@ -4253,6 +4315,7 @@ Mountain,1
 Mourner,1
 Mouse,1
 Mouse Trap,1
+Mouser,1
 Mouth,1
 Mouthwash,1
 Mover,1
@@ -4380,6 +4443,7 @@ Newton,1
 Nexus,1
 Nibbler,1
 Nibbles,1
+Nice Guy,1
 Nickel,1
 Nickname,1
 Niflheim,1
@@ -4415,7 +4479,9 @@ Nitpick,1
 Nitro,1
 Nitty Gritty,1
 Nixie,1
+No Fear,
 No Mercy,1
+No Surrender,
 No Vacancy,1
 Noble,1
 Nobody,1
@@ -4448,6 +4514,7 @@ Nova,1
 Nox,1
 Nozzle,1
 Nu,1
+Nuclear,1
 Nugget,1
 Nuggets,1
 Nuke,1
@@ -4722,6 +4789,7 @@ Peasant,1
 Peashooter,1
 Pebble,1
 Pecan,1
+Pecheneg,1
 Peddler,1
 Pedigree,1
 Peekaboo,1
@@ -4800,6 +4868,7 @@ Pigpen,1
 Pigtails,1
 Pike,1
 Pile Driver,1
+Pilgrim,1
 Pilgrim,1
 Pillager,1
 Pillar,1
@@ -5120,6 +5189,7 @@ Quiet,1
 Quill,1
 Quiver,1
 Quizshow,1
+Quokka,1
 Quote,1
 Rabbi,1
 Rabbit,1
@@ -5137,6 +5207,7 @@ Radburn,1
 Radiance,1
 Radiant,1
 Radio,1
+Radiohead,1
 Radiowave,1
 Radish,1
 Radium,1
@@ -5419,6 +5490,7 @@ Rollout,1
 Rolly Polly,1
 Roman,1
 Romantic,1
+RomCom,1
 Romeo,1
 Rommel,1
 Ronin,1
@@ -5516,6 +5588,7 @@ Sabotage,1
 Saboteur,1
 Sack,1
 Sacrifice,1
+Saddler,1
 Saddlesore,1
 Sadist,1
 Sadsack,1
@@ -5526,6 +5599,7 @@ Saffron,1
 Saga,1
 Sage,1
 Sagebrush,1
+Sagger,1
 Saggy,1
 Sagittarius,1
 Sahara,1
@@ -5546,6 +5620,7 @@ Salt Water,1
 Saltfang,1
 Saltine,1
 Salty Dog,1
+Salty,1
 Salvage,1
 Salvager,1
 Salvo,1
@@ -5560,7 +5635,9 @@ Sand Wedge,1
 Sandalwood,1
 Sandbag,1
 Sandbar,1
+Sandbox,1
 Sandcastle,1
+Sandfly,1
 Sandhog,1
 Sandman,1
 Sandrock,1
@@ -5571,9 +5648,11 @@ Sanguine,1
 Santa,1
 Sapper,1
 Sapphire,1
+Sapwood,1
 Sardine,1
 Sardonic,1
 Sarge,1
+Sark,1
 Saros,1
 Sasquatch,1
 Sassafras,1
@@ -5594,15 +5673,21 @@ Savior,1
 Savvy,1
 Sawblade,1
 Sawbuck,1
+Sawfly,1
+Sawhorse,1
 Sawmill,1
+Saxhorn,1
 Saxon,1
 Scab,1
+Scaleboard,1
 Scales,1
 Scallywag,1
 Scalpel,1
+Scamp,1
 Scamper,1
 Scandal,1
 Scanner,1
+Scapegoat,1
 Scar,1
 Scarab,1
 Scarecrow,1
@@ -5658,6 +5743,8 @@ Scribe,1
 Scrimshaw,1
 Scroll,1
 Scrooge,1
+Scrubber,1
+Scrubbrush,1
 Scruff,1
 Scruffer,1
 Scruffy,1
@@ -5851,6 +5938,7 @@ Shut-In,1
 Shutter,1
 Shutterbug,1
 Shuttle,1
+Sibling,1
 Sicilian,1
 Sickle,1
 Sidearm,1
@@ -5880,6 +5968,7 @@ Silencer,1
 Silent,1
 Silhouette,1
 Silk,1
+Silkworm,1
 Silky,1
 Silly String,1
 Silver,1
@@ -6107,6 +6196,7 @@ Sombrero,1
 Sonar,1
 Sonata,1
 Songbird,1
+Songster,1
 Sonic,1
 Sonic Boom,1
 Soot,1
@@ -6214,6 +6304,7 @@ Sprawl,1
 Spraycan,1
 Spreadsheet,1
 Spring,1
+Springer,1
 Sprinkles,1
 Sprint,1
 Sprinter,1
@@ -6240,6 +6331,7 @@ Squirrel,1
 Squirt,1
 Squirtgun,1
 Squishy,1
+Stabber,1
 Stack,1
 Stadium,1
 Stag,1
@@ -6265,6 +6357,7 @@ Star,1
 Starbird,1
 Starboard,1
 Starbreaker,1
+Starbright,1
 Starbuck,1
 Starburst,1
 Starch,1
@@ -6469,8 +6562,10 @@ Swan Song,1
 Swanky,1
 Swarm,1
 Swashbuckler,1
+Swatter,1
 Swear Jar,1
 Sweatervest,1
+Swede,1
 Sweep,1
 Sweeper,1
 Sweet,1
@@ -6755,6 +6850,7 @@ Tomato,1
 Tomb,1
 Tomboy,1
 Tombstone,1
+Tommygun,1
 Tonbokiri,1
 Tongue,1
 Tongue Twister,1
@@ -6917,6 +7013,7 @@ Turbo,1
 Turbulence,1
 Turk,1
 Turkey,1
+Turkoman,1
 Turnaround,1
 Turncoat,1
 Turnip,1
@@ -7418,6 +7515,7 @@ Ziggy,1
 Zigzag,1
 Zijing,1
 Ziming,1
+Zinc,1
 Zinger,1
 Zipline,1
 Zipper,1


### PR DESCRIPTION
Added about 100 more callsigns.

Some based on NATO codenames, some taken from those I have used in campaigns myself.

Acrid
Adze
Alamo
Alkali
Amos
Aphid
Ashigaru
Async
Atoll
Audacity
Awl
Axehead
Ayyubid
Bad Boy
Bedouin
Big Momma
Black Rider
Bushmaster 
Carabinier
Cashier
Caustic
Cloggie
Coldheart
Double Trouble
Drop Bear
Expert
Flyswatter
Fry-up
Gadfly
Gainful
Galosh
Gammon
Ganef
Gaskin
Gauloise
Gearhead
Gendarme
Gimlet
Goblet
Goldfish
Goshawk
Great White
Growler
Guild
Harasser
Hawkwood
Jojo
Kedge
Kennel
Khalifa
Khazar
Kilter
Kingbolt
Kipper
Kitchen
Kitty Kat
Kookaburra
Krypton
Lassie
Machinegun
Madball
Man-At-Arms
Martian
Marxist
Mouser
Nice guy
No Fear,
No Surrender,
Nuclear
Pecheneg
Pilgrim
Quokka
Radiohead
RomCom
Ruthless
Saddler
Sagger
Salty
Sandbox
Sandfly
Sapwood
Sark
Sawfly
Sawhorse
Saxhorn
Scaleboard
Scamp
Scapegoat
Scrubber
Scrubbrush
Sibling
Silkworm
Snapper
Songster
Spandrel
Springer
Stabber
Starbright
Swatter
Swede
Tommygun
Turkoman
Zinc