### PR TITLE
Updated Scenario Definitions to Offer More Unique Experiences; Added 23 New Scenario Types

### DIFF
--- a/data/scenariomodifiers/FacilityAlliedEvac.xml
+++ b/data/scenariomodifiers/FacilityAlliedEvac.xml
@@ -89,8 +89,8 @@
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Get 25% the following unit(s) and force(s) to the destination edge:</description>
-            <destinationEdge>NONE</destinationEdge>
+            <description>Get 25% the following unit(s) and force(s) to the destination edge. +1 SVP if succeeded, -1 SVP if failed:</description>
+            <destinationEdge>SOUTH</destinationEdge>
             <objectiveCriterion>ReachMapEdge</objectiveCriterion>
             <percentage>25</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>

--- a/data/scenariomodifiers/FacilityAlliedEvac.xml
+++ b/data/scenariomodifiers/FacilityAlliedEvac.xml
@@ -1,5 +1,5 @@
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariomodifiers/FacilityHostilePreventEvac.xml
+++ b/data/scenariomodifiers/FacilityHostilePreventEvac.xml
@@ -70,11 +70,6 @@
                     <effectScaling>Fixed</effectScaling>
                     <howMuch>1</howMuch>
                 </successEffect>
-                <failureEffect>
-                    <effectType>FacilityRemoved</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
@@ -82,15 +77,10 @@
                     <effectScaling>Fixed</effectScaling>
                     <howMuch>1</howMuch>
                 </failureEffect>
-                <failureEffect>
-                    <effectType>FacilityRemoved</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Prevent 75% the following enemy unit(s) and force(s) from escaping:</description>
-            <destinationEdge>NONE</destinationEdge>
+            <description>Prevent 75% the following enemy unit(s) and force(s) from escaping. +1 SVP if succeeded, -1 SVP if failed:</description>
+            <destinationEdge>SOUTH</destinationEdge>
             <objectiveCriterion>PreventReachMapEdge</objectiveCriterion>
             <percentage>75</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>

--- a/data/scenariomodifiers/FacilityHostilePreventEvac.xml
+++ b/data/scenariomodifiers/FacilityHostilePreventEvac.xml
@@ -1,5 +1,5 @@
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Ambush the Column.xml
+++ b/data/scenariotemplates/Ambush the Column.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,24 +18,22 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Ambush the Column</name>
+    <shortBriefing>Hit a strung-out enemy column and defeat it piecemeal before it can concentrate.</shortBriefing>
+    <detailedBriefing><![CDATA[An enemy column is moving through the area strung out on the march, its units arriving piecemeal rather than as a formed battle line. We are in position first. This is the moment to defeat them in detail—before they can pull together into a single fist.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Set your positions and hit each element hard as it arrives, then reset before the next one is on you. If you let them concentrate, their full strength will outweigh yours; if you break them piece by piece, you win. Aggression and tempo are everything here.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Shatter the column as it comes in. Rout the bulk of them before they can form up.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Hills</allowedTerrainType>
             <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -62,7 +60,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -86,7 +84,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>-1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -96,12 +94,12 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.25</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
@@ -109,7 +107,9 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SUPPORT</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -124,24 +124,23 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% of the following column. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Annihilation.xml
+++ b/data/scenariotemplates/Annihilation.xml
@@ -25,12 +25,17 @@
 The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -91,7 +96,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <minWeightClass>2</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>

--- a/data/scenariotemplates/Annihilation.xml
+++ b/data/scenariotemplates/Annihilation.xml
@@ -30,6 +30,7 @@ The victor controls the field, and we will be the ones standing when the dust se
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -93,7 +94,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>2</minWeightClass>
+                <minWeightClass>3</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeArc</syncDeploymentType>

--- a/data/scenariotemplates/Annihilation.xml
+++ b/data/scenariotemplates/Annihilation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Assassination.xml
+++ b/data/scenariotemplates/Assassination.xml
@@ -25,12 +25,16 @@
 We expect a fierce but contained battle. Your forces will be operating behind enemy lines, deep within hostile territory. Extraction is not a priority—the enemy will retain control of the battlefield when the dust settles. Your task is to neutralize the VIP, no other considerations are of value.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Urban</allowedTerrainType>
+            <allowedTerrainType>ColdUrban</allowedTerrainType>
+            <allowedTerrainType>HotUrban</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Assassination.xml
+++ b/data/scenariotemplates/Assassination.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Assassination.xml
+++ b/data/scenariotemplates/Assassination.xml
@@ -98,6 +98,10 @@ We expect a fierce but contained battle. Your forces will be operating behind en
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/data/scenariotemplates/Base Defense.xml
+++ b/data/scenariotemplates/Base Defense.xml
@@ -22,7 +22,7 @@
     <shortBriefing>Defend allied facility, minimize damage.</shortBriefing>
     <detailedBriefing><![CDATA[Your orders are clear: defend the base against the incoming enemy assault. At least 25% of the base infrastructure must remain intact by the end of the engagement.
 
-At the same time, this is not just about survival. You are to destroy at least 50% of enemy forces before the battle concludes.
+At the same time, this is not just about survival. You are to destroy at least 33% of enemy forces before the battle concludes.
 
 The victor will control the field when this is over. Ensure that it is us.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
@@ -30,9 +30,10 @@ The victor will control the field when this is over. Ensure that it is us.]]></d
     <isAlliedFacility>true</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>TemperateFacility</allowedTerrainType>
             <allowedTerrainType>ColdFacility</allowedTerrainType>
             <allowedTerrainType>HotFacility</allowedTerrainType>
-            <allowedTerrainType>TemperateFacility</allowedTerrainType>
+            <allowedTerrainType>FrozenFacility</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -160,10 +161,10 @@ The victor will control the field when this is over. Ensure that it is us.]]></d
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the attacking forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the attacking forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Base Defense.xml
+++ b/data/scenariotemplates/Base Defense.xml
@@ -137,6 +137,11 @@ The victor will control the field when this is over. Ensure that it is us.]]></d
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>ARTILLERY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Base Defense.xml
+++ b/data/scenariotemplates/Base Defense.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Bomber Escort.xml
+++ b/data/scenariotemplates/Bomber Escort.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+-->
+<ScenarioTemplate>
+    <name>Bomber Escort</name>
+    <shortBriefing>Escort allied bombers through interceptors to their target.</shortBriefing>
+    <detailedBriefing><![CDATA[Allied bombers are inbound to hit a priority target, and enemy interceptors are scrambling to knock them down before they can release. The bombers are loaded, sluggish, and cannot defend themselves—that is your job.
+
+Fly close escort. The interceptors will try to slip past you to reach the bombers, so you cannot just chase kills; you have to stay between them and your charges. Keep the bombers flying long enough to complete the run. Aces mean nothing if the bombers never reach the target.
+
+Keep the bomber flight intact and drive off the interceptors.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
+    <mapParameters>
+        <allowedTerrainTypes />
+        <allowRotation>false</allowRotation>
+        <baseHeight>50</baseHeight>
+        <baseWidth>50</baseWidth>
+        <heightScalingIncrement>5</heightScalingIncrement>
+        <mapLocation>LowAtmosphere</mapLocation>
+        <useStandardAtBSizing>true</useStandardAtBSizing>
+        <additionalMapSheetTall>1</additionalMapSheetTall>
+        <additionalMapSheetWide>2</additionalMapSheetWide>
+        <widthScalingIncrement>5</widthScalingIncrement>
+    </mapParameters>
+    <scenarioForces>
+        <entry>
+            <key>Player</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>9</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Player</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>1</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Bombers</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>true</allowAeroBombs>
+                <allowedUnitType>9</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>2</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>1</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Bombers</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>BOMBER</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
+            <key>OpFor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>9</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones />
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>OpFor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>Bombers</objectiveLinkedForce>
+                </objectiveLinkedForces>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>INTERCEPTOR</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+    </scenarioForces>
+    <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Bombers</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects />
+            <additionalDetails />
+            <description>Destroy or rout 33% of the interceptors. +1 SVP if succeeded.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+    </scenarioObjectives>
+</ScenarioTemplate>

--- a/data/scenariotemplates/Breakout.xml
+++ b/data/scenariotemplates/Breakout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Breakout</name>
+    <shortBriefing>Surrounded—punch through the ring and get the force out.</shortBriefing>
+    <detailedBriefing><![CDATA[We are encircled. The enemy has closed a ring around your position and is tightening it. Staying put means annihilation; the only answer is to pick a direction, mass everything against it, and break out.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Do not try to fight the whole ring—you cannot. Concentrate against one arc, blow a hole in it, and drive the force through to open ground before the rest of the cordon can collapse in on you. Speed and shock, not attrition.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Break out and get 50% of the force clear of the map edge.]]></detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -62,9 +60,9 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -92,24 +90,29 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>2</deploymentZone>
+                    <deploymentZone>4</deploymentZone>
+                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>8</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.25</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -117,31 +120,31 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <description>Get 50% of the following forces to the far edge. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NORTH</destinationEdge>
+            <objectiveCriterion>ReachMapEdge</objectiveCriterion>
+            <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Breakthrough.xml
+++ b/data/scenariotemplates/Breakthrough.xml
@@ -22,17 +22,22 @@
     <shortBriefing>Break through or destroy enemy.</shortBriefing>
     <detailedBriefing><![CDATA[Your objective is to break through enemy lines and reach the far side of the engagement zone. At least 50% of your forces must reach the destination, and only fully operational units will count.
 
-If the enemy resistance proves too strong, you have an alternative path to victory: destroy at least 50% of enemy forces to force them into disarray and open the way.
+If the enemy resistance proves too strong, you have an alternative path to victory: destroy at least 33% of enemy forces to force them into disarray and open the way.
 
 Be advised: the enemy will control the field when this is over. Move fast, strike hard, and don’t look back.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -153,10 +158,10 @@ Be advised: the enemy will control the field when this is over. Move fast, strik
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Breakthrough.xml
+++ b/data/scenariotemplates/Breakthrough.xml
@@ -32,6 +32,7 @@ Be advised: the enemy will control the field when this is over. Move fast, strik
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>

--- a/data/scenariotemplates/Breakthrough.xml
+++ b/data/scenariotemplates/Breakthrough.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Close Air Support.xml
+++ b/data/scenariotemplates/Close Air Support.xml
@@ -32,6 +32,7 @@ The winner of this battle will control the field when the engagement is over. Yo
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>40</baseHeight>
@@ -101,6 +102,9 @@ The winner of this battle will control the field when the engagement is over. Yo
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>ANTI_AIRCRAFT</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/data/scenariotemplates/Close Air Support.xml
+++ b/data/scenariotemplates/Close Air Support.xml
@@ -22,17 +22,22 @@
     <shortBriefing>Provide air support, minimize losses.</shortBriefing>
     <detailedBriefing><![CDATA[Your mission is to provide air support to allied ground forces currently under heavy attack. The enemy is pressing hard, and without intervention, our forces will be overwhelmed. You are to engage hostile units with precision strikes, break enemy formations, and relieve pressure on friendly positions. Coordination with ground command will be critical to ensuring maximum impact.
 
-Your primary objective is to preserve at least 50% of allied forces. Their survival is paramount to maintaining battlefield cohesion. Simultaneously, you must destroy or rout at least 50% of the enemy forces. This engagement is about turning the tide, forcing them to break, and ensuring our ground forces can hold firm.
+Your primary objective is to preserve at least 50% of allied forces. Their survival is paramount to maintaining battlefield cohesion. Simultaneously, you must destroy or rout at least 33% of the enemy forces. This engagement is about turning the tide, forcing them to break, and ensuring our ground forces can hold firm.
 
 The winner of this battle will control the field when the engagement is over. You must ensure that victory belongs to us. Strike hard, strike true, and do not let the enemy dictate the pace of battle. Your firepower will decide the outcome.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>40</baseHeight>
         <baseWidth>40</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -177,10 +182,10 @@ The winner of this battle will control the field when the engagement is over. Yo
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Close Air Support.xml
+++ b/data/scenariotemplates/Close Air Support.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Combat Drop.xml
+++ b/data/scenariotemplates/Combat Drop.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Combat Drop</name>
+    <shortBriefing>Make a combat drop into a defended zone and break the garrison.</shortBriefing>
+    <detailedBriefing><![CDATA[There is no time for a conventional landing. You are going in the hard way—a combat drop straight onto the objective, dropping through fire into the middle of a defended zone.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+You will come down scattered and exposed, with the garrison already in position around you. Land, form up fast, and break them before they can concentrate on your descending units. Every second spent reorganizing under their guns is a second they use to pick you apart.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Once you are down, drive the defenders off and hold the ground. This is a high-risk insertion—the reward is that they never saw you coming.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -62,7 +60,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -92,24 +90,29 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>1</deploymentZone>
+                    <deploymentZone>3</deploymentZone>
+                    <deploymentZone>5</deploymentZone>
+                    <deploymentZone>7</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>ANTI_AIRCRAFT</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -124,24 +127,23 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to secure the drop zone. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Convoy Escort.xml
+++ b/data/scenariotemplates/Convoy Escort.xml
@@ -35,6 +35,7 @@ We will control the field at the conclusion of the battle. This means you have f
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Convoy Escort.xml
+++ b/data/scenariotemplates/Convoy Escort.xml
@@ -23,19 +23,24 @@
     <shortBriefing>Escort supply convoy or defeat attackers.</shortBriefing>
     <detailedBriefing><![CDATA[An allied convoy carrying critical supplies is moving through hostile territory, and enemy forces are preparing to intercept. Your mission is to ensure that the convoy reaches its destination. At least 50% of the convoy must reach the far edge of the engagement area intact. These supplies are vital to sustaining our operations, and failure is not an option.
 
-Should the enemy resistance prove too strong for a full escort, you have an alternative means to secure victory. If at least 50% of the convoy survives while you destroy or rout 50% of the enemy forces, the mission will be considered a success. Breaking the enemy’s will to fight will give the convoy a clear path forward.
+Should the enemy resistance prove too strong for a full escort, you have an alternative means to secure victory. If at least 50% of the convoy survives while you destroy or rout 33% of the enemy forces, the mission will be considered a success. Breaking the enemy’s will to fight will give the convoy a clear path forward.
 
 We will control the field at the conclusion of the battle. This means you have full authority to dictate the engagement on your terms. Use the terrain, control the tempo, and eliminate threats efficiently. Hold the line, protect the convoy, and ensure that these supplies reach their destination.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -190,10 +195,10 @@ We will control the field at the conclusion of the battle. This means you have f
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Convoy Escort.xml
+++ b/data/scenariotemplates/Convoy Escort.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Convoy Hijack.xml
+++ b/data/scenariotemplates/Convoy Hijack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,19 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Annihilation</name>
-    <shortBriefing>Obliterate the enemy force.</shortBriefing>
-    <detailedBriefing><![CDATA[Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 75% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations.
+    <name>Convoy Hijack</name>
+    <shortBriefing>Capture the enemy convoy intact before it can escape.</shortBriefing>
+    <detailedBriefing><![CDATA[An enemy supply convoy is running through our area of operations, and command wants it intact—not scattered wreckage. Those vehicles and their cargo are worth far more captured than destroyed.
 
-The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
+Immobilize the transports and hold them; do not simply blow them apart. The convoy will run for the far edge the moment it sees you, and its escort will fight to keep it moving. Cripple the escort, box in the transports, and take them before they slip off the map. Restraint is the hard part—it is easier to kill a convoy than to steal one.
+
+Capture as much of the convoy as you can and drive off its escort.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Plains</allowedTerrainType>
             <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
-            <allowedTerrainType>Tundra</allowedTerrainType>
-            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -39,7 +43,7 @@ The victor controls the field, and we will be the ones standing when the dust se
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
-        <additionalMapSheetWide>0</additionalMapSheetWide>
+        <additionalMapSheetWide>1</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -49,7 +53,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -67,10 +71,47 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Convoy</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>1</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>4</deploymentZone>
+                </deploymentZones>
+                <destinationZone>8</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Convoy</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>3</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>SUPPORT</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>APC</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>
@@ -89,21 +130,60 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
+                <forceMultiplier>0.75</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>3</minWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>Convoy</objectiveLinkedForce>
+                </objectiveLinkedForces>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeArc</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>SameEdge</syncDeploymentType>
+                <syncedForceName>Convoy</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>CAVALRY</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Convoy</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+                <successEffect>
+                    <effectType>SupplyCache</effectType>
+                    <effectScaling>Linear</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Capture 50% of the following convoy intact. +2 SVP and bonus supplies if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Capture</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -116,18 +196,12 @@ The victor controls the field, and we will be the ones standing when the dust se
                     <howMuch>1</howMuch>
                 </successEffect>
             </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
+            <failureEffects />
             <additionalDetails />
-            <description>Destroy or rout 75% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following escort. +1 SVP if succeeded.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Convoy Interdiction.xml
+++ b/data/scenariotemplates/Convoy Interdiction.xml
@@ -28,12 +28,18 @@ There is no need to concern yourself with minimizing damage or securing the spoi
 No distractions. No delays. No mercy. Execute the raid, cripple their supply line, and get out before the enemy can mount a counterattack.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -186,10 +192,10 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <howMuch>1</howMuch>
             </failureEffect>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces to force convoy surrender. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to force convoy surrender. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Convoy Interdiction.xml
+++ b/data/scenariotemplates/Convoy Interdiction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Convoy Raid.xml
+++ b/data/scenariotemplates/Convoy Raid.xml
@@ -28,12 +28,18 @@ Your primary objective is to prevent at least 50% of the convoy from reaching th
 The more convoy units that survive, the greater the spoils. Disabling transports instead of outright destruction may increase salvage potential, but that is a secondary concern to stopping the convoy itself. However, do not linger. The enemy will respond quickly, and we will not control the field once the battle ends. Execute the raid with precision, neutralize the targets, and withdraw before the enemy's full force arrives.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -208,10 +214,10 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <howMuch>1</howMuch>
             </failureEffect>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces to force convoy surrender. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to force convoy surrender. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Convoy Raid.xml
+++ b/data/scenariotemplates/Convoy Raid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Covert Strike.xml
+++ b/data/scenariotemplates/Covert Strike.xml
@@ -27,12 +27,18 @@ The enemy will not allow this to happen easily. Expect heavy resistance, tight s
 Be advised, the enemy will control the field at the end of the engagement. You will not be able to hold ground or claim battlefield salvage. This is an execution, not a siege. Kill the target and get out—nothing else matters.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
+            <allowedTerrainType>Swamp</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Covert Strike.xml
+++ b/data/scenariotemplates/Covert Strike.xml
@@ -102,6 +102,11 @@ Be advised, the enemy will control the field at the end of the engagement. You w
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/data/scenariotemplates/Covert Strike.xml
+++ b/data/scenariotemplates/Covert Strike.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/data/scenariotemplates/Critical Convoy Escort.xml
@@ -35,6 +35,7 @@ We will control the field at the end of the battle, giving you full authority to
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/data/scenariotemplates/Critical Convoy Escort.xml
@@ -23,19 +23,24 @@
     <shortBriefing>Escort critical convoy or defeat attackers.</shortBriefing>
     <detailedBriefing><![CDATA[An allied convoy carrying critical supplies is moving through hostile territory, and a large, heavily armed enemy force is preparing to intercept. Your mission is to ensure that at least 50% of the convoy reaches the far edge of the engagement area intact. These supplies are essential to sustaining our war effort, and failure is not an option.
 
-The enemy will come in force, but their attack is not unstoppable. If a full escort proves untenable, you have an alternative path to victory. Should at least 50% of the convoy survive while you destroy or rout 50% of the attacking enemy force, the mission will be considered a success. Breaking their offensive will allow our convoy to continue forward without further resistance.
+The enemy will come in force, but their attack is not unstoppable. If a full escort proves untenable, you have an alternative path to victory. Should at least 50% of the convoy survive while you destroy or rout 33% of the attacking enemy force, the mission will be considered a success. Breaking their offensive will allow our convoy to continue forward without further resistance.
 
 We will control the field at the end of the battle, giving you full authority to dictate the engagement on our terms. Use the terrain, stagger your defenses, and counter their assault with precision. Hold the line, protect the convoy, and ensure these supplies reach their destination. Victory here will secure our war effort in this sector.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -190,10 +195,10 @@ We will control the field at the end of the battle, giving you full authority to
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/data/scenariotemplates/Critical Convoy Escort.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Crowd Control.xml
+++ b/data/scenariotemplates/Crowd Control.xml
@@ -30,15 +30,15 @@ The victor will control the battlefield; ensure order is reestablished.]]></deta
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>Urban</allowedTerrainType>
             <allowedTerrainType>ColdUrban</allowedTerrainType>
             <allowedTerrainType>HotUrban</allowedTerrainType>
-            <allowedTerrainType>Urban</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Crowd Control.xml
+++ b/data/scenariotemplates/Crowd Control.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Decapitation Strike.xml
+++ b/data/scenariotemplates/Decapitation Strike.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,19 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Annihilation</name>
-    <shortBriefing>Obliterate the enemy force.</shortBriefing>
-    <detailedBriefing><![CDATA[Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 75% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations.
+    <name>Decapitation Strike</name>
+    <shortBriefing>Punch through the guard and destroy the enemy commander.</shortBriefing>
+    <detailedBriefing><![CDATA[Intelligence has located the enemy field commander, and command wants them gone. Cut the head off and the surrounding formation loses cohesion for the rest of this operation.
 
-The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
+The commander will not be alone—expect a hardened bodyguard screening them and keeping them out of your reach. You will have to break through or draw off that screen to get a clean shot. Do not get bogged down trading fire with the guard; they are not the objective. The commander is.
+
+Destroy the commander. Everything else is secondary to that single kill.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Plains</allowedTerrainType>
-            <allowedTerrainType>Steppe</allowedTerrainType>
-            <allowedTerrainType>Savannah</allowedTerrainType>
-            <allowedTerrainType>Tundra</allowedTerrainType>
-            <allowedTerrainType>SnowField</allowedTerrainType>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -49,7 +53,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -58,7 +62,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -67,6 +71,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -74,7 +79,41 @@ The victor controls the field, and we will be the ones standing when the dust se
             </value>
         </entry>
         <entry>
-            <key>OpFor</key>
+            <key>Commander</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>0</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>2</deploymentZone>
+                </deploymentZones>
+                <destinationZone>2</destinationZone>
+                <fixedUnitCount>1</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Commander</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>3</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>3</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>COMMAND</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
+            <key>Bodyguard</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
@@ -90,23 +129,57 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
-                <forceName>OpFor</forceName>
+                <forceName>Bodyguard</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>3</minWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>Commander</objectiveLinkedForce>
+                </objectiveLinkedForces>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeArc</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>SameEdge</syncDeploymentType>
+                <syncedForceName>Commander</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>Commander</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy 100% of the following force. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Destroy</objectiveCriterion>
+            <percentage>100</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Bodyguard</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
@@ -116,18 +189,12 @@ The victor controls the field, and we will be the ones standing when the dust se
                     <howMuch>1</howMuch>
                 </successEffect>
             </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
+            <failureEffects />
             <additionalDetails />
-            <description>Destroy or rout 75% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to break the screen. +1 SVP if succeeded.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Decoy Engagement.xml
+++ b/data/scenariotemplates/Decoy Engagement.xml
@@ -20,21 +20,27 @@
 <ScenarioTemplate>
     <name>Decoy Engagement</name>
     <shortBriefing>Engage enemy, act as decoy.</shortBriefing>
-    <detailedBriefing><![CDATA[Your mission is to serve as a decoy, drawing the attention of a large enemy force while our allies carry out critical objectives elsewhere in the sector. The enemy must believe you are the primary threat, forcing them to commit their forces fully to your position. Your task is to survive for the designated duration or, if possible, eliminate 75% of the enemy forces to break their will.
+    <detailedBriefing><![CDATA[Your mission is to serve as a decoy, drawing the attention of a large enemy force while our allies carry out critical objectives elsewhere in the sector. The enemy must believe you are the primary threat, forcing them to commit their forces fully to your position. Your task is to survive for the designated duration or, if possible, eliminate 50% of the enemy forces to break their will.
 
 This engagement is about endurance, misdirection, and tactical maneuvering. The enemy will press hard, believing you to be the key target, but you must endure. Use the terrain to your advantage, control the pace of the battle, and engage only when necessary. If you hold them long enough, our allies will complete their objectives uncontested.
 
-Should you succeed in routing 75% of the enemy force, they will lose cohesion, and we will control the battlefield at the end of the engagement. This will allow us full access to any salvageable assets left behind. Victory here will not only ensure the success of our allies but also give us a chance to recover valuable battlefield resources.
+Should you succeed in routing 50% of the enemy force, they will lose cohesion, and we will control the battlefield at the end of the engagement. This will allow us full access to any salvageable assets left behind. Victory here will not only ensure the success of our allies but also give us a chance to recover valuable battlefield resources.
 
 Hold the line, weather the storm, and outlast them. If they break, the field is ours.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -150,10 +156,10 @@ Hold the line, weather the storm, and outlast them. If they break, the field is 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 75% of the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% of the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>50</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Decoy Engagement.xml
+++ b/data/scenariotemplates/Decoy Engagement.xml
@@ -104,6 +104,11 @@ Hold the line, weather the storm, and outlast them. If they break, the field is 
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Decoy Engagement.xml
+++ b/data/scenariotemplates/Decoy Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Decoy Interception.xml
+++ b/data/scenariotemplates/Decoy Interception.xml
@@ -104,6 +104,11 @@ Stand firm, draw them in, and ensure they never reach their goal. If they break,
                 <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Decoy Interception.xml
+++ b/data/scenariotemplates/Decoy Interception.xml
@@ -20,21 +20,27 @@
 <ScenarioTemplate>
     <name>Decoy Interception</name>
     <shortBriefing>Intercept enemy, act as decoy.</shortBriefing>
-    <detailedBriefing><![CDATA[Your mission is to intercept and engage enemy forces to draw them away from their primary objective. Our intelligence indicates that they are moving to secure a critical target, but by forcing an engagement, you will divert their attention and disrupt their plans. Your task is to hold them in combat for the specified duration or, if the opportunity presents itself, destroy 75% of their forces to rout them completely.
+    <detailedBriefing><![CDATA[Your mission is to intercept and engage enemy forces to draw them away from their primary objective. Our intelligence indicates that they are moving to secure a critical target, but by forcing an engagement, you will divert their attention and disrupt their plans. Your task is to hold them in combat for the specified duration or, if the opportunity presents itself, destroy 50% of their forces to rout them completely.
 
 This battle is about control and endurance. The longer you keep the enemy occupied, the more time our allies will have to complete their objectives elsewhere. Expect a determined enemy response, as they will attempt to break through and reestablish their mission. You must balance aggression with resilience—hold them long enough, or cripple them so severely that they can no longer continue the fight.
 
-Should you succeed in routing 75% of their forces, we will seize control of the battlefield at the end of the engagement. This will allow us to recover any remaining assets and deny the enemy any chance of regrouping. Whether by sheer endurance or decisive firepower, your success here will determine the outcome of operations across the sector.
+Should you succeed in routing 50% of their forces, we will seize control of the battlefield at the end of the engagement. This will allow us to recover any remaining assets and deny the enemy any chance of regrouping. Whether by sheer endurance or decisive firepower, your success here will determine the outcome of operations across the sector.
 
 Stand firm, draw them in, and ensure they never reach their goal. If they break, the field is ours.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -95,7 +101,7 @@ Stand firm, draw them in, and ensure they never reach their goal. If they break,
                 <minWeightClass>1</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
@@ -150,10 +156,10 @@ Stand firm, draw them in, and ensure they never reach their goal. If they break,
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 75% of the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% of the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>50</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Decoy Interception.xml
+++ b/data/scenariotemplates/Decoy Interception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Deep Raid Defense.xml
+++ b/data/scenariotemplates/Deep Raid Defense.xml
@@ -31,11 +31,13 @@ We will control the battlefield at the end of the engagement, ensuring access to
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Forest</allowedTerrainType>
-            <allowedTerrainType>ColdForest</allowedTerrainType>
-            <allowedTerrainType>HotForest</allowedTerrainType>
-            <allowedTerrainType>Jungle</allowedTerrainType>
-            <allowedTerrainType>Swamp</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Deep Raid Defense.xml
+++ b/data/scenariotemplates/Deep Raid Defense.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Deep Raid Defense.xml
+++ b/data/scenariotemplates/Deep Raid Defense.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Deep Raid Defense</name>
     <shortBriefing>Defend grounded DropShip from raid.</shortBriefing>
-    <detailedBriefing><![CDATA[The enemy has launched a deep strike behind our lines, targeting one of our DropShips before it can take off. This is a calculated assault meant to cripple our logistics and deny us critical mobility. Your mission is to defend the DropShip until it can launch or eliminate at least 50% of the attacking force to force their retreat.
+    <detailedBriefing><![CDATA[The enemy has launched a deep strike behind our lines, targeting one of our DropShips before it can take off. This is a calculated assault meant to cripple our logistics and deny us critical mobility. Your mission is to defend the DropShip until it can launch or eliminate at least 33% of the attacking force to force their retreat.
 
 Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
 
@@ -30,12 +30,18 @@ We will control the battlefield at the end of the engagement, ensuring access to
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
+            <allowedTerrainType>Swamp</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -210,10 +216,10 @@ We will control the battlefield at the end of the engagement, ensuring access to
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy, cripple or force to withdraw 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy, cripple or force to withdraw 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Deep Raid.xml
+++ b/data/scenariotemplates/Deep Raid.xml
@@ -29,12 +29,18 @@ This engagement takes place in enemy territory, meaning we will not control the 
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
+            <allowedTerrainType>Swamp</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>10</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Deep Raid.xml
+++ b/data/scenariotemplates/Deep Raid.xml
@@ -30,11 +30,13 @@ This engagement takes place in enemy territory, meaning we will not control the 
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Forest</allowedTerrainType>
-            <allowedTerrainType>ColdForest</allowedTerrainType>
-            <allowedTerrainType>HotForest</allowedTerrainType>
-            <allowedTerrainType>Jungle</allowedTerrainType>
-            <allowedTerrainType>Swamp</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -106,6 +108,11 @@ This engagement takes place in enemy territory, meaning we will not control the 
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/data/scenariotemplates/Deep Raid.xml
+++ b/data/scenariotemplates/Deep Raid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Diversion Engagement.xml
+++ b/data/scenariotemplates/Diversion Engagement.xml
@@ -103,6 +103,11 @@ Be advised: the enemy will control the field at the end of the engagement. There
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Diversion Engagement.xml
+++ b/data/scenariotemplates/Diversion Engagement.xml
@@ -22,17 +22,23 @@
     <shortBriefing>Bypass or destroy diversionary force.</shortBriefing>
     <detailedBriefing><![CDATA[The enemy has deployed a delaying force to stall our advance toward a critical objective. Their mission is to slow us down, bleed our forces, and buy time for their reinforcements to fortify their position. Your task is to push through their blockade and continue the advance.
 
-Victory can be achieved in one of two ways. Ensure at least 50% of your forces reach the far edge of the engagement zone, bypassing the enemy’s attempt to hold you in place. Alternatively, if they commit too heavily to blocking your path, destroy at least 75% of their forces, breaking their ability to resist and forcing them to withdraw.
+Victory can be achieved in one of two ways. Ensure at least 50% of your forces reach the far edge of the engagement zone, bypassing the enemy’s attempt to hold you in place. Alternatively, if they commit too heavily to blocking your path, destroy at least 50% of their forces, breaking their ability to resist and forcing them to withdraw.
 
 Be advised: the enemy will control the field at the end of the engagement. There will be no time for salvage or securing the area. Speed and decisive action are key—either break through or break them entirely, but do not allow them to stall our momentum.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -151,10 +157,10 @@ Be advised: the enemy will control the field at the end of the engagement. There
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 75% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>50</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Diversion Engagement.xml
+++ b/data/scenariotemplates/Diversion Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/DropShip Raid.xml
+++ b/data/scenariotemplates/DropShip Raid.xml
@@ -30,11 +30,12 @@ Victory in this engagement will determine control of the battlefield. If we succ
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Mountain</allowedTerrainType>
-            <allowedTerrainType>ColdMountain</allowedTerrainType>
-            <allowedTerrainType>ArcticDesert</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>ArcticDesert</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/DropShip Raid.xml
+++ b/data/scenariotemplates/DropShip Raid.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>DropShip Raid</name>
     <shortBriefing>Destroy or cripple DropShip.</shortBriefing>
-    <detailedBriefing><![CDATA[An enemy DropShip has become stranded in contested territory, presenting us with an opportunity to eliminate a critical asset before they can recover or evacuate. Your mission is to destroy or cripple the DropShip while also eliminating at least 50% of its escort forces. We cannot allow the enemy to extract personnel, equipment, or intelligence—this DropShip must not leave the battlefield intact.
+    <detailedBriefing><![CDATA[An enemy DropShip has become stranded in contested territory, presenting us with an opportunity to eliminate a critical asset before they can recover or evacuate. Your mission is to destroy or cripple the DropShip while also eliminating at least 33% of its escort forces. We cannot allow the enemy to extract personnel, equipment, or intelligence—this DropShip must not leave the battlefield intact.
 
 Expect organized resistance. The enemy will fight to defend their stranded vessel, and their escort forces will attempt to buy time for emergency repairs or reinforcement. You must strike decisively, breaking their formation and overwhelming their defenses before they can rally.
 
@@ -29,12 +29,18 @@ Victory in this engagement will determine control of the battlefield. If we succ
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Mountain</allowedTerrainType>
+            <allowedTerrainType>ColdMountain</allowedTerrainType>
+            <allowedTerrainType>ArcticDesert</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>10</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -193,10 +199,10 @@ Victory in this engagement will determine control of the battlefield. If we succ
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/DropShip Raid.xml
+++ b/data/scenariotemplates/DropShip Raid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
@@ -21,7 +21,7 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Escort DropShip, defeat enemy forces.</shortBriefing>
-    <detailedBriefing><![CDATA[Your aircraft convoy is being intercepted mid-flight by enemy forces executing a pincer maneuver. Their goal is to cut off all possible escape routes and eliminate or capture the supplies your convoy carries. If the convoy is lost, it will be a significant blow to your operational readiness. Your mission is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[Your aircraft convoy is being intercepted mid-flight by enemy forces executing a pincer maneuver. Their goal is to cut off all possible escape routes and eliminate or capture the supplies your convoy carries. If the convoy is lost, it will be a significant blow to your operational readiness. Your mission is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 33% of their forces.
 
 The enemy has chosen a pincer formation to box you in, which means they are expecting to trap and overwhelm your forces. Break their formation before they can fully close the noose. Use superior positioning, speed, and tactical maneuvers to punch through their weakest link and deny them the ability to completely surround the convoy. If necessary, sacrifice the convoy to ensure the enemy force is broken—routing them is the priority, as failure to do so will allow them to wreak havoc on our logistics in future operations.
 
@@ -169,10 +169,10 @@ We will control the battlefield at the end of this engagement, ensuring that any
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -21,7 +21,7 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Prevent your resupply falling into the hands of the enemy.</shortBriefing>
-    <detailedBriefing><![CDATA[Your convoy has been trapped by an enemy force specialized in hunting down fast-moving targets. They are well-equipped for this type of engagement, and their goal is to intercept and capture your supplies. While securing the convoy is important, your primary objective is to eliminate at least 50% of the enemy force to ensure they cannot continue their raids. If they are not routed here, they will be free to attack other convoys, posing a long-term threat to our supply lines.
+    <detailedBriefing><![CDATA[Your convoy has been trapped by an enemy force specialized in hunting down fast-moving targets. They are well-equipped for this type of engagement, and their goal is to intercept and capture your supplies. While securing the convoy is important, your primary objective is to eliminate at least 33% of the enemy force to ensure they cannot continue their raids. If they are not routed here, they will be free to attack other convoys, posing a long-term threat to our supply lines.
 
 The enemy is built for speed and pursuit, meaning direct engagements may not always be favorable. Use ambush tactics, force them into unfavorable terrain, and disrupt their ability to maneuver. They rely on overwhelming pursuit capabilities—deny them the chance to use it effectively. If the convoy can be safely extracted, do so, but not at the expense of allowing the enemy to regroup for future strikes.
 
@@ -30,12 +30,17 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>false</useStandardAtBSizing>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
@@ -162,10 +167,10 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -35,6 +35,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>

--- a/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -21,7 +21,7 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Prevent your resupply falling into the hands of the enemy.</shortBriefing>
-    <detailedBriefing><![CDATA[Your ground convoy is being cornered by aggressive enemy elements, intent on cutting off your supplies and crippling our logistics. The convoy is carrying essential resources for your operations, and its loss would be a severe blow. Your primary objective is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[Your ground convoy is being cornered by aggressive enemy elements, intent on cutting off your supplies and crippling our logistics. The convoy is carrying essential resources for your operations, and its loss would be a severe blow. Your primary objective is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 33% of their forces.
 
 The enemy is executing a relentless pursuit, attempting to isolate and destroy the convoy before it can escape. If they are not routed here, they will continue striking at our logistics, inflicting immeasurable damage over time. Prioritize extracting the convoy, but if necessary, sacrificing the supplies is acceptable if it means crushing the enemy force beyond recovery.
 
@@ -30,12 +30,17 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -100,7 +105,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
@@ -164,10 +169,10 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -35,6 +35,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>

--- a/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -35,6 +35,7 @@ We will control the battlefield at the end of this engagement, allowing us to re
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>

--- a/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -21,7 +21,7 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Prevent your resupply falling into the hands of the enemy.</shortBriefing>
-    <detailedBriefing><![CDATA[An enemy force has breached our lines and is in pursuit of an allied convoy, carrying supplies critical to your operations. If these supplies are lost, so is a vital piece of our logistical network. Your mission is to ensure the successful extraction of the convoy by escorting it to the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[An enemy force has breached our lines and is in pursuit of an allied convoy, carrying supplies critical to your operations. If these supplies are lost, so is a vital piece of our logistical network. Your mission is to ensure the successful extraction of the convoy by escorting it to the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 33% of their forces.
 
 This enemy assault is a direct attempt to cripple our supply chain. If they are not stopped here, they will continue to strike at our convoys, causing immeasurable damage to our war effort. The convoy is a priority, but if ensuring the destruction of the enemy requires sacrificing the supplies, do not hesitate. Breaking their offensive strength is the ultimate objective.
 
@@ -30,12 +30,17 @@ We will control the battlefield at the end of this engagement, allowing us to re
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -203,10 +208,10 @@ We will control the battlefield at the end of this engagement, allowing us to re
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed. Failure also incurs a -1 CVP penalty (StratCon Only).</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Engagement.xml
+++ b/data/scenariotemplates/Engagement.xml
@@ -20,19 +20,24 @@
 <ScenarioTemplate>
     <name>Engagement</name>
     <shortBriefing>Engage and destroy enemy at the front.</shortBriefing>
-    <detailedBriefing><![CDATA[Your orders are simple—engage and destroy at least 50% of enemy forces. This is not a hit-and-run operation or a delaying action. You are to commit fully to the engagement and break their strength through superior firepower and tactical positioning.
+    <detailedBriefing><![CDATA[Your orders are simple—engage and destroy at least 33% of enemy forces. This is not a hit-and-run operation or a delaying action. You are to commit fully to the engagement and break their strength through superior firepower and tactical positioning.
 
 This battle will determine control of the battlefield. The victor will hold the field at the end of the engagement, securing any salvage and denying the enemy any chance of recovery. Every enemy unit destroyed weakens their ability to wage war—make sure they do not leave this battlefield intact.
 
 Strike hard, eliminate the opposition, and take control. Victory is absolute, or it is meaningless.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -120,10 +125,10 @@ Strike hard, eliminate the opposition, and take control. Victory is absolute, or
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Engagement.xml
+++ b/data/scenariotemplates/Engagement.xml
@@ -32,6 +32,7 @@ Strike hard, eliminate the opposition, and take control. Victory is absolute, or
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Engagement.xml
+++ b/data/scenariotemplates/Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Enveloped.xml
+++ b/data/scenariotemplates/Enveloped.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Enveloped</name>
+    <shortBriefing>Caught between two converging forces—break out or beat them both.</shortBriefing>
+    <detailedBriefing><![CDATA[We advanced too far, too fast, and now the jaws are closing. Enemy forces are converging on your position from two sides at once, and there is no safe direction to face.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Fighting on two fronts means you cannot commit everything one way without exposing your back. Pick your moment, concentrate against one arm of the pincer to shatter it, and do not let them catch your formation strung out between them. A unit that splits its attention evenly gets ground down by both.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Break the enemy's grip from both directions. The victor holds the field when the dust settles.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -62,7 +60,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -92,24 +90,61 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>2</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>0.6</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
+            <key>SecondOpFor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.6</forceMultiplier>
+                <forceName>SecondOpFor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -135,13 +170,39 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>SecondOpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Escalation.xml
+++ b/data/scenariotemplates/Escalation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,13 +18,16 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Official Challenge</name>
-    <stratConScenarioType>OFFICIAL_CHALLENGE</stratConScenarioType>
-    <shortBriefing>Display your prowess.</shortBriefing>
-    <detailedBriefing><![CDATA[A combat challenge has been issued through official channels. Deploy one (and only one) of your forces to fight on our behalf. The results of this dual will significantly impact morale.
+    <name>Escalation</name>
+    <shortBriefing>A skirmish that both sides keep feeding until it becomes a battle.</shortBriefing>
+    <detailedBriefing><![CDATA[What began as a chance skirmish is drawing in everything both sides can throw at it. Reserves are already moving up on both ends, and the fight will only grow uglier as they arrive.
 
-The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
+Win the early exchange, and you set the terms; lose it, and you will be reacting to their reinforcements instead of your own. Hold your line through the opening clash, commit your reserves at the right moment, and grind the enemy down as the battle swells around you.
+
+Break the enemy force as the fight escalates. The victor holds the field.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Plains</allowedTerrainType>
@@ -39,7 +42,7 @@ The victor controls the field, and we will be the ones standing when the dust se
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
@@ -59,15 +62,47 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
+                <forceMultiplier>0.75</forceMultiplier>
                 <forceName>Player</forceName>
                 <generationMethod>0</generationMethod>
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Reserves</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>3</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>2</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Reserves</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -79,7 +114,7 @@ The victor controls the field, and we will be the ones standing when the dust se
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>0</allowedUnitType>
+                <allowedUnitType>-2</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
@@ -88,19 +123,58 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
                 <destinationZone>5</destinationZone>
-                <fixedUnitCount>-1</fixedUnitCount>
+                <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Officer</forceName>
-                <generationMethod>3</generationMethod>
+                <forceMultiplier>0.75</forceMultiplier>
+                <forceName>OpFor</forceName>
+                <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>4</minWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
+            <key>SecondOpFor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>3</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones />
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>SecondOpFor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
@@ -114,21 +188,21 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Fighter Sweep.xml
+++ b/data/scenariotemplates/Fighter Sweep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,34 +18,26 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Fighter Sweep</name>
+    <shortBriefing>Sweep the skies clear of enemy aerospace and win air superiority.</shortBriefing>
+    <detailedBriefing><![CDATA[This is not an interception—it is a hunt. Command wants the enemy's aerospace presence to break so thoroughly they cede the skies for the rest of the operation. Go out, find them, and shatter them.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Air superiority is won by aggression. Force the engagement on your terms, run down anything that tries to disengage, and do not settle for driving them off—break the back of their formation. Half their strength on the deck is the mark of a sweep well flown.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Destroy or rout half of the enemy aerospace force. Own the sky.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
-        </allowedTerrainTypes>
+        <allowedTerrainTypes />
         <allowRotation>false</allowRotation>
-        <baseHeight>0</baseHeight>
-        <baseWidth>0</baseWidth>
+        <baseHeight>50</baseHeight>
+        <baseWidth>50</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>SpecificGroundTerrain</mapLocation>
+        <mapLocation>Space</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>2</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -54,7 +46,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowedUnitType>9</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
@@ -75,7 +67,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
@@ -85,7 +77,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowedUnitType>-3</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
@@ -96,21 +88,18 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
-                <roleChoices>
-                    <forceRole>RECON</forceRole>
-                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
@@ -124,24 +113,23 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% of the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Frontier Assassination.xml
+++ b/data/scenariotemplates/Frontier Assassination.xml
@@ -33,6 +33,8 @@ The victor will control the battlefield at the end of the engagement, securing a
             <allowedTerrainType>ArcticDesert</allowedTerrainType>
             <allowedTerrainType>Desert</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>HotMountainsDry</allowedTerrainType>
+            <allowedTerrainType>HotMountainsWet</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -102,6 +104,10 @@ The victor will control the battlefield at the end of the engagement, securing a
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/data/scenariotemplates/Frontier Assassination.xml
+++ b/data/scenariotemplates/Frontier Assassination.xml
@@ -20,19 +20,25 @@
 <ScenarioTemplate>
     <name>Frontier Assassination</name>
     <shortBriefing>Eliminate VIP, minimize own losses.</shortBriefing>
-    <detailedBriefing><![CDATA[An enemy VIP has been located in an isolated position, presenting a rare opportunity to eliminate a key target. Their removal will deal a significant blow to enemy operations, but they are not unprotected. Your mission is to kill the VIP and destroy at least 50% of their escort force.
+    <detailedBriefing><![CDATA[An enemy VIP has been located in an isolated position, presenting a rare opportunity to eliminate a key target. Their removal will deal a significant blow to enemy operations, but they are not unprotected. Your mission is to kill the VIP and destroy at least 33% of their escort force.
 
 The enemy may attempt an emergency extraction or stall for reinforcements. Do not let them escape. Strike hard, eliminate the target, and ensure their escort is crippled beyond recovery. If the enemy attempts to dig in, break their defensive perimeter and neutralize them with overwhelming force.
 
 The victor will control the battlefield at the end of the engagement, securing any salvage and eliminating remaining resistance. This is a chance to change the course of the conflict—do not let it slip away.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Mountain</allowedTerrainType>
+            <allowedTerrainType>ColdMountain</allowedTerrainType>
+            <allowedTerrainType>ArcticDesert</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -177,10 +183,10 @@ The victor will control the battlefield at the end of the engagement, securing a
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Frontier Assassination.xml
+++ b/data/scenariotemplates/Frontier Assassination.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/data/scenariotemplates/Frontline Breakthrough.xml
@@ -32,6 +32,7 @@ The enemy will control the battlefield once the engagement concludes, preventing
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>

--- a/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/data/scenariotemplates/Frontline Breakthrough.xml
@@ -20,19 +20,24 @@
 <ScenarioTemplate>
     <name>Frontline Breakthrough</name>
     <shortBriefing>Break through enemy battlelines.</shortBriefing>
-    <detailedBriefing><![CDATA[You are tasked with penetrating the enemy’s main battle line and advancing beyond their position. The enemy has committed significant forces to this sector, making this a high-risk operation. Your primary objective is to reach the far edge of the engagement zone with at least 50% of your forces intact. If direct passage is impossible, an alternative path to victory is available—routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[You are tasked with penetrating the enemy’s main battle line and advancing beyond their position. The enemy has committed significant forces to this sector, making this a high-risk operation. Your primary objective is to reach the far edge of the engagement zone with at least 50% of your forces intact. If direct passage is impossible, an alternative path to victory is available—routing the enemy by destroying at least 33% of their forces.
 
 Expect heavy resistance, as the enemy will not yield ground easily. Their forces are well-positioned to block your advance, and delaying tactics may be used to slow you down. Speed, decisive strikes, and tactical maneuvering will be key to achieving your objective. If you can break their formation or force them into disarray, the path forward will open.
 
 The enemy will control the battlefield once the engagement concludes, preventing any opportunity for salvage or recovery. This is a mission of mobility and force—break through, or break them. There is no room for hesitation.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -153,10 +158,10 @@ The enemy will control the battlefield once the engagement concludes, preventing
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/data/scenariotemplates/Frontline Breakthrough.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Frontline Disruption.xml
+++ b/data/scenariotemplates/Frontline Disruption.xml
@@ -34,6 +34,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>70</baseHeight>

--- a/data/scenariotemplates/Frontline Disruption.xml
+++ b/data/scenariotemplates/Frontline Disruption.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Frontline Disruption</name>
     <shortBriefing>Disrupt and delay frontline force.</shortBriefing>
-    <detailedBriefing><![CDATA[A large enemy force is advancing toward a critical objective, and it is your responsibility to stop them. Your mission is to disrupt their advance by preventing at least 50% of their forces from reaching the opposite edge of the engagement zone. If they succeed in breaking through in large numbers, the consequences for our campaign will be severe.
+    <detailedBriefing><![CDATA[A large enemy force is advancing toward a critical objective, and it is your responsibility to stop them. Your mission is to disrupt their advance by preventing at least 33% of their forces from reaching the opposite edge of the engagement zone. If they succeed in breaking through in large numbers, the consequences for our campaign will be severe.
 
 Expect a determined push, as the enemy will prioritize speed and aggression to force their way through. They may attempt to overwhelm your defenses with sheer numbers or concentrated strikes against weak points. You must hold firm, break their momentum, and deny them passage. Use the terrain, stagger your defenses, and eliminate high-value targets to throw their advance into disarray.
 
@@ -29,12 +29,17 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>70</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -124,10 +129,10 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 50% of the following forces before they can reach the destination edge. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy 33% of the following forces before they can reach the destination edge. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Frontline Disruption.xml
+++ b/data/scenariotemplates/Frontline Disruption.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Frontline Engagement.xml
+++ b/data/scenariotemplates/Frontline Engagement.xml
@@ -32,6 +32,7 @@ The victor will control the battlefield at the end of the engagement, securing s
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Frontline Engagement.xml
+++ b/data/scenariotemplates/Frontline Engagement.xml
@@ -20,19 +20,24 @@
 <ScenarioTemplate>
     <name>Frontline Engagement</name>
     <shortBriefing>Engage and destroy enemy at the front.</shortBriefing>
-    <detailedBriefing><![CDATA[The enemy is fully committed to battle along the frontline, engaging our forces in a direct confrontation. Your mission is to break their offensive by defeating at least 50% of their forces. This engagement is a decisive clash—victory here will shift the momentum of the war in our favor.
+    <detailedBriefing><![CDATA[The enemy is fully committed to battle along the frontline, engaging our forces in a direct confrontation. Your mission is to break their offensive by defeating at least 33% of their forces. This engagement is a decisive clash—victory here will shift the momentum of the war in our favor.
 
 Expect a determined enemy response. They will not withdraw easily and may attempt to reinforce their position as losses mount. Strike hard, exploit weaknesses, and maintain battlefield control. This is not a delaying action—this is a battle for dominance.
 
 The victor will control the battlefield at the end of the engagement, securing salvage and eliminating any remaining resistance. Ensure that when the dust settles, it is our forces standing over the wreckage. Crush them and claim the field.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -93,7 +98,7 @@ The victor will control the battlefield at the end of the engagement, securing s
                 <minWeightClass>2</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
@@ -120,10 +125,10 @@ The victor will control the battlefield at the end of the engagement, securing s
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Frontline Engagement.xml
+++ b/data/scenariotemplates/Frontline Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Gauntlet Run.xml
+++ b/data/scenariotemplates/Gauntlet Run.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Gauntlet Run</name>
+    <shortBriefing>Run a fortified corridor and get the force out the far side.</shortBriefing>
+    <detailedBriefing><![CDATA[The only way out is forward, straight down a corridor the enemy has fortified with fixed emplacements. This is not a fight to win—it is a fight to survive and keep moving. Stopping to trade fire with dug-in guns is how you die here.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Push through, keep your speed up, and get the bulk of the force out the far edge. Some losses are inevitable running a gauntlet like this; a command that gets most of its strength clear has done its job. Do not let them pin you in the kill zone.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Get 50% of the force to the far edge. Speed is survival.]]></detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Hills</allowedTerrainType>
             <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>2</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -75,6 +73,37 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Emplacements</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>7</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>5</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.75</forceMultiplier>
+                <forceName>Emplacements</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>3</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -93,23 +122,24 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>0.75</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -117,31 +147,31 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <description>Get 50% of the following forces to the far edge. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NORTH</destinationEdge>
+            <objectiveCriterion>ReachMapEdge</objectiveCriterion>
+            <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -137,10 +137,10 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Preserve 5% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Preserve 25% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>
-            <percentage>5</percentage>
+            <percentage>25</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
             <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>

--- a/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -108,6 +108,11 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -31,12 +31,18 @@ The enemy will control the field at the end of the engagement, meaning there wil
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
+            <allowedTerrainType>Swamp</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>10</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>1</additionalMapSheetWide>

--- a/data/scenariotemplates/Hold Until Relief.xml
+++ b/data/scenariotemplates/Hold Until Relief.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Hold Until Relief</name>
+    <shortBriefing>Hold against a superior force until your reinforcements arrive.</shortBriefing>
+    <detailedBriefing><![CDATA[You are caught out ahead of support and a superior force is bearing down on you. Help is coming, but not soon—you must hold together long enough for the relief column to reach you.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+The early turns are the dangerous ones: outnumbered and alone, you cannot trade blows evenly. Fight defensively, preserve your strength, and stay intact until reinforcements arrive to turn the tide. Throwing away units before help comes only guarantees there is nothing left to relieve.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Keep the bulk of your command intact. Reinforcements are inbound—survive until they get here.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Hills</allowedTerrainType>
             <allowedTerrainType>ColdHills</allowedTerrainType>
             <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -81,12 +79,43 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             </value>
         </entry>
         <entry>
+            <key>Reinforcements</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>4</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Reinforcements</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
             <key>OpFor</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -96,20 +125,21 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.5</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -117,31 +147,30 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Preserve 50% of the following forces until relief arrives. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Hostile Facility.xml
+++ b/data/scenariotemplates/Hostile Facility.xml
@@ -21,7 +21,7 @@
     <name>Facility Assault</name>
     <stratConScenarioType>HOSTILE_FACILITY</stratConScenarioType>
     <shortBriefing>Assault and weaken enemy-held facility.</shortBriefing>
-    <detailedBriefing><![CDATA[A hidden enemy-controlled facility has been identified for destruction. This installation is too valuable to remain in enemy hands, and its defenders must be eliminated to ensure it is no longer operational. Your mission is to destroy at least 75% of the defending forces. This is not an occupation—this is eradication.
+    <detailedBriefing><![CDATA[A hidden enemy-controlled facility has been identified for destruction. This installation is too valuable to remain in enemy hands, and its defenders must be eliminated to ensure it is no longer operational. Your mission is to destroy at least 50% of the defending forces. This is not an occupation—this is eradication.
 
 The priority is destruction, not capture. Do not concern yourself with securing the facility. The enemy will fight to protect this installation, but their defenses will crumble under sustained pressure. Crush their forces, level their defenses, and ensure that when this battle is over, the facility is of no use to anyone.
 
@@ -30,9 +30,10 @@ The victor will control the battlefield at the end of the engagement. If the fac
     <isHostileFacility>true</isHostileFacility>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>TemperateFacility</allowedTerrainType>
             <allowedTerrainType>ColdFacility</allowedTerrainType>
             <allowedTerrainType>HotFacility</allowedTerrainType>
-            <allowedTerrainType>TemperateFacility</allowedTerrainType>
+            <allowedTerrainType>FrozenFacility</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -160,10 +161,10 @@ The victor will control the battlefield at the end of the engagement. If the fac
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 75% of the defending forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% of the defending forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>50</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Hostile Facility.xml
+++ b/data/scenariotemplates/Hostile Facility.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Hostile Facility.xml
+++ b/data/scenariotemplates/Hostile Facility.xml
@@ -137,6 +137,11 @@ The victor will control the battlefield at the end of the engagement. If the fac
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>ARTILLERY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Intercept Engagement.xml
+++ b/data/scenariotemplates/Intercept Engagement.xml
@@ -20,19 +20,25 @@
 <ScenarioTemplate>
     <name>Intercept Engagement</name>
     <shortBriefing>Break through or destroy intercepting force.</shortBriefing>
-    <detailedBriefing><![CDATA[One of your forces has been intercepted by a large enemy contingent, cutting off their path to safety. The enemy intends to encircle and destroy your units before they can regroup. Your mission is to break through their lines and reach safety or destroy at least 75% of their forces to render them combat ineffective.
+    <detailedBriefing><![CDATA[One of your forces has been intercepted by a large enemy contingent, cutting off their path to safety. The enemy intends to encircle and destroy your units before they can regroup. Your mission is to break through their lines and reach safety or destroy at least 50% of their forces to render them combat ineffective.
 
-The enemy holds the advantage in numbers and positioning, but they are not unbeatable. A direct breakthrough will require speed, coordination, and decisive strikes against their weakest points. If a clean escape is not possible, you must shift to a battle of attrition—eliminating 75% of their forces will ensure they can no longer threaten your retreat.
+The enemy holds the advantage in numbers and positioning, but they are not unbeatable. A direct breakthrough will require speed, coordination, and decisive strikes against their weakest points. If a clean escape is not possible, you must shift to a battle of attrition—eliminating 50% of their forces will ensure they can no longer threaten your retreat.
 
 The enemy will control the battlefield at the end of the engagement, meaning no recovery of fallen assets will be possible. Time is against you—break out before they close the trap, or break them so thoroughly that they can no longer fight.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -93,7 +99,7 @@ The enemy will control the battlefield at the end of the engagement, meaning no 
                 <minWeightClass>2</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
@@ -154,10 +160,10 @@ The enemy will control the battlefield at the end of the engagement, meaning no 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 75% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 50% the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>50</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Intercept Engagement.xml
+++ b/data/scenariotemplates/Intercept Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Intercept the Escapees.xml
+++ b/data/scenariotemplates/Intercept the Escapees.xml
@@ -57,7 +57,7 @@ Execute with precision. The enemy must leave empty-handed.]]></detailedBriefing>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>3</deploymentZone>
                 </deploymentZones>
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/data/scenariotemplates/Intercept the Escapees.xml
+++ b/data/scenariotemplates/Intercept the Escapees.xml
@@ -21,7 +21,7 @@
     <name>Intercept the Escapees</name>
     <stratConScenarioType>SPECIAL_JAIL_BREAK</stratConScenarioType>
     <shortBriefing>Prevent the escapees from linking up with enemy forces.</shortBriefing>
-    <detailedBriefing><![CDATA[Allied command has located a group of escaped prisoners, and enemy forces are moving to recover them. These individuals possess critical intelligence and cannot be allowed to fall back into enemy hands. Your mission is to eliminate the prisoners or destroy at least 50% of the enemy recovery team to ensure their operation fails.
+    <detailedBriefing><![CDATA[Allied command has located a group of escaped prisoners, and enemy forces are moving to recover them. These individuals possess critical intelligence and cannot be allowed to fall back into enemy hands. Your mission is to eliminate the prisoners or destroy at least 33% of the enemy recovery team to ensure their operation fails.
 
 The enemy will likely deploy fast-moving extraction units or specialized recovery teams to secure the prisoners before we can intervene. Expect them to use speed and misdirection, avoiding direct combat whenever possible. Intercept their efforts, neutralize the prisoners before they can be extracted, and cripple the recovery force to prevent future attempts.
 
@@ -32,12 +32,18 @@ Execute with precision. The enemy must leave empty-handed.]]></detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>25</baseHeight>
         <baseWidth>25</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -161,10 +167,10 @@ Execute with precision. The enemy must leave empty-handed.]]></detailedBriefing>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following force. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following force. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>95</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Intercept the Escapees.xml
+++ b/data/scenariotemplates/Intercept the Escapees.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Interception Defense.xml
+++ b/data/scenariotemplates/Interception Defense.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Interception Defense</name>
     <shortBriefing>Stop enemy from reaching the edge.</shortBriefing>
-    <detailedBriefing><![CDATA[Enemy forces are on the move, heading toward an unknown objective, and we cannot allow them to reach their destination. Their intent remains unclear, but their movement suggests a high-value mission. Your objective is to intercept and engage the enemy, destroying at least 50% of their forces before they can escape via the opposite edge of the engagement zone.
+    <detailedBriefing><![CDATA[Enemy forces are on the move, heading toward an unknown objective, and we cannot allow them to reach their destination. Their intent remains unclear, but their movement suggests a high-value mission. Your objective is to intercept and engage the enemy, destroying at least 33% of their forces before they can escape via the opposite edge of the engagement zone.
 
 Expect the enemy to favor speed and mobility, avoiding prolonged engagements as they push toward their objective. Deny them their escape route, break their formation, and ensure they do not reach their goal intact. They may attempt to punch through with concentrated force or use diversionary tactics to slip past your defenses—anticipate their maneuvers and shut them down.
 
@@ -29,12 +29,18 @@ We will control the battlefield at the end of the engagement, securing any remai
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -125,10 +131,10 @@ We will control the battlefield at the end of the engagement, securing any remai
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 50% of the following forces before they can reach the destination edge. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy 33% of the following forces before they can reach the destination edge. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Interception Defense.xml
+++ b/data/scenariotemplates/Interception Defense.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Irregular Force Assault.xml
+++ b/data/scenariotemplates/Irregular Force Assault.xml
@@ -30,15 +30,15 @@ The victor will control the battlefield at the end of the engagement, securing a
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>Urban</allowedTerrainType>
             <allowedTerrainType>ColdUrban</allowedTerrainType>
             <allowedTerrainType>HotUrban</allowedTerrainType>
-            <allowedTerrainType>Urban</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -198,10 +198,10 @@ The victor will control the battlefield at the end of the engagement, securing a
                 <howMuch>1</howMuch>
             </failureEffect>
             <additionalDetails />
-            <description>Destroy, cripple or force the withdrawal of 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy, cripple or force the withdrawal of 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Irregular Force Assault.xml
+++ b/data/scenariotemplates/Irregular Force Assault.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/data/scenariotemplates/Irregular Force Suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/data/scenariotemplates/Irregular Force Suppression.xml
@@ -30,15 +30,15 @@ The victor will control the battlefield at the end of the engagement, securing a
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>Urban</allowedTerrainType>
             <allowedTerrainType>ColdUrban</allowedTerrainType>
             <allowedTerrainType>HotUrban</allowedTerrainType>
-            <allowedTerrainType>Urban</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -164,10 +164,10 @@ The victor will control the battlefield at the end of the engagement, securing a
                 <howMuch>1</howMuch>
             </failureEffect>
             <additionalDetails />
-            <description>Destroy, cripple or force the withdrawal of 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy, cripple or force the withdrawal of 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -175,13 +175,13 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>2</howMuch>
+                    <howMuch>1</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails>
                 <additionalDetail>If the DropShip cannot be deployed regenerate the map within MegaMek.</additionalDetail>
             </additionalDetails>
-            <description>Protect the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <description>Protect the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>100</percentage>

--- a/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -34,6 +34,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -20,21 +20,26 @@
 <ScenarioTemplate>
     <name>Isolated DropShip Defense</name>
     <shortBriefing>Defend isolated DropShip from interception.</shortBriefing>
-    <detailedBriefing><![CDATA[An allied DropShip has been isolated behind enemy lines, and hostile forces are closing in fast. Your mission is to defend the DropShip until it can lift off or, if necessary, destroy at least 50% of the enemy forces to break their assault. If the DropShip fails to escape and the enemy remains intact, our strategic situation will be severely compromised.
+    <detailedBriefing><![CDATA[An allied DropShip has been isolated behind enemy lines, and hostile forces are closing in fast. Your mission is to defend the DropShip until it can lift off or, if necessary, destroy at least 33% of the enemy forces to break their assault. If the DropShip fails to escape and the enemy remains intact, our strategic situation will be severely compromised.
 
-Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating half of the enemy force will force them to retreat, buying the DropShip a chance to escape.
+Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating a third of the enemy force will force them to retreat, buying the DropShip a chance to escape.
 
 The enemy will control the field at the end of the engagement, meaning no salvage or recovery will be possible. This is a battle of survival—ensure the DropShip gets out or cripple the enemy so thoroughly that they can no longer threaten it.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>10</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -97,7 +102,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
@@ -209,10 +214,10 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy, cripple or force to withdraw 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy, cripple or force to withdraw 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Last Stand.xml
+++ b/data/scenariotemplates/Last Stand.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,18 +18,16 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Last Stand</name>
+    <shortBriefing>Hold out against a superior force and keep enough of the unit intact to withdraw.</shortBriefing>
+    <detailedBriefing><![CDATA[There is no line behind us and no help coming in time. A superior enemy force is closing from a broad front, and we cannot hold this ground—only bleed them for it and get out with a fighting command still intact.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+This is not a battle to win; it is a battle to survive. Make the enemy pay for every meter, keep your formation together, and preserve enough of the unit to fight another day. A command wiped out here achieves nothing, no matter how many it took with it.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Preserve the bulk of your force and, if you can, break their assault before you pull out. The enemy will hold this field when it is over—make sure enough of us are not on it.]]></detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Hills</allowedTerrainType>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -86,7 +84,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -96,25 +94,53 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.25</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -127,21 +153,14 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                     <howMuch>1</howMuch>
                 </successEffect>
             </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
+            <failureEffects />
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to break their assault. +1 SVP if succeeded.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
+++ b/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere Air Intercept</name>
     <shortBriefing>Intercept and destroy hostile air forces.</shortBriefing>
-    <detailedBriefing><![CDATA[A hostile aircraft force is inbound, and we have an opportunity to intercept and cripple their strength before they can achieve their objective. Your mission is to engage and destroy at least 50% of the enemy force, ensuring their airpower is severely diminished.
+    <detailedBriefing><![CDATA[A hostile aircraft force is inbound, and we have an opportunity to intercept and cripple their strength before they can achieve their objective. Your mission is to engage and destroy at least 33% of the enemy force, ensuring their airpower is severely diminished.
 
 Expect high-speed engagements, aggressive maneuvers, and coordinated enemy tactics. Control the airspace, dictate the terms of engagement, and eliminate their ability to regroup. Do not allow them to disengage intact—press the attack and ensure their losses are irreversible.
 
@@ -120,10 +120,10 @@ The victor will control the battlefield at the end of the engagement, securing d
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
+++ b/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere DropShip Escort</name>
     <shortBriefing>Escort DropShip, defeat enemy forces.</shortBriefing>
-    <detailedBriefing><![CDATA[An allied DropShip is under threat, with enemy air assets moving to intercept before it can reach safety. This vessel is critical to our operations, and its loss is not an option. Your mission is to protect the DropShip and destroy at least 50% of the attacking enemy forces.
+    <detailedBriefing><![CDATA[An allied DropShip is under threat, with enemy air assets moving to intercept before it can reach safety. This vessel is critical to our operations, and its loss is not an option. Your mission is to protect the DropShip and destroy at least 33% of the attacking enemy forces.
 
 Expect aggressive aerial engagements, fast-moving strike craft, and possible long-range missile attacks. Use superior positioning, coordinated fire, and defensive tactics to neutralize threats before they can bring down our DropShip. Every enemy unit destroyed increases the DropShip’s chance of survival—hit them hard and make them pay for their assault.
 
@@ -166,10 +166,10 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere Reinforcements Intercepted</name>
     <shortBriefing>Destroy hostile air forces.</shortBriefing>
-    <detailedBriefing><![CDATA[Your reinforcements have been intercepted by enemy forces, cutting them off before they can complete their original mission. This is an intentional move to stall our operations and weaken our ability to project force. Your mission is to break free from the engagement by destroying at least 50% of the enemy force. Until that threshold is met, you will remain pinned down and unable to proceed.
+    <detailedBriefing><![CDATA[Your reinforcements have been intercepted by enemy forces, cutting them off before they can complete their original mission. This is an intentional move to stall our operations and weaken our ability to project force. Your mission is to break free from the engagement by destroying at least 33% of the enemy force. Until that threshold is met, you will remain pinned down and unable to proceed.
 
 The enemy will press hard to keep you contained, using aggressive maneuvers and potentially overwhelming numbers to delay your advance. Do not get bogged down in a prolonged engagement—focus fire, break their cohesion, and force them into retreat. Once their losses become unsustainable, the path forward will be clear.
 
@@ -123,10 +123,10 @@ There will be no time to secure the battlefield at the end of the engagement, me
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Meeting Engagement.xml
+++ b/data/scenariotemplates/Meeting Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Meeting Engagement</name>
+    <shortBriefing>Two forces collide unexpectedly—win the encounter battle.</shortBriefing>
+    <detailedBriefing><![CDATA[Neither side chose this ground. Two forces on the move have blundered into each other, and now it is a straight fight with no prepared positions and no advantage but what you make on the fly.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+This is a test of reaction and maneuver. Both columns arrive at the same time from opposite approaches; whoever concentrates fastest and hits hardest carries the day. There are no tricks here—just steel against steel.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Break the enemy force. The victor holds the field.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -55,7 +53,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -86,7 +84,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -96,12 +94,12 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
@@ -109,7 +107,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -124,24 +123,23 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Minor Engagement.xml
+++ b/data/scenariotemplates/Minor Engagement.xml
@@ -32,6 +32,7 @@ The victor will control the battlefield at the end of the engagement, securing t
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>

--- a/data/scenariotemplates/Minor Engagement.xml
+++ b/data/scenariotemplates/Minor Engagement.xml
@@ -27,12 +27,17 @@ This is a show of strength—hit them hard, make them bleed, and leave no doubt 
 The victor will control the battlefield at the end of the engagement, securing the area and denying the enemy any future foothold here. Send a message—this ground belongs to us.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Minor Engagement.xml
+++ b/data/scenariotemplates/Minor Engagement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Mole Hunt.xml
+++ b/data/scenariotemplates/Mole Hunt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,19 +18,21 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Annihilation</name>
-    <shortBriefing>Obliterate the enemy force.</shortBriefing>
-    <detailedBriefing><![CDATA[Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 75% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations.
+    <name>Mole Hunt</name>
+    <shortBriefing>Cut through the bodyguard and eliminate the mole.</shortBriefing>
+    <detailedBriefing><![CDATA[We have finally pinned down the mole who has been bleeding our operations dry. They are no soldier—just one person on foot—but they are ringed by a hardened bodyguard detail that will not let you anywhere near them without a fight.
 
-The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
+Do not get distracted trading fire with the escort; they are not the point. Break or scatter the guard just enough to get a clean line on the target, and put the mole down. Expect them to shelter behind their protectors and among the buildings, so you will have to dig them out.
+
+Eliminate the mole. Nothing else in this engagement matters as much as that single kill.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Plains</allowedTerrainType>
-            <allowedTerrainType>Steppe</allowedTerrainType>
-            <allowedTerrainType>Savannah</allowedTerrainType>
-            <allowedTerrainType>Tundra</allowedTerrainType>
-            <allowedTerrainType>SnowField</allowedTerrainType>
+            <allowedTerrainType>Urban</allowedTerrainType>
+            <allowedTerrainType>ColdUrban</allowedTerrainType>
+            <allowedTerrainType>HotUrban</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -49,7 +51,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -58,7 +60,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -67,6 +69,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -74,7 +77,41 @@ The victor controls the field, and we will be the ones standing when the dust se
             </value>
         </entry>
         <entry>
-            <key>OpFor</key>
+            <key>Mole</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>3</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>2</destinationZone>
+                <fixedUnitCount>1</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Mole</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>3</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>CIVILIAN</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
+            <key>Bodyguard</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
@@ -85,28 +122,63 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
-                <forceName>OpFor</forceName>
+                <forceName>Bodyguard</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>3</minWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>Mole</objectiveLinkedForce>
+                </objectiveLinkedForces>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeArc</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>Mole</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy 100% of the following force. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Destroy</objectiveCriterion>
+            <percentage>100</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Bodyguard</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
@@ -116,18 +188,12 @@ The victor controls the field, and we will be the ones standing when the dust se
                     <howMuch>1</howMuch>
                 </successEffect>
             </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
+            <failureEffects />
             <additionalDetails />
-            <description>Destroy or rout 75% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the bodyguard detail. +1 SVP if succeeded.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>75</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Official Challenge.xml
+++ b/data/scenariotemplates/Official Challenge.xml
@@ -31,6 +31,7 @@ The victor controls the field, and we will be the ones standing when the dust se
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -94,7 +95,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <generationMethod>3</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>3</minWeightClass>
+                <minWeightClass>4</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>

--- a/data/scenariotemplates/Official Challenge.xml
+++ b/data/scenariotemplates/Official Challenge.xml
@@ -26,12 +26,17 @@
 The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Official Challenge.xml
+++ b/data/scenariotemplates/Official Challenge.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -32,6 +32,7 @@ As you will be pushing into enemy territory, we will be unable to secure the bat
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>

--- a/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -27,12 +27,17 @@ Expect light screening forces supported by rapid response elements. The enemy wi
 As you will be pushing into enemy territory, we will be unable to secure the battlefield following the engagement. Any salvage or wreckage left behind will be lost, so prioritize survival and mission success over prolonged engagements. Punch through, force them to react, and establish dominance beyond their lines.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Pivotal Battle.xml
+++ b/data/scenariotemplates/Pivotal Battle.xml
@@ -27,12 +27,17 @@ The enemy is relying on overwhelming numbers, expecting to steamroll our defense
 The victor will control the battlefield at the end of the engagement, ensuring we hold the ground and any remaining salvage. Stand firm, inflict maximum damage, and break their momentum before it’s too late.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -93,7 +98,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <minWeightClass>2</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>

--- a/data/scenariotemplates/Pivotal Battle.xml
+++ b/data/scenariotemplates/Pivotal Battle.xml
@@ -32,6 +32,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
             <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
             <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -95,7 +96,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>2</minWeightClass>
+                <minWeightClass>3</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeArc</syncDeploymentType>

--- a/data/scenariotemplates/Pivotal Battle.xml
+++ b/data/scenariotemplates/Pivotal Battle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Prisoner Liberation.xml
+++ b/data/scenariotemplates/Prisoner Liberation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Prisoner Liberation</name>
+    <shortBriefing>Escort freed prisoners to friendly lines before the enemy recaptures them.</shortBriefing>
+    <detailedBriefing><![CDATA[We have broken open a holding camp and freed our people, but they are not safe yet. They are lightly equipped, exhausted, and a long way from friendly lines—and the enemy is already moving to run them down and drag them back.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+The freed prisoners will make for our lines on their own; your job is to cover them. Get between them and their pursuers, keep the enemy off their backs, and see enough of them safely off the field. They cannot fight and they cannot be replaced—every one lost is one back in enemy hands.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Get the freed prisoners to safety and drive off the pursuit. Failing them will cost us dearly. The victor holds the field at the end of the engagement.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
             <allowedTerrainType>Hills</allowedTerrainType>
             <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -55,7 +53,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -75,6 +73,37 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Freed Prisoners</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>3</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>1</forceAlignment>
+                <forceMultiplier>0.4</forceMultiplier>
+                <forceName>Freed Prisoners</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>2</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -93,15 +122,15 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>5</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
@@ -109,12 +138,41 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Freed Prisoners</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Get 50% of the following forces to the destination edge. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>SOUTH</destinationEdge>
+            <objectiveCriterion>ReachMapEdge</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>false</timeLimitAtMost>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -135,13 +193,12 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to drive off the pursuit. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Recon Evasion.xml
+++ b/data/scenariotemplates/Recon Evasion.xml
@@ -31,12 +31,18 @@ The enemy will control the field at the end of the engagement, meaning there wil
     <isAlliedFacility>false</isAlliedFacility>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
+            <allowedTerrainType>Swamp</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>10</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>1</additionalMapSheetWide>

--- a/data/scenariotemplates/Recon Evasion.xml
+++ b/data/scenariotemplates/Recon Evasion.xml
@@ -137,10 +137,10 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Preserve 5% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Preserve 25% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>
-            <percentage>5</percentage>
+            <percentage>25</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
             <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>

--- a/data/scenariotemplates/Recon Evasion.xml
+++ b/data/scenariotemplates/Recon Evasion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -31,12 +31,18 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <isAlliedFacility>false</isAlliedFacility>
     <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>1</additionalMapSheetWide>

--- a/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -20,19 +20,25 @@
 <ScenarioTemplate>
     <name>Reinforcements Intercepted</name>
     <shortBriefing>Destroy hostile forces.</shortBriefing>
-    <detailedBriefing><![CDATA[Your reinforcements have been intercepted and pinned down, preventing them from completing their original mission. The enemy is attempting to isolate and eliminate them before they can rejoin the fight. Your objective is to break them free by destroying at least 50% of the enemy forces, forcing a retreat and allowing your units to escape.
+    <detailedBriefing><![CDATA[Your reinforcements have been intercepted and pinned down, preventing them from completing their original mission. The enemy is attempting to isolate and eliminate them before they can rejoin the fight. Your objective is to break them free by destroying at least 33% of the enemy forces, forcing a retreat and allowing your units to escape.
 
 Expect the enemy to hold strong defensive positions, using suppression tactics to keep your forces contained. Focus on eliminating key threats, breaking their formation, and forcing their forces into disarray. Speed and precision will be critical—you must deal enough damage to secure an escape route before more reinforcements arrive.
 
 There is no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. This is a fight for survival and mobility, not territory. Break their grip, get our forces out, and resume the mission.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Hills</allowedTerrainType>
+            <allowedTerrainType>ColdHills</allowedTerrainType>
+            <allowedTerrainType>HotHillsDry</allowedTerrainType>
+            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -93,7 +99,7 @@ There is no time to secure the battlefield at the end of the engagement, meaning
                 <minWeightClass>0</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
@@ -125,10 +131,10 @@ There is no time to secure the battlefield at the end of the engagement, meaning
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Relief Column.xml
+++ b/data/scenariotemplates/Relief Column.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Relief Column</name>
+    <shortBriefing>Break through and relieve a beleaguered allied force before it is overrun.</shortBriefing>
+    <detailedBriefing><![CDATA[An allied detachment has been cut off and pinned down, and they will not last long without help. You are the relief column. Push across the field, break the enemy's grip on our people, and keep enough of them alive to matter.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+The enemy has them surrounded and is grinding them down while you close the distance—every turn you spend fighting through is a turn our allies bleed. Prioritize breaking the assault on them over a clean sweep of the field; a destroyed relief force that "won" is no relief at all.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Preserve the beleaguered detachment and break the enemy's assault. Losing the detachment outright will cost us dearly in this sector (the loss of 1 CVP, StratCon only). The victor holds the field at the end of the engagement.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
+            <allowedTerrainType>Tundra</allowedTerrainType>
+            <allowedTerrainType>SnowField</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -55,7 +53,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -75,6 +73,37 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Beleaguered Detachment</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>2</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>1</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Beleaguered Detachment</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -96,12 +125,12 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
@@ -109,12 +138,40 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Beleaguered Detachment</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following forces. +2 SVP if succeeded, -2 SVP if failed. Losing the detachment also incurs a -1 CVP penalty (StratCon Only).</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -135,13 +192,12 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to break their assault. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Rescue the Downed.xml
+++ b/data/scenariotemplates/Rescue the Downed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Rescue the Downed</name>
+    <shortBriefing>Reach an isolated downed unit and keep it alive against closing enemies.</shortBriefing>
+    <detailedBriefing><![CDATA[One of ours is down and stranded—crippled, alone, and directly in the enemy's path. They cannot extract themselves, and the enemy is closing to finish the job. Get to them and keep them alive.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+This is a race against a kill. Screen the downed unit, put your bodies between it and the enemy's guns, and hold until the engagement is decided. One unit does not sound like much to lose, but that is our pilot out there—and we do not leave people behind.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Keep the downed unit alive. Everything else is secondary to that.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
             <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -55,7 +53,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -75,6 +73,37 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Downed Unit</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>0</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
+                <fixedUnitCount>1</fixedUnitCount>
+                <forceAlignment>1</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Downed Unit</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -96,25 +125,55 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <objectiveLinkedForces />
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>Downed Unit</objectiveLinkedForce>
+                </objectiveLinkedForces>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Downed Unit</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 100% of the following force. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>100</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -127,21 +186,14 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                     <howMuch>1</howMuch>
                 </successEffect>
             </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
+            <failureEffects />
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Rolling Thunder.xml
+++ b/data/scenariotemplates/Rolling Thunder.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Rolling Thunder</name>
+    <shortBriefing>Punch through a defense in depth, breaking each line in turn.</shortBriefing>
+    <detailedBriefing><![CDATA[The enemy has laid out their defense in depth—a forward line to blunt you and a second echelon waiting behind it. A single hard push will not carry the day; you have to break through layer by layer and keep the momentum going.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Do not let the forward line pin you long enough for the rear echelon to reposition. Hit the first line hard, punch through, and drive on to the far edge before they can consolidate. Stalling in the middle is how a fighting advance turns into a grave.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Break all the way through and get the force off the far edge.]]></detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>2</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -81,7 +79,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             </value>
         </entry>
         <entry>
-            <key>OpFor</key>
+            <key>Vanguard</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
@@ -92,24 +90,61 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>5</destinationZone>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
-                <forceName>OpFor</forceName>
+                <forceMultiplier>0.6</forceMultiplier>
+                <forceName>Vanguard</forceName>
                 <generationMethod>1</generationMethod>
-                <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <generationOrder>4</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
+            <key>Rearguard</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>2</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.6</forceMultiplier>
+                <forceName>Rearguard</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -117,31 +152,31 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <description>Get 50% of the following forces to the far edge. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NORTH</destinationEdge>
+            <objectiveCriterion>ReachMapEdge</objectiveCriterion>
+            <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Salvage Run.xml
+++ b/data/scenariotemplates/Salvage Run.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,20 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Official Challenge</name>
-    <stratConScenarioType>OFFICIAL_CHALLENGE</stratConScenarioType>
-    <shortBriefing>Display your prowess.</shortBriefing>
-    <detailedBriefing><![CDATA[A combat challenge has been issued through official channels. Deploy one (and only one) of your forces to fight on our behalf. The results of this dual will significantly impact morale.
+    <name>Salvage Run</name>
+    <shortBriefing>Secure the derelict salvage in the contested zone before the enemy does.</shortBriefing>
+    <detailedBriefing><![CDATA[The wrecks of a previous engagement litter the ground between us and the enemy—crippled machines and abandoned rigs, all of it worth recovering. We are not the only ones who want it. A rival salvage team is inbound from the far side, and whoever holds the field at the end walks away with the prize.
 
-The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
+Push into the center, disable and secure as much of the derelict materiel as you can, and drive off anyone who tries to take it from us. The salvage crews out there are non-combatants and will not put up a fight, but the rival team most certainly will. Do not let them push us off the wrecks, and do not let them deny us the haul by destroying it.
+
+Secure the salvage and break the rival team. The victor holds the field—and the salvage—at the end of the engagement.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Plains</allowedTerrainType>
             <allowedTerrainType>Steppe</allowedTerrainType>
+            <allowedTerrainType>Badlands</allowedTerrainType>
             <allowedTerrainType>Savannah</allowedTerrainType>
-            <allowedTerrainType>Tundra</allowedTerrainType>
-            <allowedTerrainType>SnowField</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -50,7 +53,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -68,6 +71,7 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -75,12 +79,46 @@ The victor controls the field, and we will be the ones standing when the dust se
             </value>
         </entry>
         <entry>
+            <key>Salvage</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Salvage Crew</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>3</generationOrder>
+                <maxWeightClass>2</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>CARGO</forceRole>
+                </roleChoices>
+            </value>
+        </entry>
+        <entry>
             <key>OpFor</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>0</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -88,23 +126,60 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
                 <destinationZone>5</destinationZone>
-                <fixedUnitCount>-1</fixedUnitCount>
+                <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Officer</forceName>
-                <generationMethod>3</generationMethod>
+                <forceName>OpFor</forceName>
+                <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>4</minWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Salvage</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+                <successEffect>
+                    <effectType>SupplyCache</effectType>
+                    <effectScaling>Linear</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Capture 50% of the following derelict force to secure the salvage. +2 SVP and bonus supplies if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Capture</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -125,10 +200,10 @@ The victor controls the field, and we will be the ones standing when the dust se
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces to drive off the rival salvage team. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/ScenarioManifest.xml
+++ b/data/scenariotemplates/ScenarioManifest.xml
@@ -1,5 +1,5 @@
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/ScenarioManifest.xml
+++ b/data/scenariotemplates/ScenarioManifest.xml
@@ -190,5 +190,97 @@
             <key>42</key>
             <value>Official Challenge.xml</value>
         </entry>
+        <entry>
+            <key>43</key>
+            <value>Relief Column.xml</value>
+        </entry>
+        <entry>
+            <key>44</key>
+            <value>Salvage Run.xml</value>
+        </entry>
+        <entry>
+            <key>45</key>
+            <value>Prisoner Liberation.xml</value>
+        </entry>
+        <entry>
+            <key>46</key>
+            <value>Last Stand.xml</value>
+        </entry>
+        <entry>
+            <key>47</key>
+            <value>Combat Drop.xml</value>
+        </entry>
+        <entry>
+            <key>48</key>
+            <value>Decapitation Strike.xml</value>
+        </entry>
+        <entry>
+            <key>49</key>
+            <value>Enveloped.xml</value>
+        </entry>
+        <entry>
+            <key>50</key>
+            <value>Screening Action.xml</value>
+        </entry>
+        <entry>
+            <key>51</key>
+            <value>Supply Denial.xml</value>
+        </entry>
+        <entry>
+            <key>52</key>
+            <value>Gauntlet Run.xml</value>
+        </entry>
+        <entry>
+            <key>53</key>
+            <value>Hold Until Relief.xml</value>
+        </entry>
+        <entry>
+            <key>54</key>
+            <value>Convoy Hijack.xml</value>
+        </entry>
+        <entry>
+            <key>55</key>
+            <value>Ambush the Column.xml</value>
+        </entry>
+        <entry>
+            <key>56</key>
+            <value>Rescue the Downed.xml</value>
+        </entry>
+        <entry>
+            <key>57</key>
+            <value>Meeting Engagement.xml</value>
+        </entry>
+        <entry>
+            <key>58</key>
+            <value>Rolling Thunder.xml</value>
+        </entry>
+        <entry>
+            <key>59</key>
+            <value>Breakout.xml</value>
+        </entry>
+        <entry>
+            <key>60</key>
+            <value>VIP Extraction.xml</value>
+        </entry>
+        <entry>
+            <key>61</key>
+            <value>Escalation.xml</value>
+        </entry>
+        <entry>
+            <key>63</key>
+            <value>Fighter Sweep.xml</value>
+        </entry>
+        <entry>
+            <key>64</key>
+            <value>Strafing Run.xml</value>
+        </entry>
+        <entry>
+            <key>65</key>
+            <value>Bomber Escort.xml</value>
+        </entry>
+        <entry>
+            <key>67</key>
+            <value>Mole Hunt.xml</value>
+        </entry>
     </scenarioFileNames>
 </scenarioManifest>

--- a/data/scenariotemplates/Screening Action.xml
+++ b/data/scenariotemplates/Screening Action.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,18 +18,16 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Screening Action</name>
+    <shortBriefing>Hold the line as a rearguard and stop the enemy from breaking through.</shortBriefing>
+    <detailedBriefing><![CDATA[The main body is pulling back, and you are the rearguard. A superior enemy force is pressing to break through and turn our withdrawal into a rout. You cannot stop them all—but you must stop enough of them, long enough, for the rest to get clear.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Hold the line and deny them the breakthrough. This is a delaying fight, not a stand-up battle; trading ground for time is acceptable, letting them stream past you is not. Keep your formation between them and the open road behind you.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Prevent the bulk of the enemy from breaking through. Buy the time, then get out yourself.]]></detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
             <allowedTerrainType>Hills</allowedTerrainType>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -62,7 +60,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -92,24 +90,26 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>5</destinationZone>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.25</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -124,24 +124,24 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <description>Prevent 50% of the following forces from reaching the far edge. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NORTH</destinationEdge>
+            <objectiveCriterion>PreventReachMapEdge</objectiveCriterion>
+            <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Space Aerospace Intercept.xml
+++ b/data/scenariotemplates/Space Aerospace Intercept.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Space Aerospace Intercept</name>
     <shortBriefing>Intercept and destroy incoming aerospace units.</shortBriefing>
-    <detailedBriefing><![CDATA[Enemy AeroSpace assets have entered our airspace, threatening our operations and territorial control. Your mission is to intercept and destroy at least 50% of the enemy’s AeroSpace forces, ensuring they are unable to regroup or continue their mission.
+    <detailedBriefing><![CDATA[Enemy AeroSpace assets have entered our airspace, threatening our operations and territorial control. Your mission is to intercept and destroy at least 33% of the enemy’s AeroSpace forces, ensuring they are unable to regroup or continue their mission.
 
 Expect high-speed engagements with agile enemy fighters and possible bomber or support craft in formation. Control the skies, dictate the terms of engagement, and press the attack until the enemy is forced to retreat or is completely neutralized. Do not allow them to escape unscathed—this is an opportunity to cripple their airpower.
 
@@ -124,10 +124,10 @@ The victor will control the battlefield at the end of the engagement, securing d
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Space Aerospace Intercept.xml
+++ b/data/scenariotemplates/Space Aerospace Intercept.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Space Blockade Run.xml
+++ b/data/scenariotemplates/Space Blockade Run.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Space Blockade Run</name>
     <shortBriefing>Break enemy blockade, escort DropShip.</shortBriefing>
-    <detailedBriefing><![CDATA[An allied DropShip must bypass an enemy space blockade, and you are its only chance at breaking through. Your mission is to escort the DropShip safely to the far edge of the engagement area, ensuring it can escape enemy interdiction. If a direct escort proves too difficult, an alternative objective is available—destroy at least 50% of the enemy forces to weaken their blockade and force them to disengage.
+    <detailedBriefing><![CDATA[An allied DropShip must bypass an enemy space blockade, and you are its only chance at breaking through. Your mission is to escort the DropShip safely to the far edge of the engagement area, ensuring it can escape enemy interdiction. If a direct escort proves too difficult, an alternative objective is available—destroy at least 33% of the enemy forces to weaken their blockade and force them to disengage.
 
 The enemy will attempt to intercept, disable, or destroy the DropShip before it can escape. Expect interdiction fighters and AeroSpace superiority craft. Protect the DropShip at all costs—keep the enemy occupied, disrupt their formations, and eliminate high-threat targets before they can close in.
 
@@ -200,10 +200,10 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Space Blockade Run.xml
+++ b/data/scenariotemplates/Space Blockade Run.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/data/scenariotemplates/Space DropShip Intercept.xml
@@ -194,10 +194,10 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/data/scenariotemplates/Space DropShip Intercept.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -20,7 +20,7 @@
 <ScenarioTemplate>
     <name>Space Reinforcements Intercepted</name>
     <shortBriefing>Destroy hostile air forces.</shortBriefing>
-    <detailedBriefing><![CDATA[Your reinforcements have been intercepted in space, cut off before they could reach their destination. There is nowhere to hide—this is a direct engagement where survival depends on decisive action. Your mission is to destroy at least 50% of the enemy forces to break free and allow your forces to resume their original mission.
+    <detailedBriefing><![CDATA[Your reinforcements have been intercepted in space, cut off before they could reach their destination. There is nowhere to hide—this is a direct engagement where survival depends on decisive action. Your mission is to destroy at least 33% of the enemy forces to break free and allow your forces to resume their original mission.
 
 The enemy will press the attack, seeking to pin your reinforcements down and eliminate them before they can regroup. Expect high-speed dogfights, coordinated fire from multiple vectors, and no room for retreat. Strike hard, cripple their numbers, and shatter their formation before they can overwhelm you.
 
@@ -127,10 +127,10 @@ There will be no time to secure the battlefield after the engagement, meaning an
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/Strafing Run.xml
+++ b/data/scenariotemplates/Strafing Run.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,31 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Strafing Run</name>
+    <shortBriefing>Fly ground-attack sorties and break an enemy column from the air.</shortBriefing>
+    <detailedBriefing><![CDATA[Enemy ground forces are exposed in the open, and we own the air over them—for now. Command wants them hit hard from above before they can reach cover or bring up their own air cover.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Work the target from altitude: line up your passes, put ordnance on the heaviest units, and keep moving so their return fire never gets a settled shot. Do not bleed off speed to linger over a kill; a strafing aircraft that slows down is a strafing aircraft that gets hit. Break their formation and get out.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Destroy or rout a third of the enemy ground column.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
-        </allowedTerrainTypes>
+        <allowedTerrainTypes />
         <allowRotation>false</allowRotation>
-        <baseHeight>0</baseHeight>
-        <baseWidth>0</baseWidth>
+        <baseHeight>50</baseHeight>
+        <baseWidth>50</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>SpecificGroundTerrain</mapLocation>
+        <mapLocation>LowAtmosphere</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>1</additionalMapSheetWide>
@@ -53,8 +45,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
             <key>Player</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowAeroBombs>true</allowAeroBombs>
+                <allowedUnitType>-3</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
@@ -75,7 +67,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
@@ -96,12 +88,12 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
@@ -109,7 +101,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>ANTI_AIRCRAFT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -124,24 +117,23 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +2 SVP if succeeded, -2 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Supply Denial.xml
+++ b/data/scenariotemplates/Supply Denial.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>Supply Denial</name>
+    <shortBriefing>Destroy the enemy's forward supply dump before its garrison can stop you.</shortBriefing>
+    <detailedBriefing><![CDATA[The enemy has staged a forward supply dump to fuel their next push. If we burn it, that push stalls before it starts. Get in, wreck the stockpile, and get out.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+The dump itself is a cluster of static bunkers and cache points—no threat on their own, but a garrison is posted to protect them and will come for you the moment you close in. Prioritize the destruction of the caches over the garrison; leaving the enemy intact but the dump in ashes is a win, and the reverse is not.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Level the supply dump. Break the garrison only as much as you must to finish the job.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
-            <allowedTerrainType>Hills</allowedTerrainType>
-            <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
+            <allowedTerrainType>Plains</allowedTerrainType>
+            <allowedTerrainType>Steppe</allowedTerrainType>
             <allowedTerrainType>Badlands</allowedTerrainType>
+            <allowedTerrainType>Desert</allowedTerrainType>
+            <allowedTerrainType>Savannah</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -44,8 +42,8 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <heightScalingIncrement>5</heightScalingIncrement>
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
-        <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetTall>0</additionalMapSheetTall>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -55,7 +53,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>1</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -75,6 +73,37 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Supply Dump</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>7</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>0.5</forceMultiplier>
+                <forceName>Supply Dump</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>3</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -96,25 +125,55 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>0.75</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <objectiveLinkedForces />
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>Supply Dump</objectiveLinkedForce>
+                </objectiveLinkedForces>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
     </scenarioForces>
     <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Supply Dump</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>2</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy 75% of the following force to level the supply dump. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Destroy</objectiveCriterion>
+            <percentage>75</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
@@ -127,21 +186,14 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                     <howMuch>1</howMuch>
                 </successEffect>
             </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
+            <failureEffects />
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded.</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
-            <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>33</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/data/scenariotemplates/Tactical Withdrawal.xml
@@ -29,12 +29,18 @@ The enemy will control the battlefield at the end of the engagement, meaning the
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
+            <allowedTerrainType>Jungle</allowedTerrainType>
+            <allowedTerrainType>Swamp</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>70</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -154,10 +160,10 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +2 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/data/scenariotemplates/Tactical Withdrawal.xml
@@ -106,6 +106,11 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/data/scenariotemplates/Tactical Withdrawal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/VIP Ambush.xml
+++ b/data/scenariotemplates/VIP Ambush.xml
@@ -27,12 +27,16 @@ Expect the enemy to stall for time, deploying fast-moving elements or defensive 
 The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for recovery or salvage. This is a surgical strike—neutralize the target and withdraw before the enemy locks down the area.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Urban</allowedTerrainType>
+            <allowedTerrainType>ColdUrban</allowedTerrainType>
+            <allowedTerrainType>HotUrban</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>

--- a/data/scenariotemplates/VIP Ambush.xml
+++ b/data/scenariotemplates/VIP Ambush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/VIP Defense.xml
+++ b/data/scenariotemplates/VIP Defense.xml
@@ -20,19 +20,23 @@
 <ScenarioTemplate>
     <name>VIP Defense</name>
     <shortBriefing>Protect VIP and defeat enemy.</shortBriefing>
-    <detailedBriefing><![CDATA[An important allied VIP is under direct threat, with enemy forces moving to eliminate them. Your mission is to ensure the VIP’s survival and destroy at least 50% of the attacking force to break their assassination attempt.
+    <detailedBriefing><![CDATA[An important allied VIP is under direct threat, with enemy forces moving to eliminate them. Your mission is to ensure the VIP’s survival and destroy at least 33% of the attacking force to break their assassination attempt.
 
 Expect the enemy to employ fast-moving strike teams, precision fire support, and possibly infiltration tactics to bypass defenses and reach the VIP. You must identify and eliminate key threats quickly while maintaining a defensive perimeter around the target. Every second counts—if the enemy is allowed to press their attack unchecked, the VIP will not survive.
 
 We will control the battlefield at the end of the engagement, ensuring that any surviving enemy forces are neutralized and that all salvageable assets remain in our hands. Hold the line, eliminate the attackers, and ensure our VIP lives to fight another day.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes>
+            <allowedTerrainType>Urban</allowedTerrainType>
+            <allowedTerrainType>ColdUrban</allowedTerrainType>
+            <allowedTerrainType>HotUrban</allowedTerrainType>
+        </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>
-        <mapLocation>AllGroundTerrain</mapLocation>
+        <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>0</additionalMapSheetTall>
         <additionalMapSheetWide>0</additionalMapSheetWide>
@@ -123,7 +127,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>2</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeArc</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
@@ -181,10 +185,10 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy or rout 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
+            <description>Destroy or rout 33% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
+            <percentage>33</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>

--- a/data/scenariotemplates/VIP Defense.xml
+++ b/data/scenariotemplates/VIP Defense.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/scenariotemplates/VIP Extraction.xml
+++ b/data/scenariotemplates/VIP Extraction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers
@@ -18,25 +18,23 @@
 # affiliated with Microsoft.
 -->
 <ScenarioTemplate>
-    <name>Reconnaissance Interdiction</name>
-    <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing><![CDATA[DISCLAIMER: it is recommended that you play this scenario with Double Blind enabled and with Single Blind disabled.
+    <name>VIP Extraction</name>
+    <shortBriefing>Escort a lone VIP off the field before the enemy runs them down.</shortBriefing>
+    <detailedBriefing><![CDATA[We have a high-value passenger who needs to be off this rock, and the only way out is across the field to the extraction point. One vehicle, no redundancy—if the VIP goes down, the mission is a failure no matter how many of the enemy you take with you.
 
-Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+Form a moving screen around the VIP and walk them out. The enemy knows exactly who they want and will send fast movers straight for the target rather than trading blows with your escort. Keep your body between the VIP and their guns the whole way to the edge.
 
-Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
-
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
+Get the VIP safely off the map. That single unit is the mission.]]></detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
-    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes>
+            <allowedTerrainType>Forest</allowedTerrainType>
+            <allowedTerrainType>ColdForest</allowedTerrainType>
+            <allowedTerrainType>HotForest</allowedTerrainType>
             <allowedTerrainType>Hills</allowedTerrainType>
             <allowedTerrainType>ColdHills</allowedTerrainType>
-            <allowedTerrainType>HotHillsDry</allowedTerrainType>
-            <allowedTerrainType>HotHillsWet</allowedTerrainType>
-            <allowedTerrainType>Badlands</allowedTerrainType>
         </allowedTerrainTypes>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
@@ -45,7 +43,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
         <mapLocation>SpecificGroundTerrain</mapLocation>
         <useStandardAtBSizing>true</useStandardAtBSizing>
         <additionalMapSheetTall>1</additionalMapSheetTall>
-        <additionalMapSheetWide>1</additionalMapSheetWide>
+        <additionalMapSheetWide>0</additionalMapSheetWide>
         <widthScalingIncrement>5</widthScalingIncrement>
     </mapParameters>
     <scenarioForces>
@@ -64,7 +62,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -75,6 +73,37 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>VIP</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
+                <fixedUnitCount>1</fixedUnitCount>
+                <forceAlignment>1</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>VIP</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>2</generationOrder>
+                <maxWeightClass>3</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -93,23 +122,26 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>5</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>0.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>2</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <objectiveLinkedForces />
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces>
+                    <objectiveLinkedForce>VIP</objectiveLinkedForce>
+                </objectiveLinkedForces>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
-                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
                 </roleChoices>
             </value>
         </entry>
@@ -117,31 +149,31 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
+                <associatedForceName>VIP</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </successEffect>
             </successEffects>
             <failureEffects>
                 <failureEffect>
                     <effectType>ScenarioDefeat</effectType>
                     <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
+                    <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 75% of the following force. +1 SVP if succeeded, -1 SVP if failed.</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
-            <percentage>75</percentage>
+            <description>Get 100% of the following force to the destination edge. +2 SVP if succeeded, -2 SVP if failed.</description>
+            <destinationEdge>SOUTH</destinationEdge>
+            <objectiveCriterion>ReachMapEdge</objectiveCriterion>
+            <percentage>100</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/Assassination.xml
+++ b/data/stratconcontractdefinitions/Assassination.xml
@@ -46,6 +46,7 @@
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>
+                <objectiveScenario>Decapitation Strike.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -47,6 +47,10 @@
                 <objectiveScenario>Decoy Engagement.xml</objectiveScenario>
                 <objectiveScenario>Decoy Interception.xml</objectiveScenario>
                 <objectiveScenario>Diversion Engagement.xml</objectiveScenario>
+                <objectiveScenario>Frontier Assassination.xml</objectiveScenario>
+                <objectiveScenario>Frontline Disruption.xml</objectiveScenario>
+                <objectiveScenario>Tactical Withdrawal.xml</objectiveScenario>
+                <objectiveScenario>Ambush the Column.xml</objectiveScenario>
             </objectiveScenarios>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>ReinforcementDelayReductionHostile.xml</objectiveScenarioModifier>

--- a/data/stratconcontractdefinitions/ExtractionRaid.xml
+++ b/data/stratconcontractdefinitions/ExtractionRaid.xml
@@ -56,6 +56,11 @@
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>
                 <objectiveScenario>DropShip Raid.xml</objectiveScenario>
                 <objectiveScenario>Isolated DropShip Defense.xml</objectiveScenario>
+                <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
+                <objectiveScenario>Convoy Raid.xml</objectiveScenario>
+                <objectiveScenario>Prisoner Liberation.xml</objectiveScenario>
+                <objectiveScenario>Rescue the Downed.xml</objectiveScenario>
+                <objectiveScenario>VIP Extraction.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -56,6 +56,10 @@
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>
                 <objectiveScenario>Intercept Engagement.xml</objectiveScenario>
                 <objectiveScenario>Tactical Withdrawal.xml</objectiveScenario>
+                <objectiveScenario>Last Stand.xml</objectiveScenario>
+                <objectiveScenario>Enveloped.xml</objectiveScenario>
+                <objectiveScenario>Gauntlet Run.xml</objectiveScenario>
+                <objectiveScenario>Breakout.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/MoleHunting.xml
+++ b/data/stratconcontractdefinitions/MoleHunting.xml
@@ -50,7 +50,9 @@
             <objectiveType>SpecificScenarioVictory</objectiveType>
             <objectiveCount>-0.5</objectiveCount>
             <objectiveScenarios>
+                <objectiveScenario>Mole Hunt.xml</objectiveScenario>
                 <objectiveScenario>Assassination.xml</objectiveScenario>
+                <objectiveScenario>Decapitation Strike.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/ObjectiveRaid.xml
+++ b/data/stratconcontractdefinitions/ObjectiveRaid.xml
@@ -50,6 +50,7 @@
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>
                 <objectiveScenario>Deep Raid.xml</objectiveScenario>
                 <objectiveScenario>Breakthrough.xml</objectiveScenario>
+                <objectiveScenario>Convoy Hijack.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/data/stratconcontractdefinitions/PirateHunting.xml
@@ -59,6 +59,7 @@
                 <objectiveScenario>Deep Raid.xml</objectiveScenario>
                 <objectiveScenario>DropShip Raid.xml</objectiveScenario>
                 <objectiveScenario>Isolated DropShip Defense.xml</objectiveScenario>
+                <objectiveScenario>Salvage Run.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/PlanetaryAssault.xml
+++ b/data/stratconcontractdefinitions/PlanetaryAssault.xml
@@ -60,6 +60,10 @@
                 <objectiveScenario>Interception Defense.xml</objectiveScenario>
                 <objectiveScenario>Picket Line Breakthrough.xml</objectiveScenario>
                 <objectiveScenario>Pivotal Battle.xml</objectiveScenario>
+                <objectiveScenario>Combat Drop.xml</objectiveScenario>
+                <objectiveScenario>Meeting Engagement.xml</objectiveScenario>
+                <objectiveScenario>Rolling Thunder.xml</objectiveScenario>
+                <objectiveScenario>Escalation.xml</objectiveScenario>
             </objectiveScenarios>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>HostileBVBudgetIncrease.xml</objectiveScenarioModifier>

--- a/data/stratconcontractdefinitions/ReliefDuty.xml
+++ b/data/stratconcontractdefinitions/ReliefDuty.xml
@@ -50,5 +50,16 @@
                 <objectiveScenarioModifier>PreBattleDamageAllies.xml</objectiveScenarioModifier>
             </objectiveScenarioModifiers>
         </objectiveParameter>
+        <objectiveParameter>
+            <objectiveType>SpecificScenarioVictory</objectiveType>
+            <objectiveCount>-0.5</objectiveCount>
+            <objectiveScenarios>
+                <objectiveScenario>Relief Column.xml</objectiveScenario>
+                <objectiveScenario>Breakthrough.xml</objectiveScenario>
+                <objectiveScenario>Frontline Engagement.xml</objectiveScenario>
+                <objectiveScenario>Screening Action.xml</objectiveScenario>
+                <objectiveScenario>Hold Until Relief.xml</objectiveScenario>
+            </objectiveScenarios>
+        </objectiveParameter>
     </objectiveParameters>
 </ScenarioTemplate>

--- a/data/stratconcontractdefinitions/Sabotage.xml
+++ b/data/stratconcontractdefinitions/Sabotage.xml
@@ -58,6 +58,7 @@
                 <objectiveScenario>Deep Raid.xml</objectiveScenario>
                 <objectiveScenario>Deep Raid Defense.xml</objectiveScenario>
                 <objectiveScenario>Frontline Disruption.xml</objectiveScenario>
+                <objectiveScenario>Supply Denial.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>

--- a/data/stratconcontractdefinitions/SecurityDuty.xml
+++ b/data/stratconcontractdefinitions/SecurityDuty.xml
@@ -51,6 +51,7 @@
                 <objectiveScenario>Critical Convoy Escort.xml</objectiveScenario>
                 <objectiveScenario>Reconnaissance Interdiction.xml</objectiveScenario>
                 <objectiveScenario>VIP Defense.xml</objectiveScenario>
+                <objectiveScenario>Hold Until Relief.xml</objectiveScenario>
             </objectiveScenarios>
             <objectiveScenarioModifiers>
                 <objectiveScenarioModifier>LiaisonGround.xml</objectiveScenarioModifier>

--- a/data/stratconcontractdefinitions/Terrorism.xml
+++ b/data/stratconcontractdefinitions/Terrorism.xml
@@ -55,6 +55,7 @@
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>
                 <objectiveScenario>VIP Ambush.xml</objectiveScenario>
+                <objectiveScenario>Supply Denial.xml</objectiveScenario>
             </objectiveScenarios>
         </objectiveParameter>
     </objectiveParameters>


### PR DESCRIPTION
# My Goal
The goal of this PR is largely to inject some diversity into our scenario roster. I wasn't happy with how 'same-y' many of our scenarios felt. Part of that is due to all of our scenarios being variations on 'kill a thing'. However, even within that we have options.

# Terrain
Another thing I wanted to address was scenario location. At time of writing the vast majority scenarios, generally, land on wholly randomized maps. This is where we get fun oddities like convoys driving through swamps, or DropShips trying to land in forests with no clear hexes. I went ahead and swept through all scenarios, placing them into terrain 'families'. Largely based on the type of scenario and the terrain I felt would offer the best experience.

The benefit of tying map type to scenario type also allows us to further our goal of diversity. If a convoy interdiction has different terrain to a field battle then both scenarios feel distinctly different. Even if their goals are both "kill x thingies".

# Kill Targets
Finally, on the topic of "kill x thingies", I've globally reduced the % of enemy forces that need to be destroyed in order to secure victory. In most cases they have gone down from 50% to 33%. For lance-on-lance this still equates to 2 unit kills necessary to score victory. However, as the size of the battle increases the number of unit kills similarly decreases. If you have 100 units (a massive battle for sure) the difference between needing 33 unit kills and 50 is noticeable.

Why have I reduced kill targets? There are three reasons, in addition to those outlined above. The first is that I want to reduce scenario times. Especially once you start fielding larger engagements it's not uncommon to see scenarios taking 20-30 turns to complete. This is a substantial amount of time invested. The other is one of salvage, by reducing kills we reduce salvage. Finally, there is a 'realism' clause. Any formation that suffers 50% casualties is effectively combat destroyed beyond recovery. Seeing them start to withdraw after 1:3 units are removed feels much more believable.

# Existing Scenario Changes

| Scenario | Changes |
|---|---|
| Annihilation | terrain → Open family; kill% 95→75; deploy OppositeEdge→OppositeArc; OpFor minWeight 2→3 |
| Assassination | terrain → Urban family; OpFor roles added |
| Base Defense | terrain +FrozenFacility; kill% 50→33; OpFor roles added |
| Breakthrough | terrain → Open family; kill% 50→33 |
| Close Air Support | terrain → Open family; kill% 50→33; OpFor roles added |
| Convoy Escort | terrain → Convoy-road family; kill% 50→33 |
| Convoy Interdiction | terrain → Hills family; kill% 50→33 |
| Convoy Raid | terrain → Hills family; kill% 50→33 |
| Covert Strike | terrain → Wooded family; OpFor roles added |
| Critical Convoy Escort | terrain → Convoy-road family; kill% 50→33 |
| Crowd Control | terrain → Urban family (activated) |
| Decoy Engagement | terrain → Hills family; kill% 75→50; OpFor roles added |
| Decoy Interception | terrain → Hills family; kill% 75→50; deploy OppositeEdge→OppositeArc; OpFor roles added |
| Deep Raid | terrain → Open/landable (DropShip); OpFor roles added |
| Deep Raid Defense | terrain → Open/landable (DropShip); kill% 50→33 |
| Diversion Engagement | terrain → Hills family; kill% 75→50; OpFor roles added |
| DropShip Raid | terrain → Open-arid/landable; kill% 50→33 (target 100 kept) |
| Emergency Convoy Defense | terrain → Convoy-road family; kill% 50→33 |
| Emergency Convoy Defense - Player | terrain → Convoy-road family; kill% 50→33; deploy OppositeEdge→OppositeArc |
| Emergency Convoy Defense - Player - Low-Atmosphere | kill% 50→33 |
| Emergency Convoy Defense - Player - VTOL | terrain → Convoy-road family; kill% 50→33 |
| Engagement | terrain → Open family; kill% 50→33 |
| Frontier Assassination | terrain → Frontier family (+HotMountains); kill% 50→33 (target 100 kept); OpFor roles added |
| Frontline Breakthrough | terrain → Open family; kill% 50→33 |
| Frontline Disruption | terrain → Open family; kill% 50→33 |
| Frontline Engagement | terrain → Open family; kill% 50→33; deploy OppositeEdge→OppositeArc |
| Heavy Recon Evasion | terrain → Wooded family; OpFor roles added; evade/Preserve% 5→25 |
| Hostile Facility | terrain +FrozenFacility; kill% 75→50; OpFor roles added; signature mod EnemyTurrets |
| Intercept Engagement | terrain → Hills family; kill% 75→50; deploy OppositeEdge→OppositeArc |
| Intercept the Escapees | terrain → Hills family; kill% 95→33 (bug fix; target 100 kept); player deploy zone 6→3 |
| Interception Defense | terrain → Hills family; kill% 50→33 |
| Irregular Force Assault | terrain → Urban family; kill% 50→33 |
| Irregular Force Suppression | terrain → Urban family; kill% 50→33 |
| Isolated DropShip Defense | terrain → Open/landable; kill% 50→33; deploy OppositeEdge→OppositeArc; failure SVP bug fix (−2→−1) |
| Low-Atmosphere Air Intercept | kill% 50→33 |
| Low-Atmosphere DropShip Escort | kill% 50→33 |
| Low-Atmosphere Reinforcements Intercepted | kill% 50→33 |
| Minor Engagement | terrain → Open family |
| Official Challenge | terrain → Open family; OpFor minWeight 3→4 (Assault champion) |
| Picket Line Breakthrough | terrain → Open family |
| Pivotal Battle | terrain → Open family; deploy OppositeEdge→OppositeArc; OpFor minWeight 2→3 |
| Recon Evasion | terrain → Wooded family; evade/Preserve% 5→25 |
| Reconnaissance Interdiction | terrain → Hills family; kill% 95→75 |
| Reinforcements Intercepted | terrain → Hills family; kill% 50→33; deploy OppositeEdge→OppositeArc |
| Space Aerospace Intercept | kill% 50→33 |
| Space Blockade Run | kill% 50→33 |
| Space DropShip Intercept | kill% 50→33 (target 100 kept) |
| Space Reinforcements Intercepted | kill% 50→33 |
| Tactical Withdrawal | terrain → Wooded family; kill% 50→33; OpFor roles added |
| VIP Ambush | terrain → Urban family |
| VIP Defense | terrain → Urban family; kill% 50→33; deploy OppositeEdge→OppositeArc |

# New scenarios

| Scenario | Map | Primary objective | Novel element | Contract home |
|---|---|---|---|---|
| Relief Column | Ground | Preserve 50% (ally) | Rescue a besieged allied force that's bleeding out | Relief Duty |
| Rescue the Downed | Ground | Preserve 100% (ally) | Protect a single isolated ally from a kill squad | Extraction Raid |
| Prisoner Liberation | Ground | ReachMapEdge 50% (ally) | Escort freed prisoners to friendly lines | Extraction Raid |
| VIP Extraction | Ground | ReachMapEdge 100% (VIP) | Walk one VIP off-map under a manhunt | Extraction Raid |
| Salvage Run | Ground | Capture 50% (neutral) | Race the enemy for a contested derelict cache (+supplies) | Pirate Hunting |
| Convoy Hijack | Ground | Capture 50% (convoy) | Seize a fleeing convoy intact instead of destroying it | Objective Raid |
| Mole Hunt | Ground | Destroy 100% (infantry) | Kill a lone infantry "mole" ringed by bodyguards | Mole Hunting |
| Decapitation Strike | Ground | Destroy 100% (command) | Kill one specific command mech through its screen | Assassination / Mole Hunting |
| Supply Denial | Ground | Destroy 75% (structures) | Demolish a static gun-emplacement depot | Terrorism / Sabotage |
| Last Stand | Ground | Preserve 50% (self) | Survive outnumbered with no ground to hold | Guerrilla Warfare |
| Hold Until Relief | Ground | Preserve 50% (self) | Hold until your own reinforcements arrive mid-battle | Security Duty / Relief Duty |
| Screening Action | Ground | PreventReachMapEdge 50% | Outnumbered rearguard denying a breakthrough | Relief Duty |
| Enveloped | Ground | ForceWithdraw 33% (×2) | Two-front pincer — fight both ways at once | Guerrilla Warfare |
| Breakout | Ground | ReachMapEdge 50% (self) | Escape an encirclement from the center | Guerrilla Warfare |
| Gauntlet Run | Ground | ReachMapEdge 50% (self) | Run a fortified corridor to the far edge | Guerrilla Warfare |
| Combat Drop | Ground | ForceWithdraw 33% | Player deploys from altitude into a garrison | Planetary Assault |
| Rolling Thunder | Ground | ReachMapEdge 50% (self) | Punch through a defense in depth | Planetary Assault |
| Meeting Engagement | Ground | ForceWithdraw 33% | Symmetric chance encounter, both arrive at once | Planetary Assault |
| Escalation | Ground | ForceWithdraw 33% | Both sides feed reserves mid-battle | Planetary Assault |
| Ambush the Column | Ground | ForceWithdraw 50% | Defeat a staggered-arrival column in detail | Diversionary Raid |
| Fighter Sweep | Space | ForceWithdraw 50% | Air-superiority hunt (aerospace) | manifest-only* |
| Strafing Run | Low-Atmo | ForceWithdraw 33% | Air-to-ground against a ground column | manifest-only* |
| Bomber Escort | Low-Atmo | Preserve 50% (bombers) | Shepherd allied bombers through interceptors | manifest-only* |

* manifest only scenarios can only occur through random scenario generation and will not spawn as contractual scenarios.