### PR TITLE
Fix case-sensitive tileset include paths

### DIFF
--- a/data/images/hexes/atmospheric.tileset
+++ b/data/images/hexes/atmospheric.tileset
@@ -58,8 +58,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 include "StandardIncludes/StandardThemes.tileinc"

--- a/data/images/hexes/bw_atmospheric.tileset
+++ b/data/images/hexes/bw_atmospheric.tileset
@@ -55,8 +55,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 #include "bloodwolf/grass/ThemeGrass.tileinc"

--- a/data/images/hexes/classic.tileset
+++ b/data/images/hexes/classic.tileset
@@ -34,8 +34,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 include "StandardIncludes/StandardThemes.tileinc"

--- a/data/images/hexes/hq_atmospheric.tileset
+++ b/data/images/hexes/hq_atmospheric.tileset
@@ -59,8 +59,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 include "hq_boring/ThemeHQDesert.tileinc"

--- a/data/images/hexes/hq_isometric.tileset
+++ b/data/images/hexes/hq_isometric.tileset
@@ -59,8 +59,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 include "hq_boring/ThemeHQDesert.tileinc"

--- a/data/images/hexes/isometric.tileset
+++ b/data/images/hexes/isometric.tileset
@@ -58,8 +58,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 include "StandardIncludes/StandardThemes.tileinc"

--- a/data/images/hexes/largeTextures.tileset
+++ b/data/images/hexes/largeTextures.tileset
@@ -62,8 +62,8 @@
 
 super * "ground_fluff:*" "" "saxarba/misc/blank.png"
 
-include "incline/inclines2.tileinc"
-include "high_incline/high_inclines.tileinc"
+include "Incline/Inclines2.tileinc"
+include "High_Incline/High_Inclines.tileinc"
 include "Cliff/Cliffs.tileinc"
 
 super * "swamp:1" "grass" "bloodwolf/hq_boring/swamp_1.png;bloodwolf/hq_boring/swamp_1.png(0,72-84,-72);bloodwolf/hq_boring/swamp_1.png(84,0--84,72);bloodwolf/hq_boring/swamp_1.png(84,72--84,-72)"


### PR DESCRIPTION
Part 2 of 2 for fixing case-insensitive image paths under Linux.

This is the other half of my first set of PRs for the MegaMek project! While working on correcting the case-insensitive paths for a lot of mech images, I recalled another issue during battle where I noticed that the tileset I wanted to use wasn't actually showing properly when I selected it. After poking around, I ended up finding the same problem with the same solution as the previous PR. All I did was change the capitalization of the paths to properly match the files being referenced.