### PR TITLE
Fix spelling of Mek in education options

### DIFF
--- a/data/universe/academies/Prestigious Academies.xml
+++ b/data/universe/academies/Prestigious Academies.xml
@@ -426,10 +426,10 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Allison MechWarrior Institute</name>
+        <name>Allison MekWarrior Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed MekWarriors to uphold loyalty.</description>
+        <description>The Allison MekWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed MekWarriors to uphold loyalty.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Olympia</locationSystem>
@@ -446,10 +446,10 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Allison MechWarrior Institute (Officer)</name>
+        <name>Allison MekWarrior Institute (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed MekWarriors to uphold loyalty.</description>
+        <description>The Allison MekWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed MekWarriors to uphold loyalty.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Olympia</locationSystem>

--- a/data/universe/academies/Unit Education.xml
+++ b/data/universe/academies/Unit Education.xml
@@ -67,7 +67,7 @@
         <facultySkill>9</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MechWarrior Apprenticeship</qualification>
+        <qualification>MekWarrior Apprenticeship</qualification>
         <curriculum>Gunnery/Mek, Piloting/Mek</curriculum>
         <qualificationStartYear>2439</qualificationStartYear>
         <qualification>Mechanized Apprenticeship</qualification>
@@ -180,7 +180,7 @@
         <durationDays>150</durationDays>
         <facultySkill>9</facultySkill>
         <ageMin>16</ageMin>
-        <qualification>Basic MechWarrior Training</qualification>
+        <qualification>Basic MekWarrior Training</qualification>
         <curriculum>Gunnery/Mek, Piloting/Mek</curriculum>
         <qualificationStartYear>2439</qualificationStartYear>
         <qualification>Basic Aerospace Training</qualification>


### PR DESCRIPTION
We try to use Mek instead of Mech these days. Found a few education options where that wasn't the case, so updated them accordingly.