### PR TITLE
Close #449: Improved Contract Diversity

### DIFF
--- a/data/stratconcontractdefinitions/Assassination.xml
+++ b/data/stratconcontractdefinitions/Assassination.xml
@@ -22,25 +22,26 @@
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Eliminate designated targets.</briefing>
     <allowEarlyVictory>true</allowEarlyVictory>
-    <hostileFacilityCount>1.0</hostileFacilityCount>
+    <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>28</scenarioOdds>
+        <scenarioOdds>38</scenarioOdds>
+        <scenarioOdds>38</scenarioOdds>
+        <scenarioOdds>48</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-2.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/Assassination.xml
+++ b/data/stratconcontractdefinitions/Assassination.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,12 +31,12 @@
         <scenarioOdds>48</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Fast, decisive strikes. The value '3' is intentionally repeated three times to weight the probability of selecting 3 as a deployment time. -->
+        <deploymentTimes>2</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>

--- a/data/stratconcontractdefinitions/CadreDuty.xml
+++ b/data/stratconcontractdefinitions/CadreDuty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -32,12 +32,12 @@
         <scenarioOdds>26</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <!-- Slower pacing: training a cadre takes time. The value '6' is intentionally repeated three times to weight the probability of selecting 6 as a deployment time. -->
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>

--- a/data/stratconcontractdefinitions/CadreDuty.xml
+++ b/data/stratconcontractdefinitions/CadreDuty.xml
@@ -25,22 +25,23 @@
     <hostileFacilityCount>0</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>6</scenarioOdds>
+        <scenarioOdds>16</scenarioOdds>
+        <scenarioOdds>16</scenarioOdds>
+        <scenarioOdds>26</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
-            <objectiveCount>-2</objectiveCount>
+            <objectiveCount>-1</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>AlliedTraineesGround.xml</objectiveScenarioModifier>

--- a/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -25,22 +25,23 @@
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>26</scenarioOdds>
+        <scenarioOdds>36</scenarioOdds>
+        <scenarioOdds>36</scenarioOdds>
+        <scenarioOdds>46</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
-            <objectiveCount>-2.0</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -32,27 +32,25 @@
         <scenarioOdds>46</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Fast, provocative turnover. The value '3' is intentionally repeated three times to weight the probability of selecting 3 as a deployment time. -->
+        <deploymentTimes>2</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveCount>-1.0</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
-                <objectiveScenario>Assassination.xml</objectiveScenario>
-                <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
-                <objectiveScenario>Convoy Raid.xml</objectiveScenario>
-                <objectiveScenario>Covert Strike.xml</objectiveScenario>
                 <objectiveScenario>Decoy Engagement.xml</objectiveScenario>
-                <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
-                <objectiveScenario>Frontline Disruption.xml</objectiveScenario>
-                <objectiveScenario>Tactical Withdrawal.xml</objectiveScenario>
+                <objectiveScenario>Decoy Interception.xml</objectiveScenario>
+                <objectiveScenario>Diversion Engagement.xml</objectiveScenario>
             </objectiveScenarios>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>ReinforcementDelayReductionHostile.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/Espionage.xml
+++ b/data/stratconcontractdefinitions/Espionage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,35 +31,24 @@
         <scenarioOdds>58</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
+        <!-- Prolonged infiltration. The value '7' is intentionally repeated three times to weight the probability of selecting 7 as a deployment time. -->
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
+        <deploymentTimes>8</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveCount>-1</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
-                <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
-                <objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>ReinforcementDelayReductionHostile.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
-            <objectiveScenarios>
-                <objectiveScenario>Hostile Facility.xml</objectiveScenario>
-            </objectiveScenarios>
-            <objectiveScenarioModifiers>
-                <objectiveScenarioModifier>FacilityHostileRecon.xml</objectiveScenarioModifier>
-            </objectiveScenarioModifiers>
-        </objectiveParameter>
-        <objectiveParameter>
-            <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/Espionage.xml
+++ b/data/stratconcontractdefinitions/Espionage.xml
@@ -21,21 +21,22 @@
     <contractTypeName>Espionage</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Conduct reconnaissance while evading hostile forces.</briefing>
-    <allowEarlyVictory>false</allowEarlyVictory>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>38</scenarioOdds>
+        <scenarioOdds>48</scenarioOdds>
+        <scenarioOdds>48</scenarioOdds>
+        <scenarioOdds>58</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -48,7 +49,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>
@@ -58,7 +59,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ExtractionRaid.xml
+++ b/data/stratconcontractdefinitions/ExtractionRaid.xml
@@ -24,23 +24,24 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>22</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>
@@ -50,7 +51,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ExtractionRaid.xml
+++ b/data/stratconcontractdefinitions/ExtractionRaid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,12 +31,12 @@
         <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Fast smash-and-grab turnover. The value '3' is intentionally repeated three times to weight the probability of selecting 3 as a deployment time. -->
+        <deploymentTimes>2</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -53,10 +53,9 @@
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
-                <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>
-                <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
-                <objectiveScenario>Convoy Raid.xml</objectiveScenario>
+                <objectiveScenario>DropShip Raid.xml</objectiveScenario>
+                <objectiveScenario>Isolated DropShip Defense.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/GarrisonDuty.xml
+++ b/data/stratconcontractdefinitions/GarrisonDuty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -42,6 +42,9 @@
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
             <objectiveCount>-1</objectiveCount>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>LocalGarrisonTurrets.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/GarrisonDuty.xml
+++ b/data/stratconcontractdefinitions/GarrisonDuty.xml
@@ -24,23 +24,24 @@
     <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
         <scenarioOdds>10</scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
+        <scenarioOdds>30</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-2</objectiveCount>
+            <objectiveCount>-1</objectiveCount>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -32,12 +32,12 @@
         <scenarioOdds>52</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Fast hit-and-run turnover. The value '3' is intentionally repeated three times to weight the probability of selecting 3 as a deployment time. -->
+        <deploymentTimes>2</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -54,11 +54,7 @@
             <objectiveScenarios>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>
-                <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
-                <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Intercept Engagement.xml</objectiveScenario>
-                <objectiveScenario>Recon Evasion.xml</objectiveScenario>
-                <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Tactical Withdrawal.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>

--- a/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -25,18 +25,19 @@
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>42</scenarioOdds>
+        <scenarioOdds>42</scenarioOdds>
+        <scenarioOdds>52</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -48,7 +49,7 @@
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-2.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/MoleHunting.xml
+++ b/data/stratconcontractdefinitions/MoleHunting.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,27 +31,25 @@
         <scenarioOdds>34</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <!-- Patient investigation. The value '5' is intentionally repeated three times to weight the probability of selecting 5 as a deployment time. -->
         <deploymentTimes>4</deploymentTimes>
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveCount>-1.0</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
-                <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
-                <objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>BadIntelGround.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
-                <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>

--- a/data/stratconcontractdefinitions/MoleHunting.xml
+++ b/data/stratconcontractdefinitions/MoleHunting.xml
@@ -24,18 +24,19 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>30</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>14</scenarioOdds>
+        <scenarioOdds>24</scenarioOdds>
+        <scenarioOdds>24</scenarioOdds>
+        <scenarioOdds>34</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -48,7 +49,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-2.0</objectiveCount>
+            <objectiveCount>1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ObjectiveRaid.xml
+++ b/data/stratconcontractdefinitions/ObjectiveRaid.xml
@@ -24,27 +24,28 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>22</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ObjectiveRaid.xml
+++ b/data/stratconcontractdefinitions/ObjectiveRaid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -47,12 +47,9 @@
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
-                <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
-                <objectiveScenario>Assassination.xml</objectiveScenario>
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>
-                <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
-                <objectiveScenario>Convoy Raid.xml</objectiveScenario>
                 <objectiveScenario>Deep Raid.xml</objectiveScenario>
+                <objectiveScenario>Breakthrough.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/ObservationRaid.xml
+++ b/data/stratconcontractdefinitions/ObservationRaid.xml
@@ -24,23 +24,24 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>1.0</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>22</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>2.0</objectiveCount>
+            <objectiveCount>1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>

--- a/data/stratconcontractdefinitions/ObservationRaid.xml
+++ b/data/stratconcontractdefinitions/ObservationRaid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,12 +31,12 @@
         <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
+        <!-- Patient, passive watching. The value '7' is intentionally repeated three times to weight the probability of selecting 7 as a deployment time. -->
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
+        <deploymentTimes>8</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -47,6 +47,7 @@
             </objectiveScenarios>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>FacilityHostileRecon.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>GoodIntel.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/ObservationRaid.xml
+++ b/data/stratconcontractdefinitions/ObservationRaid.xml
@@ -22,7 +22,7 @@
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Conduct reconnaissance on designated locations.</briefing>
     <allowEarlyVictory>true</allowEarlyVictory>
-    <hostileFacilityCount>1.0</hostileFacilityCount>
+    <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
         <!-- This is based on CamOps pg 42 rev 5th printing -->
         <scenarioOdds>22</scenarioOdds>
@@ -41,7 +41,7 @@
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>

--- a/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/data/stratconcontractdefinitions/PirateHunting.xml
@@ -24,30 +24,31 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
         <scenarioOdds>10</scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
+        <scenarioOdds>30</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.33</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.33</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.33</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Escort.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/data/stratconcontractdefinitions/PirateHunting.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,17 +31,20 @@
         <scenarioOdds>30</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Irregular, unpredictable pursuit of pirates. -->
+        <deploymentTimes>2</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
             <objectiveCount>-0.33</objectiveCount>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>BadEquipment.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>

--- a/data/stratconcontractdefinitions/PlanetaryAssault.xml
+++ b/data/stratconcontractdefinitions/PlanetaryAssault.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,12 +31,12 @@
         <scenarioOdds>40</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <!-- Sustained large-scale campaign. The value '6' is intentionally repeated three times to weight the probability of selecting 6 as a deployment time. -->
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -61,6 +61,9 @@
                 <objectiveScenario>Picket Line Breakthrough.xml</objectiveScenario>
                 <objectiveScenario>Pivotal Battle.xml</objectiveScenario>
             </objectiveScenarios>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>HostileBVBudgetIncrease.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/PlanetaryAssault.xml
+++ b/data/stratconcontractdefinitions/PlanetaryAssault.xml
@@ -45,7 +45,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveCount>-0.5</objectiveCount>
-            <objectiveType>AnyScenarioVictory</objectiveType>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Annihilation.xml</objectiveScenario>
                 <objectiveScenario>Breakthrough.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/PlanetaryAssault.xml
+++ b/data/stratconcontractdefinitions/PlanetaryAssault.xml
@@ -21,30 +21,31 @@
     <contractTypeName>Planetary Assault</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Destroy or capture designated facilities.</briefing>
-    <allowEarlyVictory>false</allowEarlyVictory>
+    <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
         <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>80</scenarioOdds>
+        <scenarioOdds>30</scenarioOdds>
+        <scenarioOdds>30</scenarioOdds>
         <scenarioOdds>40</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-2</objectiveCount>
+            <objectiveCount>-1</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-2.0</objectiveCount>
-            <objectiveType>SpecificScenarioVictory</objectiveType>
+            <objectiveCount>-0.5</objectiveCount>
+            <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Annihilation.xml</objectiveScenario>
                 <objectiveScenario>Breakthrough.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ReconRaid.xml
+++ b/data/stratconcontractdefinitions/ReconRaid.xml
@@ -24,23 +24,24 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>-0.5</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>22</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>32</scenarioOdds>
+        <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Hostile Facility.xml</objectiveScenario>
             </objectiveScenarios>
@@ -50,7 +51,7 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/ReconRaid.xml
+++ b/data/stratconcontractdefinitions/ReconRaid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,32 +31,25 @@
         <scenarioOdds>42</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Fast, aggressive combat recon. The value '3' is intentionally repeated three times to weight the probability of selecting 3 as a deployment time. -->
+        <deploymentTimes>2</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
-            <objectiveScenarios>
-                <objectiveScenario>Hostile Facility.xml</objectiveScenario>
-            </objectiveScenarios>
-            <objectiveScenarioModifiers>
-                <objectiveScenarioModifier>FacilityHostileRecon.xml</objectiveScenarioModifier>
-            </objectiveScenarioModifiers>
-        </objectiveParameter>
-        <objectiveParameter>
-            <objectiveType>SpecificScenarioVictory</objectiveType>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1.0</objectiveCount>
             <objectiveScenarios>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
             </objectiveScenarios>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>BadIntelAir.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/ReliefDuty.xml
+++ b/data/stratconcontractdefinitions/ReliefDuty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,10 +31,10 @@
         <scenarioOdds>38</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Urgent initial rush to relieve embattled allies, settling shortly after. -->
+        <deploymentTimes>2</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
         <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
@@ -46,6 +46,9 @@
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
             <objectiveCount>-0.5</objectiveCount>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>PreBattleDamageAllies.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/ReliefDuty.xml
+++ b/data/stratconcontractdefinitions/ReliefDuty.xml
@@ -24,27 +24,28 @@
     <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>60</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>18</scenarioOdds>
+        <scenarioOdds>28</scenarioOdds>
+        <scenarioOdds>28</scenarioOdds>
+        <scenarioOdds>38</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/Retainer.xml
+++ b/data/stratconcontractdefinitions/Retainer.xml
@@ -24,18 +24,19 @@
     <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>16</scenarioOdds>
+        <scenarioOdds>26</scenarioOdds>
+        <scenarioOdds>26</scenarioOdds>
+        <scenarioOdds>36</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters />
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/data/stratconcontractdefinitions/RiotDuty.xml
@@ -24,26 +24,27 @@
     <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
         <scenarioOdds>10</scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
         <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
+        <scenarioOdds>30</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Irregular Force Assault.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/data/stratconcontractdefinitions/RiotDuty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,12 +31,12 @@
         <scenarioOdds>30</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <!-- Steady standing watch. The value '5' is intentionally repeated three times to weight the probability of selecting 5 as a deployment time. -->
         <deploymentTimes>4</deploymentTimes>
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -51,6 +51,9 @@
                 <objectiveScenario>Irregular Force Suppression.xml</objectiveScenario>
                 <objectiveScenario>VIP Defense.xml</objectiveScenario>
             </objectiveScenarios>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>Rookies.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/Sabotage.xml
+++ b/data/stratconcontractdefinitions/Sabotage.xml
@@ -24,18 +24,19 @@
     <allowEarlyVictory>true</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>80</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>38</scenarioOdds>
+        <scenarioOdds>48</scenarioOdds>
+        <scenarioOdds>48</scenarioOdds>
+        <scenarioOdds>58</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -48,10 +49,10 @@
         </objectiveParameter>
         <objectiveParameter>
             <objectiveType>FacilityDestruction</objectiveType>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-1</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/Sabotage.xml
+++ b/data/stratconcontractdefinitions/Sabotage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,20 +31,20 @@
         <scenarioOdds>58</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
+        <!-- Fast strike-and-vanish turnover. The value '3' is intentionally repeated three times to weight the probability of selecting 3 as a deployment time. -->
+        <deploymentTimes>2</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
+        <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveCount>-1</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
-                <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
-                <objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>EnemyHotDrop.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>BadEvent.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
@@ -55,9 +55,9 @@
             <objectiveCount>-0.5</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
-                <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Deep Raid.xml</objectiveScenario>
                 <objectiveScenario>Deep Raid Defense.xml</objectiveScenario>
+                <objectiveScenario>Frontline Disruption.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/SecurityDuty.xml
+++ b/data/stratconcontractdefinitions/SecurityDuty.xml
@@ -24,18 +24,19 @@
     <allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>14</scenarioOdds>
+        <scenarioOdds>24</scenarioOdds>
+        <scenarioOdds>24</scenarioOdds>
+        <scenarioOdds>34</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -43,7 +44,7 @@
             <objectiveCount>-1</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-1.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Escort.xml</objectiveScenario>

--- a/data/stratconcontractdefinitions/SecurityDuty.xml
+++ b/data/stratconcontractdefinitions/SecurityDuty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -31,20 +31,20 @@
         <scenarioOdds>34</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <!-- Steady standing watch. The value '5' is intentionally repeated three times to weight the probability of selecting 5 as a deployment time. -->
         <deploymentTimes>4</deploymentTimes>
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveType>AlliedFacilityControl</objectiveType>
-            <objectiveCount>-1</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-0.5</objectiveCount>
+            <objectiveCount>-1</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Escort.xml</objectiveScenario>
@@ -52,6 +52,9 @@
                 <objectiveScenario>Reconnaissance Interdiction.xml</objectiveScenario>
                 <objectiveScenario>VIP Defense.xml</objectiveScenario>
             </objectiveScenarios>
+            <objectiveScenarioModifiers>
+                <objectiveScenarioModifier>LiaisonGround.xml</objectiveScenarioModifier>
+            </objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/Terrorism.xml
+++ b/data/stratconcontractdefinitions/Terrorism.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -32,20 +32,20 @@
         <scenarioOdds>48</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
-        <deploymentTimes>4</deploymentTimes>
+        <!-- Prolonged insurgency campaign. The value '6' is intentionally repeated three times to weight the probability of selecting 6 as a deployment time. -->
         <deploymentTimes>5</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>6</deploymentTimes>
+        <deploymentTimes>7</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
             <objectiveCount>-1</objectiveCount>
             <objectiveType>AnyScenarioVictory</objectiveType>
             <objectiveScenarioModifiers>
-                <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
-                <objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>PiratesPresentGround.xml</objectiveScenarioModifier>
+                <objectiveScenarioModifier>PiratesPresentAir.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
@@ -54,7 +54,6 @@
             <objectiveScenarios>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>
-                <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>

--- a/data/stratconcontractdefinitions/Terrorism.xml
+++ b/data/stratconcontractdefinitions/Terrorism.xml
@@ -25,18 +25,19 @@
     <hostileFacilityCount>-1</hostileFacilityCount>
     <objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
     <scenarioOdds>
-        <scenarioOdds>10</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
-        <scenarioOdds>40</scenarioOdds>
-        <scenarioOdds>20</scenarioOdds>
+        <!-- This is based on CamOps pg 42 rev 5th printing -->
+        <scenarioOdds>28</scenarioOdds>
+        <scenarioOdds>38</scenarioOdds>
+        <scenarioOdds>38</scenarioOdds>
+        <scenarioOdds>48</scenarioOdds>
     </scenarioOdds>
     <deploymentTimes>
-        <deploymentTimes>2</deploymentTimes>
-        <!-- The value '3' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
-        <deploymentTimes>3</deploymentTimes>
-        <deploymentTimes>3</deploymentTimes>
+        <!-- The value '4' is intentionally repeated three times to weight the probability of selecting 4 as a deployment time. -->
         <deploymentTimes>3</deploymentTimes>
         <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>4</deploymentTimes>
+        <deploymentTimes>5</deploymentTimes>
     </deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
@@ -48,7 +49,7 @@
             </objectiveScenarioModifiers>
         </objectiveParameter>
         <objectiveParameter>
-            <objectiveCount>-2.0</objectiveCount>
+            <objectiveCount>-0.5</objectiveCount>
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveScenarios>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>


### PR DESCRIPTION
Close #449

Now that I'm actually able to make time to _play_ MekHQ I'm noticing things that weren't necessarily obvious when I only had time to dev. One of those issues is the sheer volume of objectives and facilities.

# General Fixes
Scenario odds are now based on the operational tempo found in CamOps (pg 42 rev 5th printing). Our scenario changes are now the tempo multiplied by 20. To ensure there is some variety that tempo-based result is then increased by 10 and decreased by 10. That gives us a range, such as `Assassination 28/38/38/48`. In this example there are four possible tempos with the average (38) being twice as likely as the low or high tempo versions.

I've increased the deployment zone baseline from 2/3/3/3/4 to 3/4/4/4/5. The goal here is to make deployment feel weighty. I wasn't happy with how quickly forces returned. I wanted these return times to have impact without being crippling. However, 3/4/4/4/5 is just the baseline, some contract types adjust this (see below).

A couple of contract types were slightly misconfigured with objective count and CVP gaining rules. Those have all now been fixed.

# Flavor Changes
I was really unhappy with how _samey_ our contracts felt. There really wasn't a lot of difference between assassination and recon raid. With that in mind, I have made the following changes:

| Contract | Deployment pacing | Changes |
|---|---|---|
| **Garrison Duty** | Baseline `3/4/4/4/5` | Added `LocalGarrisonTurrets` to the facility-control objective — actual defenses present. Otherwise the plain baseline. |
| **Cadre Duty** | Slow `5,6,6,6,7` | Pacing only — training takes time. |
| **Security Duty** | Moderate `4,5,5,5,6` | Shifted weight from facility control (-1 → -0.5) toward the VIP/escort pool (-0.5 → -1); added `LiaisonGround` (employer's observer present). |
| **Riot Duty** | Moderate `4,5,5,5,6` | Added `Rookies` to the irregular-force objective — rioters are undertrained civilians, not soldiers. |
| **Planetary Assault** | Slow `5,6,6,6,7` | Added `HostileBVBudgetIncrease` to the big-battle objective — larger, better-resourced defenders. |
| **Relief Duty** | Urgent-front `2,3,3,4,5` | Added `PreBattleDamageAllies` — the allies you're relieving are already damaged. |
| **Guerrilla Warfare** | Fast `2,3,3,3,4` | Now the **sole owner** of the Overwhelming-reinforcements filler (fits "behind enemy lines without support"). Pool trimmed to hit-and-run harassment: Convoy Interdiction, Convoy Raid, Intercept Engagement, Tactical Withdrawal. |
| **Pirate Hunting** | Irregular `2,3,4,5,6` | Added `BadEquipment` to the facility objective — pirates run salvaged gear. |
| **Diversionary Raid** | Fast `2,3,3,3,4` | Added `ReinforcementDelayReductionHostile` (the point is provoking a fast response); pool is now Decoy Engagement, Decoy Interception, and Diversion Engagement (previously unused). |
| **Objective Raid** | Baseline `3/4/4/4/5` | The plain baseline raid; pool trimmed to Covert Strike, Deep Raid, Breakthrough (previously unused). |
| **Extraction Raid** | Fast `2,3,3,3,4` | Kept its unique `FacilityHostileExtract` combo; secondary pool leans dropship smash-and-grab: Covert Strike, DropShip Raid, Isolated DropShip Defense. |
| **Sabotage** | Fast `2,3,3,3,4` | Kept its unique full-weight `FacilityDestruction`; replaced the shared filler with `EnemyHotDrop` + `BadEvent` (the bang draws a fast, hard response); pool now Deep Raid, Deep Raid Defense, Frontline Disruption. |
| **Terrorism** (Black-Ops Insurgency) | Slow `5,6,6,6,7` | Replaced the shared filler with `PiratesPresentGround` + `PiratesPresentAir` — "unidentified forces" fits masked insurgent cells. |
| **Assassination** | Fast `2,3,3,3,4` | Now the anchor owner of VIP Ambush / Frontier Assassination / Assassination scenarios; pacing only otherwise. |
| **Mole Hunting** | Moderate `4,5,5,5,6` | Dropped Frontier Assassination (now Assassination-exclusive); replaced the shared filler with `BadIntelGround` — your informant network may be compromised. Also fixed the Assassination-scenario objective count (`1.0` → `-0.5`) so it scales with contract size. |
| **Observation Raid** | Very slow `6,7,7,7,8` | Now the **sole owner** of the `Hostile Facility` + `FacilityHostileRecon` combo; added `GoodIntel` — patient surveillance pays off. Lowest-intensity recon variant. |
| **Recon Raid** | Fast `2,3,3,3,4` | Dropped the facility-recon block (now Observation Raid's); added `BadIntelAir` — raiding blind. Aggressive recon variant. |
| **Espionage** | Very slow `6,7,7,7,8` | Dropped the facility block entirely (pure infiltration); replaced the shared filler with `ReinforcementDelayReductionHostile` — the longer you're in, the faster they respond once blown. |
| **Retainer** | Baseline `3/4/4/4/5` | Untouched — its empty objective set is already its identity. |