### PR TITLE
Convert factionhints.xml to per-conflict factionDiplomacy YAML files

### DIFF
--- a/data/universe/factionDiplomacy/2398-2404_firstAndurienWar.yml
+++ b/data/universe/factionDiplomacy/2398-2404_firstAndurienWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: First Andurien War
+    start: 2398-01-01
+    end: 2404-12-31
+    parties:
+      - factions: [FWL, CC]

--- a/data/universe/factionDiplomacy/2407-2408_commonwealthCombineWar.yml
+++ b/data/universe/factionDiplomacy/2407-2408_commonwealthCombineWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Commonwealth-Combine War
+    start: 2407-01-01
+    end: 2408-12-31
+    parties:
+      - factions: [LA, DC]

--- a/data/universe/factionDiplomacy/2418-2422_rimWar.yml
+++ b/data/universe/factionDiplomacy/2418-2422_rimWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Rim War
+    start: 2418-01-01
+    end: 2422-12-31
+    parties:
+      - factions: [CC, TC]

--- a/data/universe/factionDiplomacy/2463-2468_theLongMarch.yml
+++ b/data/universe/factionDiplomacy/2463-2468_theLongMarch.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: The Long March
+    start: 2463-01-01
+    end: 2468-12-31
+    parties:
+      - factions: [LA, DC]
+      - factions: [LA, FWL]

--- a/data/universe/factionDiplomacy/2525-2540_davionCivilWar.yml
+++ b/data/universe/factionDiplomacy/2525-2540_davionCivilWar.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Civil war: the same faction is listed twice.
+
+wars:
+  - name: Davion Civil War
+    start: 2525-01-01
+    end: 2540-12-31
+    parties:
+      - factions: [FS, FS]

--- a/data/universe/factionDiplomacy/2528-2531_secondAndurienWar.yml
+++ b/data/universe/factionDiplomacy/2528-2531_secondAndurienWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Second Andurien War
+    start: 2528-01-01
+    end: 2531-12-31
+    parties:
+      - factions: [FWL, CC]

--- a/data/universe/factionDiplomacy/2551-2556_thirdAndurienWar.yml
+++ b/data/universe/factionDiplomacy/2551-2556_thirdAndurienWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Third Andurien War
+    start: 2551-01-01
+    end: 2556-12-31
+    parties:
+      - factions: [FWL, CC]

--- a/data/universe/factionDiplomacy/2571-2781_starLeague.yml
+++ b/data/universe/factionDiplomacy/2571-2781_starLeague.yml
@@ -1,0 +1,93 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The first Star League (2571-2781): member alliance and SLDF presence within the
+# member and territorial states.
+
+alliances:
+  - name: Star League
+    start: 2571-07-09
+    end: 2781-08-12
+    parties:
+      - factions: [SL, TH]
+      - factions: [SL, CC]
+      - factions: [SL, DC]
+      - factions: [SL, FS]
+      - factions: [SL, FWL]
+      - factions: [SL, LA]
+      - factions: [SL, OA]
+        start: 2597-03-21
+        end: 2765-01-01
+      - factions: [SL, TC]
+        start: 2597-03-21
+        end: 2765-01-01
+      - factions: [SL, MOC]
+        start: 2597-03-21
+        end: 2765-01-01
+      - factions: [SL, RWR]
+        start: 2597-03-21
+        end: 2765-01-01
+containedFactions:
+  - host: TH
+    contained: SL
+    start: 2572-08-22
+    end: 2781-08-12
+  - host: CC
+    contained: SL
+    start: 2572-10-07
+    end: 2781-08-12
+    fraction: 0.4
+  - host: DC
+    contained: SL
+    start: 2572-10-07
+    end: 2781-08-12
+    fraction: 0.4
+  - host: FS
+    contained: SL
+    start: 2572-10-07
+    end: 2781-08-12
+    fraction: 0.4
+  - host: FWL
+    contained: SL
+    start: 2572-10-07
+    end: 2781-08-12
+    fraction: 0.4
+  - host: LA
+    contained: SL
+    start: 2572-10-07
+    end: 2781-08-12
+    fraction: 0.4
+  - host: TC
+    contained: SL
+    start: 2597-03-21
+    end: 2765-01-01
+    fraction: 0.4
+  - host: OA
+    contained: SL
+    start: 2597-03-21
+    end: 2765-01-01
+    fraction: 0.4
+  - host: MOC
+    contained: SL
+    start: 2597-03-21
+    end: 2765-01-01
+    fraction: 0.4
+  - host: RWR
+    contained: SL
+    start: 2597-03-21
+    end: 2765-01-01
+    fraction: 0.4

--- a/data/universe/factionDiplomacy/2578-2597_reunificationWar.yml
+++ b/data/universe/factionDiplomacy/2578-2597_reunificationWar.yml
@@ -1,0 +1,30 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Reunification War
+    start: 2578-04-30
+    end: 2597-09-22
+    parties:
+      - factions: [SL, TC]
+      - factions: [SL, MOC]
+        end: 2588-12-06
+      - factions: [SL, OA]
+        end: 2581-11-17
+      - factions: [SL, RWR]
+        end: 2596-09-03

--- a/data/universe/factionDiplomacy/2725-2729_warOfDavionSuccession.yml
+++ b/data/universe/factionDiplomacy/2725-2729_warOfDavionSuccession.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: War of Davion Succession
+    start: 2725-01-01
+    end: 2729-12-31
+    parties:
+      - factions: [FS, DC]

--- a/data/universe/factionDiplomacy/2760-2762_davionLiaoBorderWar.yml
+++ b/data/universe/factionDiplomacy/2760-2762_davionLiaoBorderWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Davion-Liao Border War
+    start: 2760-01-01
+    end: 2762-07-31
+    parties:
+      - factions: [FS, CC]

--- a/data/universe/factionDiplomacy/2765-2767_peripheryRevolt.yml
+++ b/data/universe/factionDiplomacy/2765-2767_peripheryRevolt.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Periphery Revolt
+    start: 2765-01-01
+    end: 2767-12-31
+    parties:
+      - factions: [SL, TC]
+      - factions: [SL, MOC]
+      - factions: [SL, OA]

--- a/data/universe/factionDiplomacy/2767-2779_amarisCivilWar.yml
+++ b/data/universe/factionDiplomacy/2767-2779_amarisCivilWar.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Amaris Civil War
+    start: 2767-08-01
+    end: 2779-12-31
+    parties:
+      - factions: [SL, RWR]
+      - factions: [SL, TH]

--- a/data/universe/factionDiplomacy/2773-2775_theRepublicCommonwealthWar.yml
+++ b/data/universe/factionDiplomacy/2773-2775_theRepublicCommonwealthWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: The Republic-Commonwealth War
+    start: 2773-04-01
+    end: 2775-12-31
+    parties:
+      - factions: [LA, RWR]

--- a/data/universe/factionDiplomacy/2785-2821_firstSuccessionWar.yml
+++ b/data/universe/factionDiplomacy/2785-2821_firstSuccessionWar.yml
@@ -1,0 +1,30 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: First Succession War
+    start: 2786-12-01
+    end: 2821-05-16
+    parties:
+      - factions: [CC, FS]
+      - factions: [CC, FWL]
+      - factions: [DC, FS]
+      - factions: [DC, FWL]
+      - factions: [DC, LA]
+      - factions: [FWL, LA]
+        start: 2785-03-01

--- a/data/universe/factionDiplomacy/2807-3080_fireMandrillFactionalism.yml
+++ b/data/universe/factionDiplomacy/2807-3080_fireMandrillFactionalism.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Kindraa infighting: the same faction is listed twice.
+
+wars:
+  - name: Fire Mandrill Factionalism
+    start: 2807-01-01
+    end: 3080-12-31
+    parties:
+      - factions: [CFM, CFM]

--- a/data/universe/factionDiplomacy/2813-2814_theTaurianCanopianWar.yml
+++ b/data/universe/factionDiplomacy/2813-2814_theTaurianCanopianWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: The Taurian-Canopian War
+    start: 2813-07-01
+    end: 2814-02-28
+    parties:
+      - factions: [TC, MOC]

--- a/data/universe/factionDiplomacy/2821-2822_operationKlondike.yml
+++ b/data/universe/factionDiplomacy/2821-2822_operationKlondike.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Operation Klondike
+    start: 2821-07-02
+    end: 2822-05-26
+    parties:
+      - factions: [CLAN, REB]

--- a/data/universe/factionDiplomacy/2830-2864_secondSuccessionWar.yml
+++ b/data/universe/factionDiplomacy/2830-2864_secondSuccessionWar.yml
@@ -1,0 +1,30 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Second Succession War
+    start: 2830-05-01
+    end: 2864-11-30
+    parties:
+      - factions: [CC, FS]
+      - factions: [CC, FWL]
+      - factions: [DC, FS]
+      - factions: [DC, LA]
+        start: 2830-03-14
+      - factions: [FWL, LA]
+        start: 2830-06-14

--- a/data/universe/factionDiplomacy/2830-present_nuevaCastile.yml
+++ b/data/universe/factionDiplomacy/2830-present_nuevaCastile.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Umayyad conquest presence within Nueva Castile.
+
+containedFactions:
+  - host: NC
+    contained: UC
+    start: 2830-01-01
+    fraction: 0.6

--- a/data/universe/factionDiplomacy/2866-3025_thirdSuccessionWar.yml
+++ b/data/universe/factionDiplomacy/2866-3025_thirdSuccessionWar.yml
@@ -1,0 +1,31 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Dates are the canonical span (declared over by ComStar in 3025); intensity was
+# lower than the first two Succession Wars but the House borders were in
+# near-continuous conflict.
+
+wars:
+  - name: Third Succession War
+    start: 2866-01-01
+    end: 3025-12-31
+    parties:
+      - factions: [CC, FS]
+      - factions: [CC, FWL]
+      - factions: [DC, FS]
+      - factions: [DC, LA]
+      - factions: [FWL, LA]

--- a/data/universe/factionDiplomacy/3014-3015_marikCivilWar.yml
+++ b/data/universe/factionDiplomacy/3014-3015_marikCivilWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Marik Civil War
+    start: 3014-05-22
+    end: 3015-05-31
+    parties:
+      - factions: [FWL, FWLR]

--- a/data/universe/factionDiplomacy/3020-3067_federatedCommonwealth.yml
+++ b/data/universe/factionDiplomacy/3020-3067_federatedCommonwealth.yml
@@ -1,0 +1,41 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# FedCom-era standing relationships: the alliance of the two realms, the brief
+# Tikonov Free Republic alignment, and the member states contained within the
+# combined Federated Commonwealth.
+
+alliances:
+  - start: 3020-01-01
+    end: 3057-12-31
+    parties:
+      - factions: [FS, LA, FC]
+  - start: 3029-03-03
+    end: 3031-09-01
+    parties:
+      - factions: [FS, FC, LA, TFR]
+containedFactions:
+  - host: FC
+    contained: FS
+    start: 3028-08-20
+    end: 3067-04-16
+    fraction: 0.5
+  - host: FC
+    contained: LA
+    start: 3028-08-20
+    end: 3067-04-16
+    fraction: 0.5

--- a/data/universe/factionDiplomacy/3021-3035_auriganCivilWar.yml
+++ b/data/universe/factionDiplomacy/3021-3035_auriganCivilWar.yml
@@ -1,0 +1,44 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Setting for HBS' BattleTech game. The dates are very roughly estimated based on
+# descriptions in game and in the sourcebook, then adjusted to match the planetary
+# control dates in MHQ to help contract generation. The MOC containment covers the
+# Arano government-in-exile; the alliance end is a guess (we don't have a clean end
+# to when the MOC stopped overtly supporting ARC, so a decade was used).
+
+wars:
+  - name: Aurigan Civil War
+    start: 3025-01-25
+    end: 3025-12-30
+    parties:
+      - factions: [ARC, ARD]
+      - factions: [ARC, TC]
+        start: 3025-05-09
+        end: 3025-08-15
+alliances:
+  - start: 3021-01-01
+    end: 3035-12-30
+    parties:
+      - factions: [ARC, MOC]
+      - factions: [ARD, TC]
+containedFactions:
+  - host: MOC
+    contained: ARC
+    start: 3022-02-01
+    end: 3025-09-01
+    opponents: [ARD]

--- a/data/universe/factionDiplomacy/3026-3030_fourthSuccessionWar.yml
+++ b/data/universe/factionDiplomacy/3026-3030_fourthSuccessionWar.yml
@@ -1,0 +1,27 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Fourth Succession War
+    start: 3026-01-01
+    end: 3030-12-31
+    parties:
+      - factions: [FS, CC]
+      - factions: [FS, DC]
+      - factions: [LA, CC]
+      - factions: [LA, DC]

--- a/data/universe/factionDiplomacy/3029-3063_stIvesCompact.yml
+++ b/data/universe/factionDiplomacy/3029-3063_stIvesCompact.yml
@@ -1,0 +1,29 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# St. Ives Compact alignment with the Federated Commonwealth powers, ending with the
+# Compact's reabsorption after the Capellan-St. Ives War.
+
+alliances:
+  - start: 3029-01-01
+    end: 3063-06-10
+    parties:
+      - factions: [FS, FC, SIC]
+  - start: 3029-01-01
+    end: 3063-06-10
+    parties:
+      - factions: [LA, SIC]

--- a/data/universe/factionDiplomacy/3029-3081_comStarPresence.yml
+++ b/data/universe/factionDiplomacy/3029-3081_comStarPresence.yml
@@ -1,0 +1,55 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# ComStar's HPG-compound presence within the Inner Sphere states.
+
+containedFactions:
+  - host: CC
+    contained: CS
+    start: 3029-01-01
+    end: 3081-04-02
+    fraction: 0.01
+  - host: DC
+    contained: CS
+    start: 3030-01-01
+    end: 3081-04-02
+    fraction: 0.01
+  - host: FC
+    contained: CS
+    start: 3029-12-07
+    end: 3081-04-02
+    fraction: 0.01
+  - host: FS
+    contained: CS
+    start: 3029-12-07
+    end: 3081-04-02
+    fraction: 0.01
+  - host: FWL
+    contained: CS
+    start: 3030-01-01
+    end: 3052-07-01
+    fraction: 0.01
+  - host: LA
+    contained: CS
+    start: 3030-01-01
+    end: 3081-04-02
+    fraction: 0.01
+  - host: FRR
+    contained: CS
+    start: 3034-03-14
+    end: 3081-04-02
+    fraction: 0.01

--- a/data/universe/factionDiplomacy/3030-3040_fourthAndurienWar.yml
+++ b/data/universe/factionDiplomacy/3030-3040_fourthAndurienWar.yml
@@ -1,0 +1,29 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Fourth Andurien War
+    start: 3030-09-11
+    end: 3040-01-31
+    parties:
+      - factions: [CC, MOC]
+        end: 3035-06-01
+      - factions: [CC, DA]
+        end: 3035-06-01
+      - factions: [FWL, DA]
+        start: 3035-10-01

--- a/data/universe/factionDiplomacy/3034_roninWar.yml
+++ b/data/universe/factionDiplomacy/3034_roninWar.yml
@@ -1,0 +1,32 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Includes the rogue samurai forces operating inside the newly-formed FRR.
+
+wars:
+  - name: Ronin War
+    start: 3034-03-14
+    end: 3034-10-31
+    parties:
+      - factions: [DC, RON]
+      - factions: [FRR, RON]
+containedFactions:
+  - host: FRR
+    contained: RON
+    start: 3034-03-14
+    end: 3034-10-31
+    opponents: [DC, FRR]

--- a/data/universe/factionDiplomacy/3039-3040_warOf3039.yml
+++ b/data/universe/factionDiplomacy/3039-3040_warOf3039.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: War of 3039
+    start: 3039-01-01
+    end: 3040-12-31
+    parties:
+      - factions: [FC, DC]

--- a/data/universe/factionDiplomacy/3049-3052_clanInvasion.yml
+++ b/data/universe/factionDiplomacy/3049-3052_clanInvasion.yml
@@ -1,0 +1,44 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Operation Revival. The alliance covers ComStar's cooperation with the invading
+# Clans until the Battle of Tukayyid.
+
+wars:
+  - name: Clan Invasion
+    start: 3049-08-01
+    end: 3052-06-01
+    parties:
+      - factions: [FC, CJF]
+      - factions: [FC, CSV]
+      - factions: [FC, CW]
+      - factions: [FRR, CW]
+      - factions: [FRR, CGB]
+      - factions: [DC, CGB]
+      - factions: [DC, CSJ]
+      - factions: [DC, CNC]
+alliances:
+  - start: 3049-11-02
+    end: 3052-05-01
+    parties:
+      - factions: [CS, CJF]
+      - factions: [CS, CW]
+      - factions: [CS, CGB]
+      - factions: [CS, CSJ]
+      - factions: [CS, CSV]
+      - factions: [CS, CNC]
+      - factions: [CS, CDS]

--- a/data/universe/factionDiplomacy/3052-3081_wordOfBlakeJihad.yml
+++ b/data/universe/factionDiplomacy/3052-3081_wordOfBlakeJihad.yml
@@ -1,0 +1,73 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Jihad, including the WOB-FWL alliance, the Blake Protectorate presence in League
+# space, and Devlin Stone's allied coalition from 3073.
+
+wars:
+  - name: Word of Blake Jihad
+    start: 3067-12-05
+    end: 3081-04-02
+    parties:
+      - factions: [WOB, LA]
+      - factions: [WOB, FS]
+      - factions: [WOB, MERC]
+        start: 3067-10-15
+      - factions: [WOB, DC]
+        start: 3068-01-01
+      - factions: [WOB, CS]
+        start: 3068-01-21
+      - factions: [WOB, CC]
+        start: 3070-01-07
+      - factions: [WOB, Stone]
+        start: 3073-11-25
+      - factions: [WOB, CNC]
+        start: 3073-11-25
+      - factions: [WOB, CJF]
+        start: 3073-11-25
+      - factions: [WOB, CW]
+        start: 3073-11-25
+      - factions: [WOB, CGB]
+        start: 3074-12-15
+      - factions: [WOB, CSR]
+        start: 3076-02-16
+alliances:
+  - start: 3052-07-01
+    end: 3081-04-02
+    parties:
+      - factions: [WOB, FWL]
+  - start: 3073-11-25
+    end: 3081-04-02
+    parties:
+      - factions: [Stone, CNC]
+        start: 3071-10-31
+      - factions: [Stone, CNC, CJF, CW, LA, FS, DC, CS]
+      - factions: [Stone, CNC, CJF, CW, LA, FS, DC, CS, CGB]
+        start: 3075-09-21
+      - factions: [Stone, CNC, CJF, CW, LA, FS, DC, CS, CGB, CSR]
+        start: 3076-02-16
+containedFactions:
+  - host: FWL
+    contained: WOB
+    start: 3052-07-01
+    end: 3081-04-02
+    fraction: 0.1
+  - host: Stone
+    contained: CS
+    start: 3073-11-25
+    end: 3081-04-02
+    opponents: [WOB]

--- a/data/universe/factionDiplomacy/3054_marianLothianWar.yml
+++ b/data/universe/factionDiplomacy/3054_marianLothianWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Marian-Lothian War
+    start: 3054-01-01
+    end: 3054-12-31
+    parties:
+      - factions: [MH, LL]

--- a/data/universe/factionDiplomacy/3057_refusalWar.yml
+++ b/data/universe/factionDiplomacy/3057_refusalWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Refusal War
+    start: 3057-01-01
+    end: 3057-12-31
+    parties:
+      - factions: [CJF, CW]

--- a/data/universe/factionDiplomacy/3057_warOf3057.yml
+++ b/data/universe/factionDiplomacy/3057_warOf3057.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: War of 3057
+    start: 3057-01-01
+    end: 3057-12-31
+    parties:
+      - factions: [CC, FS]
+      - factions: [FWL, FS]

--- a/data/universe/factionDiplomacy/3058-3067_arcRoyalDefenseCordon.yml
+++ b/data/universe/factionDiplomacy/3058-3067_arcRoyalDefenseCordon.yml
@@ -1,0 +1,31 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Arc-Royal Defense Cordon (3058-3067): the autonomous Lyran region during the FedCom
+# Civil War. LA and FC players can get contracts in ARDC space.
+
+containedFactions:
+  - host: ARDC
+    contained: LA
+    start: 3058-01-01
+    end: 3067-04-20
+    fraction: 0.5
+  - host: ARDC
+    contained: FC
+    start: 3058-01-01
+    end: 3067-04-20
+    fraction: 0.3

--- a/data/universe/factionDiplomacy/3058-3067_secondStarLeague.yml
+++ b/data/universe/factionDiplomacy/3058-3067_secondStarLeague.yml
@@ -1,0 +1,55 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Second Star League, formed at the First Whitting Conference (November 3058; founding
+# day approximate) and dissolved at the Fourth Whitting Conference on 28 November 3067.
+# Without this entry the member states are treated as mutual enemies for the League's
+# whole existence. Pairs are ended early where a war between members is recorded
+# (Capellan-St. Ives War, FedCom Civil War). CC-FS and CC-FC pairs are deliberately
+# omitted: the Chaos March and Xin Sheng raiding kept that border hostile despite
+# shared membership.
+
+alliances:
+  - name: Second Star League
+    start: 3058-11-01
+    end: 3067-11-28
+    parties:
+      - factions: [SL, CS, DC, FRR, FWL, CC]
+      - factions: [FC, SL, CS, FRR, FWL]
+      - factions: [FC, FS]
+      - factions: [FC, DC]
+        end: 3062-11-15
+      - factions: [FS, SL, CS, FRR, FWL]
+      - factions: [FS, DC]
+        end: 3062-11-15
+      - factions: [LA, SL, CS, DC, FRR, FWL]
+      - factions: [LA, FC]
+        end: 3062-11-15
+      - factions: [LA, FS]
+        end: 3062-11-15
+      - factions: [SIC, SL, CS, DC, FRR, FWL]
+      - factions: [SIC, LA]
+      - factions: [SIC, FC]
+      - factions: [SIC, FS]
+      - factions: [SIC, CC]
+        end: 3061-01-26
+      - factions: [SL, MOC]
+        start: 3061-01-01
+      - factions: [SL, TC]
+        start: 3061-01-01
+      - factions: [SL, CNC]
+        start: 3059-05-20

--- a/data/universe/factionDiplomacy/3059-present_novaCatMigration.yml
+++ b/data/universe/factionDiplomacy/3059-present_novaCatMigration.yml
@@ -1,0 +1,34 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Clan Nova Cat's alignment with ComStar and the Draconis Combine, and their
+# presence in Combine space until the Nova Cat Rebellion.
+
+alliances:
+  - start: 3059-10-01
+    parties:
+      - factions: [CS, CNC]
+  - start: 3059-05-20
+    end: 3141-06-14
+    parties:
+      - factions: [DC, CNC]
+containedFactions:
+  - host: DC
+    contained: CNC
+    start: 3059-05-20
+    end: 3141-06-14
+    fraction: 0.4

--- a/data/universe/factionDiplomacy/3059_operationBulldog.yml
+++ b/data/universe/factionDiplomacy/3059_operationBulldog.yml
@@ -1,0 +1,96 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Second Star League's liberation of the Combine worlds conquered by Clan Smoke
+# Jaguar. The containments cover coalition forces staging in Combine space, restricted
+# to fighting the Jaguars only.
+
+wars:
+  - name: Operation Bulldog
+    start: 3059-05-20
+    end: 3059-08-13
+    parties:
+      - factions: [SL, CSJ]
+      - factions: [DC, CSJ]
+      - factions: [CS, CSJ]
+      - factions: [CC, CSJ]
+      - factions: [FS, CSJ]
+      - factions: [FWL, CSJ]
+      - factions: [LA, CSJ]
+      - factions: [FRR, CSJ]
+      - factions: [SIC, CSJ]
+containedFactions:
+  - host: DC
+    contained: SL
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.2
+    opponents: [CSJ]
+  - host: DC
+    contained: CS
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.3
+    opponents: [CSJ]
+  - host: DC
+    contained: FWL
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.08
+    opponents: [CSJ]
+  - host: DC
+    contained: LA
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.15
+    opponents: [CSJ]
+  - host: DC
+    contained: FS
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.2
+    opponents: [CSJ]
+  - host: DC
+    contained: CC
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.13
+    opponents: [CSJ]
+  - host: DC
+    contained: FRR
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.03
+    opponents: [CSJ]
+  - host: DC
+    contained: SIC
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.05
+    opponents: [CSJ]
+  - host: DC
+    contained: CWIE
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.05
+    opponents: [CSJ]
+  - host: DC
+    contained: CNC
+    start: 3059-05-20
+    end: 3059-08-13
+    fraction: 0.05
+    opponents: [CSJ]

--- a/data/universe/factionDiplomacy/3061-3063_capellanStIvesWar.yml
+++ b/data/universe/factionDiplomacy/3061-3063_capellanStIvesWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Capellan-St. Ives War
+    start: 3061-01-27
+    end: 3063-06-10
+    parties:
+      - factions: [CC, SIC]

--- a/data/universe/factionDiplomacy/3061_falconViperWar.yml
+++ b/data/universe/factionDiplomacy/3061_falconViperWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Falcon-Viper War
+    start: 3061-04-01
+    end: 3061-07-04
+    parties:
+      - factions: [CJF, CSV]

--- a/data/universe/factionDiplomacy/3062-3064_combineGhostBearWar.yml
+++ b/data/universe/factionDiplomacy/3062-3064_combineGhostBearWar.yml
@@ -1,0 +1,29 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Combine-Ghost Bear War
+    start: 3062-10-18
+    end: 3064-05-18
+    parties:
+      - factions: [CGB, DC]
+        end: 3063-12-22
+      - factions: [CGB, CHH]
+        start: 3063-11-17
+      - factions: [CGB, CW]
+        start: 3063-11-17

--- a/data/universe/factionDiplomacy/3062-3067_fedComCivilWar.yml
+++ b/data/universe/factionDiplomacy/3062-3067_fedComCivilWar.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: FedCom Civil War
+    start: 3062-11-16
+    end: 3067-04-20
+    parties:
+      - factions: [LA, FC]
+      - factions: [LA, FS]
+      - factions: [FS, DC]

--- a/data/universe/factionDiplomacy/3062-present_trinityAlliance.yml
+++ b/data/universe/factionDiplomacy/3062-present_trinityAlliance.yml
@@ -1,0 +1,23 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+alliances:
+  - name: Trinity Alliance
+    start: 3062-08-06
+    parties:
+      - factions: [CC, TC, MOC]

--- a/data/universe/factionDiplomacy/3063_marianIllyrianWar.yml
+++ b/data/universe/factionDiplomacy/3063_marianIllyrianWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Marian-Illyrian War
+    start: 3063-01-19
+    end: 3063-06-30
+    parties:
+      - factions: [MH, IP]

--- a/data/universe/factionDiplomacy/3064-3065_jadeFalconIncursion.yml
+++ b/data/universe/factionDiplomacy/3064-3065_jadeFalconIncursion.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Jade Falcon Incursion
+    start: 3064-05-10
+    end: 3065-02-27
+    parties:
+      - factions: [LA, CJF]
+      - factions: [CWIE, CJF]

--- a/data/universe/factionDiplomacy/3064-present_ravenAlliance.yml
+++ b/data/universe/factionDiplomacy/3064-present_ravenAlliance.yml
@@ -1,0 +1,22 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+alliances:
+  - start: 3064-02-18
+    parties:
+      - factions: [CSR, OA, RA]

--- a/data/universe/factionDiplomacy/3065_jadeFalconWolfOzWar.yml
+++ b/data/universe/factionDiplomacy/3065_jadeFalconWolfOzWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Jade Falcon/Wolf OZ War
+    start: 3065-01-10
+    end: 3065-06-27
+    parties:
+      - factions: [CW, CJF]

--- a/data/universe/factionDiplomacy/3066_marianCircinusWar.yml
+++ b/data/universe/factionDiplomacy/3066_marianCircinusWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Marian-Circinus War
+    start: 3066-01-01
+    end: 3066-05-31
+    parties:
+      - factions: [MH, CIR]

--- a/data/universe/factionDiplomacy/3068-3069_operationHammerstrike.yml
+++ b/data/universe/factionDiplomacy/3068-3069_operationHammerstrike.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Operation Hammerstrike
+    start: 3068-02-04
+    end: 3069-12-02
+    parties:
+      - factions: [LA, FWL]

--- a/data/universe/factionDiplomacy/3068-3070_operationSovereignJustice.yml
+++ b/data/universe/factionDiplomacy/3068-3070_operationSovereignJustice.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Operation Sovereign Justice
+    start: 3068-06-28
+    end: 3070-03-19
+    parties:
+      - factions: [FS, CC]

--- a/data/universe/factionDiplomacy/3070-3072_hellsHorsesStampede.yml
+++ b/data/universe/factionDiplomacy/3070-3072_hellsHorsesStampede.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Hell's Horses Stampede
+    start: 3070-11-14
+    end: 3072-01-31
+    parties:
+      - factions: [CHH, CW]

--- a/data/universe/factionDiplomacy/3070-3072_operationIceStorm.yml
+++ b/data/universe/factionDiplomacy/3070-3072_operationIceStorm.yml
@@ -1,0 +1,33 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Ice Hellion invasion of the Jade Falcon occupation zone; dates approximate.
+# The CHH-CIH alliance ends 3071-11-01, when the Horses turned on the Hellions.
+
+wars:
+  - name: Operation Ice Storm
+    start: 3071-05-01
+    end: 3072-04-30
+    parties:
+      - factions: [CIH, CJF]
+      - factions: [CIH, CHH]
+        start: 3071-11-01
+alliances:
+  - start: 3070-11-14
+    end: 3071-11-01
+    parties:
+      - factions: [CHH, CIH]

--- a/data/universe/factionDiplomacy/3070-present_rasalhagueDominion.yml
+++ b/data/universe/factionDiplomacy/3070-present_rasalhagueDominion.yml
@@ -1,0 +1,33 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Ghost Bear-Rasalhague merger: precursor alliance and the merged components
+# contained within the Rasalhague Dominion.
+
+alliances:
+  - start: 3070-08-01
+    parties:
+      - factions: [FRR, CGB, RD]
+containedFactions:
+  - host: RD
+    contained: CGB
+    start: 3103-01-01
+    fraction: 0.5
+  - host: RD
+    contained: FRR
+    start: 3103-01-01
+    fraction: 0.5

--- a/data/universe/factionDiplomacy/3074-3080_taurianFedSunsWar.yml
+++ b/data/universe/factionDiplomacy/3074-3080_taurianFedSunsWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Taurian-FedSuns War
+    start: 3074-05-29
+    end: 3080-07-02
+    parties:
+      - factions: [TC, FS]

--- a/data/universe/factionDiplomacy/3079-3139_freeWorldsLeagueFragmentation.yml
+++ b/data/universe/factionDiplomacy/3079-3139_freeWorldsLeagueFragmentation.yml
@@ -1,0 +1,53 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Free Worlds League (former FWL) contained within its splinter states during the
+# 3079-3139 fragmentation. Entries end with the 3139 re-formation of the League
+# where the splinter survived past it (the Regulan Fiefs and Duchy of Andurien
+# themselves stayed independent).
+
+containedFactions:
+  - host: DA
+    contained: FWL
+    start: 3079-01-01
+    end: 3139-01-01
+    fraction: 0.15
+  - host: DO
+    contained: FWL
+    start: 3079-01-01
+    end: 3086-01-01
+    fraction: 0.15
+  - host: OP
+    contained: FWL
+    start: 3086-01-01
+    end: 3139-01-01
+    fraction: 0.15
+  - host: PR
+    contained: FWL
+    start: 3079-01-01
+    end: 3086-01-01
+    fraction: 0.15
+  - host: RF
+    contained: FWL
+    start: 3086-01-01
+    end: 3139-01-01
+    fraction: 0.15
+  - host: MSC
+    contained: FWL
+    start: 3082-01-01
+    end: 3138-01-01
+    fraction: 0.25

--- a/data/universe/factionDiplomacy/3080-present_escorpionImperio.yml
+++ b/data/universe/factionDiplomacy/3080-present_escorpionImperio.yml
@@ -1,0 +1,47 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Clan Goliath Scorpion's exile state: the Escorpion Imperio (start date is a guess
+# based on conquest beginning late January 3080) and its expansion into the Scorpion
+# Empire after the Hanseatic Crusade.
+
+alliances:
+  - name: Escorpión Imperio
+    start: 3080-04-01
+    parties:
+      - factions: [CGS, NC, UC]
+  - name: Scorpion Empire
+    start: 3141-03-03
+    parties:
+      - factions: [CGS, NC, UC, HL]
+containedFactions:
+  - host: CEI
+    contained: CGS
+    start: 3080-01-01
+    fraction: 1.0
+  - host: CEI
+    contained: NC
+    start: 3080-01-01
+    fraction: 0.3
+  - host: CEI
+    contained: UC
+    start: 3080-01-01
+    fraction: 0.3
+  - host: CEI
+    contained: HL
+    start: 3141-01-01
+    fraction: 0.5

--- a/data/universe/factionDiplomacy/3081-3085_capellanConflict.yml
+++ b/data/universe/factionDiplomacy/3081-3085_capellanConflict.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Dates approximate.
+
+wars:
+  - name: Capellan Conflict
+    start: 3081-10-01
+    end: 3085-06-01
+    parties:
+      - factions: [ROS, CC]

--- a/data/universe/factionDiplomacy/3081_operationGoldenDawn.yml
+++ b/data/universe/factionDiplomacy/3081_operationGoldenDawn.yml
@@ -1,0 +1,28 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Operation Golden Dawn
+    start: 3081-03-25
+    end: 3081-09-07
+    parties:
+      - factions: [ROS, SHC]
+      - factions: [ROS, MCM]
+      - factions: [ROS, SC]
+      - factions: [ROS, DO]
+        end: 3081-07-31

--- a/data/universe/factionDiplomacy/3098-3101_secondDominionCombineWar.yml
+++ b/data/universe/factionDiplomacy/3098-3101_secondDominionCombineWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Second Dominion-Combine War
+    start: 3098-07-01
+    end: 3101-06-30
+    parties:
+      - factions: [CGB, DC]

--- a/data/universe/factionDiplomacy/3103-3105_victoriaWar.yml
+++ b/data/universe/factionDiplomacy/3103-3105_victoriaWar.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Dates approximate.
+
+wars:
+  - name: Victoria War
+    start: 3103-06-01
+    end: 3105-04-30
+    parties:
+      - factions: [CC, FS]

--- a/data/universe/factionDiplomacy/3110-3113_capellanRepublicWar.yml
+++ b/data/universe/factionDiplomacy/3110-3113_capellanRepublicWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Capellan-Republic War
+    start: 3110-07-01
+    end: 3113-06-30
+    parties:
+      - factions: [CC, ROS]

--- a/data/universe/factionDiplomacy/3134-3135_jadeFalconInvasion.yml
+++ b/data/universe/factionDiplomacy/3134-3135_jadeFalconInvasion.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Jade Falcon Invasion
+    start: 3134-05-01
+    end: 3135-12-31
+    parties:
+      - factions: [CJF, ROS]

--- a/data/universe/factionDiplomacy/3134-3136_capellanInvasion.yml
+++ b/data/universe/factionDiplomacy/3134-3136_capellanInvasion.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Capellan Invasion
+    start: 3134-05-01
+    end: 3136-10-14
+    parties:
+      - factions: [CC, ROS]

--- a/data/universe/factionDiplomacy/3135-3138_combineInvasion.yml
+++ b/data/universe/factionDiplomacy/3135-3138_combineInvasion.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Combine Invasion of the Republic was fought by the Draconis Combine (an older
+# revision of this data listed CC here by mistake).
+
+wars:
+  - name: Combine Invasion
+    start: 3135-04-20
+    end: 3138-12-31
+    parties:
+      - factions: [DC, ROS]

--- a/data/universe/factionDiplomacy/3137-3142_operationHammerfall.yml
+++ b/data/universe/factionDiplomacy/3137-3142_operationHammerfall.yml
@@ -1,0 +1,42 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Lyran-Wolf invasion of the Free Worlds League region. The LA-CW alliance ends
+# when the Wolves turn on the Lyrans (the CW,LA war party starts 3140-05-23).
+
+wars:
+  - name: Operation Hammerfall
+    start: 3137-07-25
+    end: 3142-01-01
+    parties:
+      - factions: [CW, MSC]
+        start: 3138-02-15
+        end: 3140-05-19
+      - factions: [CW, FWL]
+        start: 3138-02-15
+        end: 3140-05-19
+      - factions: [LA, DTA]
+        end: 3137-12-14
+      - factions: [LA, MSC]
+      - factions: [LA, FWL]
+      - factions: [CW, LA]
+        start: 3140-05-23
+alliances:
+  - start: 3137-01-01
+    end: 3140-05-19
+    parties:
+      - factions: [LA, CW]

--- a/data/universe/factionDiplomacy/3138-present_chainelaneIsles.yml
+++ b/data/universe/factionDiplomacy/3138-present_chainelaneIsles.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Clans Sea Fox (Diamond Shark) and Nova Cat presence in the Chainelane Isles.
+
+containedFactions:
+  - host: CP
+    contained: CDS
+    start: 3138-07-27
+  - host: CP
+    contained: CNC
+    start: 3138-07-27

--- a/data/universe/factionDiplomacy/3138_orienteAndurienWar.yml
+++ b/data/universe/factionDiplomacy/3138_orienteAndurienWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Oriente-Andurien War
+    start: 3138-02-06
+    end: 3138-08-05
+    parties:
+      - factions: [DO, DA]

--- a/data/universe/factionDiplomacy/3139-3141_draconisMarchInvasion.yml
+++ b/data/universe/factionDiplomacy/3139-3141_draconisMarchInvasion.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Draconis March Invasion
+    start: 3139-03-01
+    end: 3141-04-30
+    parties:
+      - factions: [DC, FS]

--- a/data/universe/factionDiplomacy/3140-3145_falconHorsesInvasion.yml
+++ b/data/universe/factionDiplomacy/3140-3145_falconHorsesInvasion.yml
@@ -1,0 +1,40 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Falcon-Horses invasion of the Lyran Commonwealth. The alliance and the Horses'
+# presence in the Falcon OZ end when the Horses turn on the Falcons in early 3145.
+
+wars:
+  - name: Falcon/Horses Invasion
+    start: 3142-06-01
+    end: 3145-02-23
+    parties:
+      - factions: [CJF, LA]
+      - factions: [CHH, LA]
+      - factions: [CW, LA]
+        start: 3142-11-24
+alliances:
+  - start: 3140-01-15
+    end: 3145-03-31
+    parties:
+      - factions: [CJF, CHH]
+containedFactions:
+  - host: CJF
+    contained: CHH
+    start: 3142-06-01
+    end: 3145-03-31
+    opponents: [LA, CWIE, CW]

--- a/data/universe/factionDiplomacy/3141-3142_hanseaticCrusade.yml
+++ b/data/universe/factionDiplomacy/3141-3142_hanseaticCrusade.yml
@@ -1,0 +1,27 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Hanseatic Crusade PDF states the war started January 3rd of 3141 and lasted
+# 15 months.
+
+wars:
+  - name: Hanseatic Crusade
+    start: 3141-01-03
+    end: 3142-03-31
+    parties:
+      - factions: [CEI, HL]
+      - factions: [CGS, HL]

--- a/data/universe/factionDiplomacy/3141-3143_novaCatRebellion.yml
+++ b/data/universe/factionDiplomacy/3141-3143_novaCatRebellion.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Nova Cat Rebellion
+    start: 3141-06-14
+    end: 3143-01-06
+    parties:
+      - factions: [DC, CNC]

--- a/data/universe/factionDiplomacy/3144-present_capellanFedSunsWar.yml
+++ b/data/universe/factionDiplomacy/3144-present_capellanFedSunsWar.yml
@@ -1,0 +1,23 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Capellan-FedSuns War
+    start: 3144-11-11
+    parties:
+      - factions: [CC, FS]

--- a/data/universe/factionDiplomacy/3144-present_combineFedSunsWar.yml
+++ b/data/universe/factionDiplomacy/3144-present_combineFedSunsWar.yml
@@ -1,0 +1,23 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Combine-FedSuns War
+    start: 3144-03-14
+    parties:
+      - factions: [DC, FS]

--- a/data/universe/factionDiplomacy/3147-3148_buenaLyranWar.yml
+++ b/data/universe/factionDiplomacy/3147-3148_buenaLyranWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Buena-Lyran War
+    start: 3147-06-06
+    end: 3148-01-30
+    parties:
+      - factions: [BC, LA]

--- a/data/universe/factionDiplomacy/3151-present_isleOfSkye.yml
+++ b/data/universe/factionDiplomacy/3151-present_isleOfSkye.yml
@@ -1,0 +1,23 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Galatean League allied with and later merged into the Isle of Skye.
+
+alliances:
+  - start: 3151-12-15
+    parties:
+      - factions: [IoS, GL]

--- a/data/universe/factionDiplomacy/3151-present_operationPersuasion.yml
+++ b/data/universe/factionDiplomacy/3151-present_operationPersuasion.yml
@@ -1,0 +1,27 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The new Star League's coercion of the Capellan Confederation, including the Raven
+# Alliance naval bombardment of Chang-an on Liao (20 June 3152).
+
+wars:
+  - name: Operation Persuasion
+    start: 3151-12-05
+    parties:
+      - factions: [SL3, CC]
+      - factions: [RA, CC]
+        start: 3152-06-20

--- a/data/universe/factionDiplomacy/3151-present_thirdStarLeague.yml
+++ b/data/universe/factionDiplomacy/3151-present_thirdStarLeague.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Third Star League, re-established under Clan Wolf on 25 May 3151. The Raven
+# Alliance fought for the new League in Operation Persuasion (start approximate).
+
+alliances:
+  - start: 3151-05-25
+    parties:
+      - factions: [SL3, CWE]
+      - factions: [SL3, RA]
+        start: 3151-12-05

--- a/data/universe/factionDiplomacy/3151_battleOfTerra.yml
+++ b/data/universe/factionDiplomacy/3151_battleOfTerra.yml
@@ -1,0 +1,34 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Derived from the Sarna 3151 year page. The Wolf Empire and Jade Falcon invasions of
+# the Republic remnant end with Devlin Stone's surrender on 14 April 3151; the ilClan
+# Trial between the Wolves and the Falcons follows (16-19 April). Note Clan Wolf uses
+# faction code CW through 3142 and CWE (Wolf Empire) from 3143 on.
+
+wars:
+  - name: Battle of Terra
+    start: 3151-01-01
+    end: 3151-04-19
+    parties:
+      - factions: [CWE, ROS]
+        end: 3151-04-14
+      - factions: [CJF, ROS]
+        start: 3151-01-21
+        end: 3151-04-14
+      - factions: [CWE, CJF]
+        start: 3151-04-16

--- a/data/universe/factionDiplomacy/3151_bolanFront.yml
+++ b/data/universe/factionDiplomacy/3151_bolanFront.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Bolan Front
+    start: 3151-01-04
+    end: 3151-06-16
+    parties:
+      - factions: [LA, FWL]

--- a/data/universe/factionDiplomacy/3151_liberationOfTheFalconOz.yml
+++ b/data/universe/factionDiplomacy/3151_liberationOfTheFalconOz.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Lyran counteroffensive into the collapsing Jade Falcon occupation zone, beginning
+# with Melissia; end date approximate.
+
+wars:
+  - name: Liberation of the Falcon OZ
+    start: 3151-01-30
+    end: 3151-12-31
+    parties:
+      - factions: [LA, CJF]

--- a/data/universe/factionDiplomacy/3151_marianHegemonyIncursion.yml
+++ b/data/universe/factionDiplomacy/3151_marianHegemonyIncursion.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Marian attacks on Atzenbrugg and Lepaterique; end date approximate.
+
+wars:
+  - name: Marian Hegemony Incursion
+    start: 3151-01-12
+    end: 3151-06-30
+    parties:
+      - factions: [MH, FWL]

--- a/data/universe/factionDiplomacy/3151_operationStampede.yml
+++ b/data/universe/factionDiplomacy/3151_operationStampede.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Hell's Horses drive toward Terra and their claim to ilClanship; dates approximate.
+
+wars:
+  - name: Operation Stampede
+    start: 3151-02-01
+    end: 3151-04-14
+    parties:
+      - factions: [CHH, ROS]

--- a/data/universe/factionDiplomacy/3152-present_andurienCapellanWar.yml
+++ b/data/universe/factionDiplomacy/3152-present_andurienCapellanWar.yml
@@ -1,0 +1,23 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Andurien-Capellan War
+    start: 3152-01-06
+    parties:
+      - factions: [DA, CC]

--- a/data/universe/factionDiplomacy/3152-present_leagueInvasionOfTheWolfEmpire.yml
+++ b/data/universe/factionDiplomacy/3152-present_leagueInvasionOfTheWolfEmpire.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Mercenary and Tamarind attacks on Wolf-held Dixie from February 3152; the first
+# full invasion wave launched 28 June 3152.
+
+wars:
+  - name: League Invasion of the Wolf Empire
+    start: 3152-02-01
+    parties:
+      - factions: [FWL, CWE]

--- a/data/universe/factionDiplomacy/3152-present_thirdDominionCombineWar.yml
+++ b/data/universe/factionDiplomacy/3152-present_thirdDominionCombineWar.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# The Dominion's limited invasion of the Combine; start approximate.
+
+wars:
+  - name: Third Dominion-Combine War
+    start: 3152-06-01
+    parties:
+      - factions: [RD, DC]

--- a/data/universe/factionDiplomacy/3152_horsesFalconWar.yml
+++ b/data/universe/factionDiplomacy/3152_horsesFalconWar.yml
@@ -1,0 +1,26 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Destruction of the Turkina Ascendancy and the invasion of Sudeten; start
+# approximate.
+
+wars:
+  - name: Horses-Falcon War
+    start: 3152-02-01
+    end: 3152-03-09
+    parties:
+      - factions: [CHH, CJF]

--- a/data/universe/factionDiplomacy/3152_ravenFedSunsConflict.yml
+++ b/data/universe/factionDiplomacy/3152_ravenFedSunsConflict.yml
@@ -1,0 +1,24 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+wars:
+  - name: Raven-FedSuns Conflict
+    start: 3152-06-03
+    end: 3152-06-30
+    parties:
+      - factions: [RA, FS]

--- a/data/universe/factionDiplomacy/clanAlliances.yml
+++ b/data/universe/factionDiplomacy/clanAlliances.yml
@@ -1,0 +1,49 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Long-standing alliances between Clans.
+
+alliances:
+  - name: Clan Alliances
+    parties:
+      - factions: [CBS, CFM]
+      - factions: [CBS, CSR]
+      - factions: [CBS, CDS]
+      - factions: [CB, CCC]
+      - factions: [CCC, CDS]
+      - factions: [CCC, CSR]
+      - factions: [CCO, CDS]
+      - factions: [CCO, CGB]
+      - factions: [CCO, CHH]
+      - factions: [CCO, CSL]
+      - factions: [CDS, CGB]
+      - factions: [CDS, CNC]
+      - factions: [CDS, CWIE]
+      - factions: [CGB, CSR]
+      - factions: [CGB, CGS]
+      - factions: [CGS, CSR]
+      - factions: [CSR, CSA]
+      - factions: [CCC, CSA]
+        start: 3059-02-16
+      - factions: [CCO, CW]
+        end: 3057-12-31
+      - factions: [CDS, CW]
+        end: 3057-12-31
+      - factions: [CGS, CW]
+        end: 3057-12-31
+      - factions: [CHH, CW]
+        end: 3064-08-12

--- a/data/universe/factionDiplomacy/clanRivalries.yml
+++ b/data/universe/factionDiplomacy/clanRivalries.yml
@@ -1,0 +1,53 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Clan rivalries. These are cumulative with wars and alliances.
+
+rivalries:
+  - factions: [CBS, CB]
+  - factions: [CBS, CM]
+  - factions: [CBS, CSA]
+    start: 3059-02-16
+  - factions: [CBS, CSV]
+  - factions: [CBS, CFM]
+  - factions: [CCC, CCO]
+  - factions: [CCO, CSA]
+  - factions: [CCO, CSJ]
+  - factions: [CCO, CJF]
+  - factions: [CFM, CGS]
+  - factions: [CFM, CHH]
+  - factions: [CFM, CSA]
+  - factions: [CFM, CSV]
+  - factions: [CGB, CHH]
+    end: 3070-07-21
+  - factions: [CGB, CSV]
+  - factions: [CGB, CNC]
+    start: 3062-10-18
+  - factions: [CGS, CNC]
+  - factions: [CJF, CSV]
+  - factions: [CJF, CW]
+  - factions: [CJF, CWIE]
+  - factions: [CMG, CSR]
+  - factions: [CMG, CSA]
+  - factions: [CSJ, CSA]
+    start: 2868-01-01
+  - factions: [CSJ, CW]
+  - factions: [CSR, CSV]
+  - factions: [CWI, CW]
+  - factions: [CW, CWIE]
+  - factions: [CWOV, CSR]
+  - factions: [CWOV, CW]

--- a/data/universe/factionDiplomacy/neutralFactions.yml
+++ b/data/universe/factionDiplomacy/neutralFactions.yml
@@ -1,0 +1,37 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Factions considered allied with everyone except the listed exceptions.
+# MERC neutrality only applies to mercenaries not under contract, to prevent
+# mercenaries being treated as potential rivals to factions near such planets as
+# Outreach and Northwind. The Azami Brotherhood is made neutral for lack of better
+# information; they shouldn't be fighting the DC or Stone's Coalition.
+
+neutralFactions:
+  - faction: CS
+    exceptions:
+      - factions: [PIR, TD, GV, MV, BoS, MM, WOB, IND]
+      - factions: [OC]
+        end: 3012-01-01
+      - factions: [CJF, CW, CGB, CSJ, CSV, CNC, CDS]
+        start: 3052-05-01
+      - factions: [WOB]
+        start: 3068-01-21
+  - faction: MERC
+    exceptions:
+      - factions: [WOB]
+  - faction: AB

--- a/data/universe/factionDiplomacy/oberonConfederation.yml
+++ b/data/universe/factionDiplomacy/oberonConfederation.yml
@@ -1,0 +1,21 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+
+alliances:
+  - parties:
+      - factions: [OC, EF]

--- a/data/universe/factionDiplomacy/republicOfTheSphere.yml
+++ b/data/universe/factionDiplomacy/republicOfTheSphere.yml
@@ -1,0 +1,25 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Republic of the Sphere standing relationships.
+
+alliances:
+  - parties:
+      - factions: [ROS, Stone]
+  - start: 3135-05-13
+    parties:
+      - factions: [ROS, FS]

--- a/data/universe/factionDiplomacy/wolfInExile.yml
+++ b/data/universe/factionDiplomacy/wolfInExile.yml
@@ -1,0 +1,38 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Clan Wolf-in-Exile on Arc-Royal from the Refusal War until Operation REUNION
+# returned the exiles to the ranks of Clan Wolf on 19 February 3151. The ARDC
+# containment start reflects the Cordon's formation in 3058.
+
+alliances:
+  - parties:
+      - factions: [ARDC, CWIE, FC]
+  - start: 3067-03-23
+    parties:
+      - factions: [LA, CWIE, ARDC]
+containedFactions:
+  - host: ARDC
+    contained: CWIE
+    start: 3058-01-01
+    end: 3067-03-22
+  - host: LA
+    contained: CWIE
+    start: 3067-03-23
+    end: 3151-02-19
+    fraction: 0.15
+    opponents: [CJF, CNC, CGB]

--- a/data/universe/factionhints.xml
+++ b/data/universe/factionhints.xml
@@ -18,6 +18,13 @@
 # affiliated with Microsoft.
 -->
 <!--
+NOTE: This file is superseded by data/universe/factionDiplomacy/*.yml - the current format is
+documented in "Faction Diplomacy Readme.md" in the MekHQ docs folder. MekHQ loads the YAML
+directory when it is present and falls back to this file otherwise. Until the YAML loader
+ships in a stable MekHQ release, keep BOTH representations in sync when editing diplomacy
+data.
+-->
+<!--
 factionhints.xml
 written by Neoancient
 
@@ -245,6 +252,17 @@ forces).
     <war name="The Taurian-Canopian War" start="2813-07-01" end="2814-02-28">
         <parties>TC,MOC</parties>
     </war>
+    <!-- The Third Succession War was previously missing entirely, leaving a war desert between
+    2864 and 3014. Dates are the canonical span (declared over by ComStar in 3025); intensity was
+    lower than the first two Succession Wars but the House borders were in near-continuous
+    conflict. -->
+    <war name="Third Succession War" start="2866-01-01" end="3025-12-31">
+        <parties>CC,FS</parties>
+        <parties>CC,FWL</parties>
+        <parties>DC,FS</parties>
+        <parties>DC,LA</parties>
+        <parties>FWL,LA</parties>
+    </war>
     <war name="Marik Civil War" start="3014-05-22" end="3015-05-31">
         <parties>FWL,FWLR</parties>
     </war>
@@ -406,6 +424,36 @@ forces).
     <alliance start="3059-10-01">
         <parties>CS,CNC</parties>
     </alliance>
+    <!-- Second Star League, formed at the First Whitting Conference (November 3058; founding day
+    approximate) and dissolved at the Fourth Whitting Conference on 28 November 3067. Previously
+    only Operation Bulldog existed for this era, so the member states were treated as mutual
+    enemies for the League's whole existence. Pairs are ended early where a war between members
+    is recorded (Capellan-St. Ives War, FedCom Civil War). CC-FS and CC-FC pairs are deliberately
+    omitted: the Chaos March and Xin Sheng raiding kept that border hostile despite shared
+    membership. -->
+    <alliance name="Second Star League" start="3058-11-01" end="3067-11-28">
+        <parties>SL,CS,DC,FRR,FWL,CC</parties>
+        <parties>FC,SL,CS,FRR,FWL</parties>
+        <parties>FC,FS</parties>
+        <parties end="3062-11-15">FC,DC</parties>
+        <parties>FS,SL,CS,FRR,FWL</parties>
+        <parties end="3062-11-15">FS,DC</parties>
+        <parties>LA,SL,CS,DC,FRR,FWL</parties>
+        <parties end="3062-11-15">LA,FC</parties>
+        <parties end="3062-11-15">LA,FS</parties>
+        <parties>SIC,SL,CS,DC,FRR,FWL</parties>
+        <parties>SIC,LA</parties>
+        <parties>SIC,FC</parties>
+        <parties>SIC,FS</parties>
+        <parties end="3061-01-26">SIC,CC</parties>
+        <!-- Taurian Concordat and Magistracy of Canopus admitted around the Second Whitting
+        Conference; dates approximate -->
+        <parties start="3061-01-01">SL,MOC</parties>
+        <parties start="3061-01-01">SL,TC</parties>
+        <!-- The Nova Cats fought beside the SLDF in Operation Bulldog and were subsequently
+        granted membership -->
+        <parties start="3059-05-20">SL,CNC</parties>
+    </alliance>
     <war name="Operation Bulldog" start="3059-05-20" end="3059-08-13">
         <parties>SL,CSJ</parties>
         <parties>DC,CSJ</parties>
@@ -417,6 +465,14 @@ forces).
         <parties>FRR,CSJ</parties>
         <parties>SIC,CSJ</parties>
     </war>
+    <!-- The Second Star League itself operating in DC space during Operation Bulldog - the very
+    example cited in this file's header documentation, but previously missing an entry. -->
+    <location start="3059-05-20" end="3059-08-13">
+        <outer>DC</outer>
+        <inner>SL</inner>
+        <fraction>0.2</fraction>
+        <opponents>CSJ</opponents>
+    </location>
     <location start="3059-05-20" end="3059-08-13">
         <outer>DC</outer>
         <inner>CS</inner>
@@ -537,6 +593,12 @@ forces).
     <war name="Hell's Horses Stampede" start="3070-11-14" end="3072-01-31">
         <parties>CHH,CW</parties>
     </war>
+    <!-- The Ice Hellion invasion of the Jade Falcon occupation zone. The CHH-CIH alliance
+    already ends 3071-11-01, matching the Horses turning on the Hellions. Dates approximate. -->
+    <war name="Operation Ice Storm" start="3071-05-01" end="3072-04-30">
+        <parties>CIH,CJF</parties>
+        <parties start="3071-11-01">CIH,CHH</parties>
+    </war>
     <war name="Taurian-FedSuns War" start="3074-05-29" end="3080-07-02">
         <parties>TC,FS</parties>
     </war>
@@ -568,6 +630,10 @@ forces).
     <war name="Second Dominion-Combine War" start="3098-07-01" end="3101-06-30">
         <parties>CGB,DC</parties>
     </war>
+    <!-- The Victoria War was previously missing entirely. Dates approximate. -->
+    <war name="Victoria War" start="3103-06-01" end="3105-04-30">
+        <parties>CC,FS</parties>
+    </war>
     <war name="Capellan-Republic War" start="3110-07-01" end="3113-06-30">
         <parties>CC,ROS</parties>
     </war>
@@ -580,7 +646,7 @@ forces).
         <parties>CJF,ROS</parties>
     </war>
     <war name="Combine Invasion" start="3135-04-20" end="3138-12-31">
-        <parties>CC,ROS</parties>
+        <parties>DC,ROS</parties>
     </war>
     <war name="Draconis March Invasion" start="3139-03-01" end="3141-04-30">
         <parties>DC,FS</parties>
@@ -598,6 +664,12 @@ forces).
     </alliance>
     <war name="Oriente-Andurien War" start="3138-02-06" end="3138-08-05">
         <parties>DO,DA</parties>
+    </war>
+    <!-- Referenced by the Scorpion Empire alliance comment (the Hanseatic Crusade PDF states the
+    war started January 3rd of 3141 and lasted 15 months) but previously had no war entry. -->
+    <war name="Hanseatic Crusade" start="3141-01-03" end="3142-03-31">
+        <parties>CEI,HL</parties>
+        <parties>CGS,HL</parties>
     </war>
     <war name="Buena-Lyran War" start="3147-06-06" end="3148-01-30">
         <parties>BC,LA</parties>
@@ -622,21 +694,69 @@ forces).
         <parties>DC,FS</parties>
     </war>
     <war name="Capellan-FedSuns War" start="3144-11-11">
-        <parties>DC,FS</parties>
+        <parties>CC,FS</parties>
     </war>
+    <!--ilClan
+    Era (derived from the Sarna 3151/3152 year pages; dates approximate where only a month is
+    given). Note Clan Wolf uses code CW through 3142 and CWE (Wolf Empire) from 3143 on.-->
+    <war name="Battle of Terra" start="3151-01-01" end="3151-04-19">
+        <parties end="3151-04-14">CWE,ROS</parties>
+        <parties start="3151-01-21" end="3151-04-14">CJF,ROS</parties>
+        <!-- The ilClan Trial between the Wolves and the Falcons -->
+        <parties start="3151-04-16">CWE,CJF</parties>
+    </war>
+    <!-- Hell's Horses drive toward Terra and their claim to ilClanship -->
+    <war name="Operation Stampede" start="3151-02-01" end="3151-04-14">
+        <parties>CHH,ROS</parties>
+    </war>
+    <!-- Lyran counteroffensive into the collapsing Jade Falcon occupation zone, beginning with
+    Melissia; end date approximate -->
+    <war name="Liberation of the Falcon OZ" start="3151-01-30" end="3151-12-31">
+        <parties>LA,CJF</parties>
+    </war>
+    <war name="Bolan Front" start="3151-01-04" end="3151-06-16">
+        <parties>LA,FWL</parties>
+    </war>
+    <!-- Marian attacks on Atzenbrugg and Lepaterique; end date approximate -->
+    <war name="Marian Hegemony Incursion" start="3151-01-12" end="3151-06-30">
+        <parties>MH,FWL</parties>
+    </war>
+    <war name="Operation Persuasion" start="3151-12-05">
+        <parties>SL3,CC</parties>
+        <!-- Raven Alliance naval bombardment of Chang-an on Liao -->
+        <parties start="3152-06-20">RA,CC</parties>
+    </war>
+    <war name="Andurien-Capellan War" start="3152-01-06">
+        <parties>DA,CC</parties>
+    </war>
+    <!-- Destruction of the Turkina Ascendancy and the invasion of Sudeten; start approximate -->
+    <war name="Horses-Falcon War" start="3152-02-01" end="3152-03-09">
+        <parties>CHH,CJF</parties>
+    </war>
+    <!-- The Dominion's limited invasion of the Combine; start approximate -->
+    <war name="Third Dominion-Combine War" start="3152-06-01">
+        <parties>RD,DC</parties>
+    </war>
+    <!-- Raven Alliance seizure of Milligan; end date approximate -->
+    <war name="Raven-FedSuns Conflict" start="3152-06-03" end="3152-06-30">
+        <parties>RA,FS</parties>
+    </war>
+    <!-- Mercenary and Tamarind attacks on Wolf-held Dixie from February; the first full
+    invasion wave launched 28 June 3152 -->
+    <war name="League Invasion of the Wolf Empire" start="3152-02-01">
+        <parties>FWL,CWE</parties>
+    </war>
+    <!-- The loader only supports one inner faction per location, so CDS and CNC need separate entries. -->
     <location start="3138-07-27">
         <outer>CP</outer>
         <inner>CDS</inner>
+    </location>
+    <location start="3138-07-27">
+        <outer>CP</outer>
         <inner>CNC</inner>
     </location>
-    <alliance start="3140-01-15">
-        <parties>CJF,CHH</parties>
-    </alliance>
     <alliance start="3135-05-13">
         <parties>ROS,FS</parties>
-    </alliance>
-    <alliance start="3137-01-01">
-        <parties>LA,CW</parties>
     </alliance>
     <alliance>
         <parties>OC,EF</parties>
@@ -667,11 +787,13 @@ forces).
     <alliance start="3067-03-23">
         <parties>LA,CWIE,ARDC</parties>
     </alliance>
-    <location end="3067-03-22">
+    <!-- Wolf-in-Exile settled on Arc-Royal after the Refusal War; the ARDC itself formed in 3058. -->
+    <location start="3058-01-01" end="3067-03-22">
         <outer>ARDC</outer>
         <inner>CWIE</inner>
     </location>
-    <location start="3067-03-23">
+    <!-- Ends with Operation REUNION returning Wolf-in-Exile to the ranks of Clan Wolf -->
+    <location start="3067-03-23" end="3151-02-19">
         <outer>LA</outer>
         <inner>CWIE</inner>
         <fraction>0.15</fraction>
@@ -688,6 +810,17 @@ forces).
     </alliance>
     <alliance start="3064-02-18">
         <parties>CSR,OA,RA</parties>
+    </alliance>
+    <!-- The Third Star League, re-established under Clan Wolf on 25 May 3151 -->
+    <alliance start="3151-05-25">
+        <parties>SL3,CWE</parties>
+        <!-- The Raven Alliance fought for the new League in Operation Persuasion; start
+        approximate -->
+        <parties start="3151-12-05">SL3,RA</parties>
+    </alliance>
+    <!-- The Galatean League allied with and later merged into the Isle of Skye -->
+    <alliance start="3151-12-15">
+        <parties>IoS,GL</parties>
     </alliance>
     <!-- Clan Ghost Bear contained within Rasalhague Dominion after merger -->
     <location start="3103-01-01">
@@ -726,8 +859,8 @@ forces).
         <fraction>0.5</fraction>
     </location>
     <!-- Free Worlds League (Former FWL) contained within splinter states during 3079-3139 fragmentation -->
-    <!-- Duchy of Andurien controls Andurien region -->
-    <location start="3079-01-01">
+    <!-- Duchy of Andurien controls Andurien region; FWL presence ends with the 3139 re-formation of the League -->
+    <location start="3079-01-01" end="3139-01-01">
         <outer>DA</outer>
         <inner>FWL</inner>
         <fraction>0.15</fraction>
@@ -750,8 +883,8 @@ forces).
         <inner>FWL</inner>
         <fraction>0.15</fraction>
     </location>
-    <!-- Regulan Fiefs (3086+) -->
-    <location start="3086-01-01">
+    <!-- Regulan Fiefs (3086+); FWL presence ends with the 3139 re-formation of the League (the Fiefs stayed independent) -->
+    <location start="3086-01-01" end="3139-01-01">
         <outer>RF</outer>
         <inner>FWL</inner>
         <fraction>0.15</fraction>

--- a/data/universe/factions/SL.yml
+++ b/data/universe/factions/SL.yml
@@ -29,6 +29,12 @@ capital: Terra
 yearsActive:
   - start: 2571
     end: 2780
+  # Second Star League: First Whitting Conference (November 3058) through the Fourth
+  # Whitting Conference dissolution vote on 28 November 3067. Without this span the SL
+  # entries in the faction diplomacy data (Operation Bulldog, Second Star League alliance)
+  # reference an inactive faction. The Third Star League has its own code (SL3).
+  - start: 3058
+    end: 3067
 # NOTE: TH (Terran Hegemony) is intentionally NOT listed here. TH.fallBackFactions
 # already contains SL, so adding TH here would create a SL <-> TH cycle that crashes
 # RATGenerator.findModelAvailabilityRecord with StackOverflowError. The bidirectional


### PR DESCRIPTION
## DO NOT MERGE WITHOUT - https://github.com/MegaMek/mekhq/pull/9588

## Summary

Splits the monolithic factionhints.xml into 94 per-conflict YAML files under data/universe/factionDiplomacy/, named chronologically (2398-2404_firstAndurienWar.yml, 3144-present_combineFedSunsWar.yml; perpetual relationships like clanRivalries.yml unprefixed). Fixes several data bugs found during conversion and fills major canon gaps. The XML is kept in full parity with the YAML (verified by an automated set-based comparison of all five section types: 72 wars, 28 alliances, 29 rivalries, 3 neutrals, 54 containments) because it remains the live file until the MekHQ YAML loader ships — and because MekHQ's new custom-file detection warns players whenever the two diverge.

## Changes

1. New data/universe/factionDiplomacy/ — one file per war (conflict-scoped alliances/containments bundled, e.g. Operation Bulldog's staging locations) plus standing-relationship files (starLeague, federatedCommonwealth, comStarPresence, wolfInExile, clanRivalries, …). Format documented in MekHQ's docs/Faction Diplomacy Readme.md (companion MekHQ PR); Neoancient's original documentation preserved verbatim there.
2. Data bugs fixed (in both YAML and XML): Combine Invasion listed CC,ROS → DC,ROS; Capellan-FedSuns War listed DC,FS → CC,FS; the CP location's double <inner> split into two entries (the parser silently dropped Clan Sea Fox); two contradictory perpetual duplicate alliances removed (LA,CW, CJF,CHH); missing dates added (ARDC/CWIE start, DA + RF splinter ends at the 3139 FWL re-formation, LA/CWIE ends at Operation REUNION).
3. Canon gaps filled (both formats): Third Succession War (the data had a war desert from 2864–3014), Victoria War, Hanseatic Crusade, Operation Ice Storm, the Second Star League alliance (previously only Operation Bulldog existed for 3058–3067, so League members were treated as mutual enemies), the missing DC/SL Bulldog containment, and the ilClan era from the Sarna 3151/3152 year pages (Battle of Terra, Operations Stampede/Persuasion, FWL invasion of the Wolf Empire, etc.).
4. factions/SL.yml — added the missing 3058–3067 active span (the Second Star League faction was inactive during its own era, so even the existing Bulldog entries referenced a dead faction).
5. factionhints.xml — supersession note added at the top; keep both representations in sync until the YAML loader ships.

## Testing

Automated XML↔YAML parity comparison (zero differences); every faction code validated against data/universe/factions/; all YAML validated by parse; MekHQ's new loader test suite (companion PR) loads this format. Dates marked "approximate" in comments where sources only give a month.

Known follow-ups (flagged, not filled): Wars of Reaving, WOB–MOC/TC Jihad pacts, CSJ's 3151 rebirth span, no Turkina Ascendancy faction code, TiC has no yearsActive.