### PR TITLE
Numerous long callsigns removed 

### DIFF
--- a/data/names/callsigns.csv
+++ b/data/names/callsigns.csv
@@ -144,7 +144,6 @@ Amberglow,1
 Ambiance,1
 Ambrosia,1
 Ambush,1
-Ame-no-Ohabari,1
 Amen,1
 Amethyst,1
 Ammo,1
@@ -170,7 +169,6 @@ Anecdote,1
 Anemone,1
 Angel,1
 Anger,1
-Anger Management,1
 Angle,1
 Angora,1
 Angry,1
@@ -352,7 +350,6 @@ Babel,1
 Baboon,1
 Babs,1
 Baby,1
-Baby on Board,1
 Bacchus,1
 Back Alley,1
 Backdoor,1
@@ -361,7 +358,6 @@ Backfire,1
 Backfist,1
 Backflip,1
 Backlash,1
-Backseat Driver,1
 Backspin,1
 Backstab,1
 Backstage,1
@@ -388,7 +384,6 @@ Baklava,1
 Balance,1
 Balancer,1
 Bald,1
-Bald and Ugly,1
 Balderdash,1
 Baldy,1
 Balisong,1
@@ -578,7 +573,6 @@ Big Gulp,1
 Big Iron,1
 Big League,1
 Big Mac,1
-Big McLargeHuge,1
 Big Momma,1
 Big Money,1
 Big Nasty,1
@@ -917,7 +911,6 @@ Bruiser,1
 Brunch,1
 Brush Stroke,1
 Brushfire,1
-Brussels Sprout,1
 Brutal,1
 Brute,1
 Brutus,1
@@ -1010,7 +1003,6 @@ Butane,1
 Butch,1
 Butcher,1
 Butler,1
-Butt For Days,1
 Butter,1
 Butter Bars,1
 Butter Knife,1
@@ -1287,7 +1279,6 @@ Cherry,1
 Cherry Blossom,1
 Cherry Bomb,1
 Cherub,1
-Cheshire Cat,1
 Chester,1
 Chestnut,1
 Chevalier,1
@@ -1382,7 +1373,6 @@ Citrus,1
 City,1
 Citylight,1
 Civilian,1
-Claiomh Solais,1
 Clairvoyant,1
 Clam,1
 Clamor,1
@@ -1641,7 +1631,6 @@ Crane,1
 Crank,1
 Crankcase,1
 Crash,1
-Crash Test Dummy,1
 Crashdown,1
 Crashland,1
 Crashsite,1
@@ -1853,7 +1842,6 @@ Death Angel,1
 Death Knell,1
 Deathblow,1
 Deathdealer,1
-Deathscythe Murderkill,1
 Deathspire,1
 Deathstalker,1
 Deathstroke,1
@@ -2359,7 +2347,6 @@ Exquisite,1
 Extra Large,1
 Extra Life,1
 Extractor,1
-Extraterrestrial,1
 Eye Guy,1
 Eyeball,1
 Eyeballs,1
@@ -2411,7 +2398,6 @@ Fantasy,1
 Faraday,1
 Farmboy,1
 Farmer,1
-Farts Loudly,1
 Fashion Plate,1
 Fast Draw,1
 Fast Track,1
@@ -2484,7 +2470,6 @@ Finger,1
 Finger,1
 Fingers,1
 Fingers,1
-Fingers Nose,1
 Finish Line,1
 Finn,1
 Fire,1
@@ -3907,7 +3892,6 @@ Kukri,1
 Kumiho,1
 Kumquat,1
 Kunai,1
-Kusanagi-no-Tsurugi,1
 Lab Rat,1
 Lace,1
 Laceleaf,1
@@ -4065,7 +4049,6 @@ Loafer,1
 Loaner,1
 Lob,1
 Lobby,1
-Lobo Plumado,1
 Lobster,1
 Lock,1
 Lock-On,1
@@ -4607,7 +4590,6 @@ Murdock,1
 Murk,1
 Murky,1
 Murmillo,1
-Murphy's Law,1
 Muscles,1
 Muse,1
 Museum,1
@@ -4741,9 +4723,9 @@ Nitpick,1
 Nitro,1
 Nitty Gritty,1
 Nixie,1
-No Fear,,1
+No Fear,
 No Mercy,1
-No Surrender,,1
+No Surrender,1
 No Vacancy,1
 Noble,1
 Nobody,1
@@ -4890,7 +4872,6 @@ Osiris,1
 Osprey,1
 Ostrich,1
 Otegine,1
-Other New Guy,1
 Otter,1
 Otterhound,1
 Ouchie,1
@@ -5859,7 +5840,6 @@ Runaway,1
 Rune,1
 Runesmith,1
 Runner,1
-Runs With Scissors,1
 Runt,1
 Runtime,1
 Runway,1
@@ -6349,7 +6329,6 @@ Skyscraper,1
 Skysweeper,1
 Skyward,1
 Slab,1
-Slab Bulkhead,1
 Slacker,1
 Slag,1
 Slalom,1
@@ -6841,7 +6820,6 @@ Strudel,1
 Strut,1
 Stubborn,1
 Stuck Up,1
-Stuffed Shirt,1
 Stuka,1
 Stumpy,1
 Stungun,1
@@ -6872,7 +6850,6 @@ Sugar Baby,1
 Sugar Plum,1
 Sugar Rush,1
 Sugarcoat,1
-Sugari no Ontachi,1
 Sulfur,1
 Sulk,1
 Sulphur,1
@@ -7146,7 +7123,6 @@ Thorns,1
 Thorny,1
 Thoth,1
 Thought,1
-Thoughts n Prayers,1
 Thracian,1
 Thraex,1
 Thrall,1
@@ -7746,7 +7722,6 @@ Whale,1
 Whaler,1
 Wharf,1
 What?,1
-Whats Their Face,1
 Wheat,1
 Wheel,1
 Wheelbarrow,1
@@ -7901,7 +7876,6 @@ Xena,1
 Xerxes,1
 Xi,1
 Xuande,1
-XxDeathKiller47xX,1
 Xylophone,1
 Ya Dingus,1
 Yacht,1


### PR DESCRIPTION
As stated in the titles, 30 call signs which were long and cumbersome callsigns were removed from the CSV. 

Method:
The CSV was opened in OpenLibre Math, additional columns were added to count the number length of each string and how many words were present. All callsigns greater than 14 characters were removed. Then callsigns which were two words and and greater than 12 characters were than evaluated and determined if they were a reasonably brief callsign based purely on my opinion. The additional columns were then removed and the CSV was sorted back into natural order. 

Approximately 100 callsigns (out of >7500) remain which are >13 characters.  