### PR TITLE
Add 50 more callsigns, based on band names (mostly metal)

### DIFF
--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -21,8 +21,10 @@ Absurd,1
 Abyss,1
 Academic,1
 Accelerator,1
+Accept,1
 Accomplice,1
 Accountant,1
+AC/DC,1
 Ace,1
 Achilles,1
 Acid,1
@@ -55,6 +57,7 @@ Aeneas,1
 Aerial,1
 Aerie,1
 Aero,1
+Aerosmith,1
 Aether,1
 Aethon,1
 Afro,1
@@ -166,6 +169,7 @@ Andromeda,1
 Anecdote,1
 Anemone,1
 Angel,1
+Angel Witch,1
 Anger,1
 Anger Management,1
 Angora,1
@@ -174,6 +178,7 @@ Angst,1
 Angus,1
 Animal,1
 Ankh,1
+Annihilator,1
 Announcer,1
 Anomaly,1
 Ant,1
@@ -181,6 +186,7 @@ Antares,1
 Anteater,1
 Antelope,1
 Anthem,1
+Anthrax,1
 Anticipation,1
 Antidote,1
 Antique,1
@@ -288,6 +294,7 @@ Aswang,1
 Asylum,1
 Async,1
 Atalanta,1
+Atheist,1
 Athena,1
 Athens,1
 Athlete,1
@@ -296,6 +303,7 @@ Atlantis,1
 Atlas,1
 Atoll,1
 Atom,1
+Atomkraft,1
 Atomic,1
 Attila,1
 Attitude,1
@@ -309,6 +317,7 @@ Aurora,1
 Austin,1
 Auto,1
 Autocannon,1
+Autopsy,1
 Autumn,1
 Avalanche,1
 Avalon,1
@@ -362,6 +371,7 @@ Backup,1
 Bacon,1
 Baconator,1
 Bad Boy,1
+Bad Company,1
 Bad Luck,1
 Badge,1
 Badger,1
@@ -614,6 +624,7 @@ Black Knight,1
 Black Magic,1
 Black Powder,1
 Black Rider,1
+Black Sabbath,1
 Black Sheep,1
 Black Swan,1
 Black Widow,1
@@ -731,6 +742,7 @@ Bolero,1
 Bollard,1
 Bolo,1
 Bolt,1
+Bolt Thrower,1
 Bomb,1
 Bombardier,1
 Bomber,1
@@ -1035,6 +1047,7 @@ Cancer,1
 Candelabra,1
 Candle,1
 Candlelight,1
+Candlemass,1
 Candlestick,1
 Candlewax,1
 Candy,1
@@ -1047,6 +1060,7 @@ Canis,1
 Canister,1
 Canister Shot,1
 Cannibal,1
+Cannibal Corpse,1
 Cannon,1
 Cannonball,1
 Canteen,1
@@ -1129,6 +1143,7 @@ Catamaran,1
 Catapult,1
 Catastrophe,1
 Catfish,1
+Cathedral,1
 Catherine,1
 Catman,1
 Catnip,1
@@ -1147,6 +1162,7 @@ Celeste,1
 Celestial,1
 Cellar,1
 Cello,1
+Celtic Frost,1
 Cement,1
 Census,1
 Centaur,1
@@ -1304,6 +1320,7 @@ Circle,1
 Circuit,1
 Circuit Breaker,1
 Circus,1
+Cirith Ungol,1
 Citadel,1
 Citrine,1
 Citrus,1
@@ -1359,6 +1376,7 @@ Clot,1
 Cloud,1
 Cloudbreaker,1
 Cloudburst,1
+Cloven Hoof,1
 Clover,1
 Clown,1
 Clown Car,1
@@ -1493,6 +1511,7 @@ Cornrows,1
 Corny,1
 Corona,1
 Coronet,1
+Coroner,1
 Coronis,1
 Corporate,1
 Corpse,1
@@ -1779,11 +1798,13 @@ Decoy,1
 Decryption,1
 Deep Dish,1
 Deep Freeze,1
+Deep Purple,1
 Deep Six,1
 Deepfang,1
 Deepfield,1
 Deepsea,1
 Deer Hunter,1
+Def Leppard,1
 Defcon,1
 Defector,1
 Defender,1
@@ -1793,6 +1814,7 @@ Defrag,1
 Defrost,1
 Defuse,1
 Dehydrate,1
+Deicide,1
 Deimos,1
 Dekker,1
 Delivery,1
@@ -1849,6 +1871,7 @@ Diadem,1
 Diagram,1
 Dialtone,1
 Diamond,1
+Diamond Head,1
 Diamondback,1
 Dian Wei,1
 Dice,1
@@ -2227,6 +2250,7 @@ Executive,1
 Executor,1
 Exile,1
 Exit,1
+Exodus,1
 Exotic,1
 Expedition,1
 Experience,1
@@ -2265,6 +2289,7 @@ Fair Weather,1
 Fairground,1
 Fairytale,1
 Faith,1
+Faith No More,1
 Faithful,1
 Faker,1
 Falchion,1
@@ -2352,6 +2377,7 @@ Fine-line,1
 Fingers,1
 Finish Line,1
 Finn,1
+Finntroll,1
 Finback,1
 Fire,1
 Fire Cat,1
@@ -2447,6 +2473,7 @@ Floppy,1
 Flora,1
 Floss,1
 Flotsam,1
+Flotsam and Jetsam,1
 Flounder,1
 Flourish,1
 Flow,1
@@ -2702,6 +2729,7 @@ Gingersnap,1
 Ginsu,1
 Giraffe,1
 Girder,1
+Girlschool,1
 Gizmo,1
 Gizzard,1
 Glacier,1
@@ -2754,6 +2782,7 @@ Godfather,1
 Godiva,1
 Godless,1
 Godric,1
+Godsmack,1
 Godspeed,1
 Goggles,1
 Goji,1
@@ -3022,6 +3051,7 @@ Havok,1
 Hawk,1
 Hawkeye,1
 Hawkstrike,1
+Hawkwind,1
 Hawkwood,1
 Haymaker,1
 Hayseed,1
@@ -3082,6 +3112,7 @@ Hellebore,1
 Hellfire,1
 Hellhound,1
 Hellion,1
+Helloween,1
 Helm,1
 Helmet,1
 Helo,1
@@ -3169,6 +3200,7 @@ Hollow,1
 Holly,1
 Hollywood,1
 Holo,1
+Holocaust,1
 Holovid,1
 Holy,1
 Holy Man,1
@@ -3331,6 +3363,7 @@ Illiad,1
 Illusion,1
 Image,1
 Immigrant,1
+Immolation,1
 Immortal,1
 Imp,1
 Impact,1
@@ -3515,6 +3548,7 @@ Joy,1
 Joystick,1
 Jubilee,1
 Jubokko,1
+Judas Priest,1
 Judge,1
 Judgement,1
 Judo,1
@@ -3627,6 +3661,7 @@ Kindle,1
 Kindling,1
 Kinetic,1
 King,1
+King Diamond,1
 King Kong,1
 Kingcrab,1
 Kingfisher,1
@@ -3640,6 +3675,7 @@ Kipper,1
 Kipup,1
 Kishi,1
 Kismet,1
+Kiss,1
 Kitbash,1
 Kitchen,1
 Kitchen Sink,1
@@ -3680,6 +3716,7 @@ Kraken,1
 Krakenborn,1
 Krampus,1
 Krav,1
+Kreator,1
 Krieger,1
 Krill,1
 Kronos,1
@@ -3755,6 +3792,7 @@ Leaky,1
 Leash,1
 Leather,1
 Leatherneck,1
+Led Zeppelin,1
 Leech,1
 Lefty,1
 Leg Biter,1
@@ -3941,6 +3979,7 @@ Mach,1
 Machete,1
 Machine,1
 Machinegun,1
+Machinehead,1
 Macho,1
 Mack,1
 Macro,1
@@ -4061,6 +4100,7 @@ Masquerade,1
 Massacre,1
 Masseuse,1
 Mast,1
+Master,1
 Masterkey,1
 Mastermind,1
 Masterpiece,1
@@ -4106,6 +4146,7 @@ Medivac,1
 Medusa,1
 Meep,1
 Mega,1
+Megadeath,1
 Megaflop,1
 Megamind,1
 Megaphone,1
@@ -4134,6 +4175,7 @@ Merchant,1
 Merciless,1
 Mercury,1
 Mercy,1
+Mercyful Fate,1
 Meridian,1
 Merlin,1
 Merlot,1
@@ -4145,7 +4187,9 @@ Mesa,1
 Messenger,1
 Meta,1
 Metal,1
+Metal Church,1
 Metalhead,1
+Metallica,1
 Metalshard,1
 Meteor,1
 Meteorite,1
@@ -4187,6 +4231,7 @@ Miner,1
 Minerva,1
 Minimum,1
 Minion,1
+Ministry,1
 Minor,1
 Minos,1
 Minotaur,1
@@ -4260,6 +4305,7 @@ Monolith,1
 Monopoly,1
 Monsoon,1
 Monster,1
+Monster Magnet,1
 Monster Mash,1
 Monument,1
 Moo-Moo,1
@@ -4286,6 +4332,7 @@ Moped,1
 Moral,1
 Morale,1
 Moray,1
+Morbid Angel,1
 Mordred,1
 Morgana,1
 Morning Glory,1
@@ -4309,7 +4356,9 @@ Mothership,1
 Mothman,1
 Motion,1
 Motley,1
+Mötley Crue,1
 Motor Mouth,1
+Motörhead,1
 Motown,1
 Mountain,1
 Mourner,1
@@ -4391,6 +4440,7 @@ Nano,1
 Nanobot,1
 Nanofang,1
 Napalm,1
+Napalm Death,1
 Napkin,1
 Napoleon,1
 Naptime,1
@@ -4405,6 +4455,7 @@ Nav,1
 Navigator,1
 NavPoint,1
 Naysayer,1
+Nazareth,1
 Neanderthal,1
 Nebula,1
 Necromancer,1
@@ -4466,6 +4517,7 @@ Nightstalker,1
 Nightstick,1
 Nightwalker,1
 Nightwatch,1
+Nightwish,1
 Nihongo,1
 Niles,1
 Nimble,1
@@ -4515,6 +4567,7 @@ Nox,1
 Nozzle,1
 Nu,1
 Nuclear,1
+Nuclear Assault,1
 Nugget,1
 Nuggets,1
 Nuke,1
@@ -4537,6 +4590,7 @@ Oath,1
 Oatmeal,1
 Obedient,1
 Oberon,1
+Obituary,1
 Oblivion,1
 Oblivious,1
 Oboe,1
@@ -4681,6 +4735,7 @@ Packet,1
 Packrat,1
 Padlock,1
 Pagan,1
+Pagan Altar,1
 Pagoda,1
 Paingod,1
 Paint,1
@@ -4706,6 +4761,7 @@ Pandemonium,1
 Pandora,1
 Pangea,1
 Panic,1
+Pantera,1
 Panther,1
 Pantry,1
 Pants,1
@@ -5013,8 +5069,10 @@ Portal,1
 Porthos,1
 Poseidon,1
 Positron,1
+Possessed,1
 Possibilities,1
 Possum,1
+Post Mortem,1
 Poster,1
 Postie,1
 Postman,1
@@ -5064,6 +5122,7 @@ Primer,1
 Primetime,1
 Primo,1
 Primrose,1
+Primus,1
 Prince,1
 Princess,1
 Prism,1
@@ -5074,6 +5133,7 @@ Privilege,1
 Prize,1
 Probability,1
 Probe,1
+Probot,1
 Prodigal,1
 Prodigy,1
 Professor,1
@@ -5175,6 +5235,7 @@ Quasimodo,1
 Queen,1
 Queen Bee,1
 Queenie,1
+Queensrÿche,1
 Quench,1
 Quest,1
 Question,1
@@ -5186,6 +5247,7 @@ Quickshot,1
 Quicksilver,1
 Quickstrike,1
 Quiet,1
+Quiet Riot,1
 Quill,1
 Quiver,1
 Quizshow,1
@@ -5264,6 +5326,7 @@ Rat Party,1
 Rat Trap,1
 Ratbag,1
 Ratchet,1
+Ratt,1
 Rattle,1
 Rattler,1
 Rattlesnake,1
@@ -5468,6 +5531,7 @@ Roc,1
 Rock,1
 Rock Bottom,1
 Rock Candy,1
+Rock Goddess,1
 Rock n Roll,1
 Rock Solid,1
 Rocket,1
@@ -5606,6 +5670,7 @@ Sahara,1
 Sai,1
 Sailor,1
 Saint,1
+Saint Vitus,1
 Sake,1
 Salad,1
 Salamander,1
@@ -5649,6 +5714,7 @@ Santa,1
 Sapper,1
 Sapphire,1
 Sapwood,1
+Saracen,1
 Sardine,1
 Sardonic,1
 Sarge,1
@@ -5799,6 +5865,7 @@ Sentry,1
 Sentry Crow,1
 Sepia,1
 Septic,1
+Sepultura,1
 Sequence,1
 Sequoia,1
 Seraph,1
@@ -6020,6 +6087,7 @@ Skully,1
 Skunk,1
 Sky,1
 Sky Crane,1
+Skyclad,1
 Skydancer,1
 Skye,1
 Skyfall,1
@@ -6172,6 +6240,7 @@ Socks,1
 Socrates,1
 Soda Pop,1
 Sodium,1
+Sodom,1
 Sofa,1
 Soft Serve,1
 Softball,1
@@ -6207,8 +6276,10 @@ Sorry,1
 Sortie,1
 Soul,1
 Soulfire,1
+Soulfly,1
 Sound,1
 Sounder,1
+Soundgarden,1
 Soup,1
 Soup Can,1
 Sourbug,1
@@ -6269,6 +6340,7 @@ Spider,1
 Spider Monkey,1
 Spigot,1
 Spike,1
+Spinal Tap,1
 Spinalcord,1
 Spindle,1
 Spindrift,1
@@ -6380,8 +6452,10 @@ Startup,1
 Starward,1
 Stash,1
 Static,1
+Static-X,1
 Station,1
 Statistic,1
+Status Quo,1
 Steadfast,1
 Steak,1
 Stealth,1
@@ -6597,6 +6671,7 @@ Syndrome,1
 Synergy,1
 Syrup,1
 Sysop,1
+System of a Down,1
 T-Bone,1
 T-Rex,1
 T-Wrecks,1
@@ -6637,6 +6712,7 @@ Tangle,1
 Tango,1
 Taniwha,1
 Tank,1
+Tankard,1
 Tankbuster,1
 Tanker,1
 Tantrum,1
@@ -6725,6 +6801,7 @@ Tesla,1
 Tesseract,1
 Test Pilot,1
 Test Tube,1
+Testament,1
 Tetanus,1
 Tetrad,1
 Texas,1
@@ -6745,6 +6822,7 @@ Theta,1
 Thief,1
 Thimble,1
 Thin Ice,1
+Thin Lizzy,1
 Thinker,1
 Third Degree,1
 Thirteen,1
@@ -7031,6 +7109,7 @@ Twinkle,1
 Twinkletoes,1
 Twirl,1
 Twisted,1
+Twisted Sister,1
 Twister,1
 Twitch,1
 Two Face,1
@@ -7041,6 +7120,7 @@ Two-Dog,1
 Two-Strike,1
 Two-Ton,1
 Two-Tone,1
+Type O Negative,1
 Typewriter,1
 Typhon,1
 Typhoon,1
@@ -7202,6 +7282,7 @@ Vodka,1
 Vogel,1
 Voice,1
 Void,1
+Voivod,1
 Volcano,1
 Volley,1
 Volleyball,1
@@ -7339,9 +7420,11 @@ White Knight,1
 White Lie,1
 White Rose,1
 White Tiger,1
+White Zombie,1
 Whitecap,1
 Whitefish,1
 Whiteout,1
+Whitesnake,1
 Whitewash,1
 Whittle,1
 Whiz Kid,1
@@ -7401,6 +7484,7 @@ Wisteria,1
 Witch,1
 Witch Doctor,1
 Witch Hunt,1
+Witchfinder General,1
 Witchhazel,1
 Withered,1
 Witness,1
@@ -7435,6 +7519,7 @@ Wraithborn,1
 Wraithcaller,1
 Wrangler,1
 Wrath,1
+Wrathchild,1
 Wreath,1
 Wreckage,1
 Wrecker,1

--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -3751,7 +3751,6 @@ Joy,1
 Joystick,1
 Jubilee,1
 Jubokko,1
-Judas Priest,1
 Judge,1
 Judgement,1
 Judo,1
@@ -6599,7 +6598,6 @@ Soulfire,1
 Soulfly,1
 Sound,1
 Sounder,1
-Soundgarden,1
 Soup,1
 Soup Can,1
 Sourbug,1

--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -171,7 +171,6 @@ Andromeda,1
 Anecdote,1
 Anemone,1
 Angel,1
-Angel Witch,1
 Anger,1
 Anger Management,1
 Angle,1
@@ -380,7 +379,6 @@ Backup,1
 Bacon,1
 Baconator,1
 Bad Boy,1
-Bad Company,1
 Bad Luck,1
 Badge,1
 Badger,1
@@ -641,7 +639,6 @@ Black Knight,1
 Black Magic,1
 Black Powder,1
 Black Rider,1
-Black Sabbath,1
 Black Sheep,1
 Black Swan,1
 Black Widow,1
@@ -767,7 +764,7 @@ Bolero,1
 Bollard,1
 Bolo,1
 Bolt,1
-Bolt Thrower,1
+Boltthrower,1
 Bomb,1
 Bombardier,1
 Bomber,1
@@ -1110,7 +1107,6 @@ Canis,1
 Canister,1
 Canister Shot,1
 Cannibal,1
-Cannibal Corpse,1
 Cannon,1
 Cannonball,1
 Canteen,1
@@ -1216,7 +1212,6 @@ Celeste,1
 Celestial,1
 Cellar,1
 Cello,1
-Celtic Frost,1
 Cement,1
 Census,1
 Centaur,1
@@ -1391,7 +1386,6 @@ Circle,1
 Circuit,1
 Circuit Breaker,1
 Circus,1
-Cirith Ungol,1
 Citadel,1
 Citrine,1
 Citrus,1
@@ -1966,7 +1960,6 @@ Diadem,1
 Diagram,1
 Dialtone,1
 Diamond,1
-Diamond Head,1
 Diamondback,1
 Dian Wei,1
 Dice,1
@@ -2409,7 +2402,6 @@ Fair Weather,1
 Fairground,1
 Fairytale,1
 Faith,1
-Faith No More,1
 Faithful,1
 Faker,1
 Falchion,1
@@ -2612,7 +2604,6 @@ Flora,1
 Floss,1
 Flossy,1
 Flotsam,1
-Flotsam and Jetsam,1
 Flounder,1
 Flourish,1
 Flow,1
@@ -3876,7 +3867,6 @@ Kindle,1
 Kindling,1
 Kinetic,1
 King,1
-King Diamond,1
 King Kong,1
 Kingcrab,1
 Kingfisher,1
@@ -4414,7 +4404,6 @@ Merchant,1
 Merciless,1
 Mercury,1
 Mercy,1
-Mercyful Fate,1
 Meridian,1
 Merlin,1
 Merlot,1
@@ -4427,9 +4416,7 @@ Messenger,1
 Messiah,1
 Meta,1
 Metal,1
-Metal Church,1
 Metalhead,1
-Metallica,1
 Metalshard,1
 Meteor,1
 Meteorite,1
@@ -4550,7 +4537,6 @@ Monolith,1
 Monopoly,1
 Monsoon,1
 Monster,1
-Monster Magnet,1
 Monster Mash,1
 Monument,1
 Moo-Moo,1
@@ -4578,7 +4564,6 @@ Moped,1
 Moral,1
 Morale,1
 Moray,1
-Morbid Angel,1
 Mordred,1
 Morgana,1
 Morning Glory,1
@@ -4690,7 +4675,6 @@ Nano,1
 Nanobot,1
 Nanofang,1
 Napalm,1
-Napalm Death,1
 Napkin,1
 Napoleon,1
 Naptime,1
@@ -4826,7 +4810,6 @@ Nox,1
 Nozzle,1
 Nu,1
 Nuclear,1
-Nuclear Assault,1
 Nugget,1
 Nuggets,1
 Nuke,1
@@ -4998,7 +4981,6 @@ Packet,1
 Packrat,1
 Padlock,1
 Pagan,1
-Pagan Altar,1
 Pagoda,1
 Paingod,1
 Paint,1
@@ -5354,7 +5336,7 @@ Positron,1
 Possessed,1
 Possibilities,1
 Possum,1
-Post Mortem,1
+Postmortem,1
 Poster,1
 Postie,1
 Postman,1
@@ -5532,7 +5514,6 @@ Quickshot,1
 Quicksilver,1
 Quickstrike,1
 Quiet,1
-Quiet Riot,1
 Quill,1
 Quiver,1
 Quizshow,1
@@ -5964,7 +5945,6 @@ Sahara,1
 Sai,1
 Sailor,1
 Saint,1
-Saint Vitus,1
 Sake,1
 Salad,1
 Salamander,1
@@ -6684,7 +6664,6 @@ Spider,1
 Spider Monkey,1
 Spigot,1
 Spike,1
-Spinal Tap,1
 Spinalcord,1
 Spindle,1
 Spindrift,1
@@ -6807,7 +6786,6 @@ Static,1
 Static-X,1
 Station,1
 Statistic,1
-Status Quo,1
 Steadfast,1
 Steak,1
 Stealth,1
@@ -7203,7 +7181,6 @@ Theta,1
 Thief,1
 Thimble,1
 Thin Ice,1
-Thin Lizzy,1
 Thing,1
 Thinker,1
 Third Degree,1
@@ -7525,7 +7502,6 @@ Two-Strike,1
 Two-Ton,1
 Two-Tone,1
 Tycoon,1
-Type O Negative,1
 Typewriter,1
 Typhon,1
 Typhoon,1
@@ -7849,7 +7825,6 @@ White Knight,1
 White Lie,1
 White Rose,1
 White Tiger,1
-White Zombie,1
 Whitecap,1
 Whitefish,1
 Whiteout,1
@@ -7919,7 +7894,7 @@ Wisteria,1
 Witch,1
 Witch Doctor,1
 Witch Hunt,1
-Witchfinder General,1
+Witchfinder,1
 Witchhazel,1
 Withered,1
 Witness,1

--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -58,7 +58,6 @@ Aeneas,1
 Aerial,1
 Aerie,1
 Aero,1
-Aerosmith,1
 Aether,1
 Aethon,1
 Afro,1
@@ -1894,13 +1893,11 @@ Decoy,1
 Decryption,1
 Deep Dish,1
 Deep Freeze,1
-Deep Purple,1
 Deep Six,1
 Deepfang,1
 Deepfield,1
 Deepsea,1
 Deer Hunter,1
-Def Leppard,1
 Defcon,1
 Defector,1
 Defender,1
@@ -4014,7 +4011,6 @@ Leaky,1
 Leash,1
 Leather,1
 Leatherneck,1
-Led Zeppelin,1
 Leech,1
 Lefty,1
 Leg Biter,1
@@ -5525,7 +5521,6 @@ Quasimodo,1
 Queen,1
 Queen Bee,1
 Queenie,1
-Queensrÿche,1
 Quench,1
 Quest,1
 Question,1
@@ -7043,7 +7038,6 @@ Syndrome,1
 Synergy,1
 Syrup,1
 Sysop,1
-System of a Down,1
 T-Bone,1
 T-Rex,1
 T-Wrecks,1
@@ -7519,7 +7513,6 @@ Twinkle,1
 Twinkletoes,1
 Twirl,1
 Twisted,1
-Twisted Sister,1
 Twister,1
 Twitch,1
 Twix,1


### PR DESCRIPTION
Added another 50 callsigns, based on band names (mostly metal). 

I think these tend to fit the BT theme, your opinion may differ. Feel free to ask for removal of any of them.

But I think 'Cloven Hoof' would make a good Locust pilot, 'Immolation' should go in a Firestarter and there are others that have their uses.

Accept
AC/DC
Annihilator
Anthrax
Atheist
Atomkraft
Autopsy
Boltthrower
Candlemass
Cathedral
Cloven Hoof
Coroner
Deicide
Exodus
Finntroll
Girlschool
Godsmack
Hawkwind
Helloween
Holocaust
Immolation
Kiss
Kreator
Machinehead
Megadeath
Ministry
Motörhead
Nazareth
Nightwish
Obituary
Pantera
Possessed
Postmortem
Primus
Probot
Ratt
Rock Goddess
Saracen
Sepultura
Skyclad
Sodom
Soulfly
Static-X
Tankard
Testament
Voivod
Whitesnake
Witchfinder
Wrathchild