### PR TITLE
Minor availability updates to clean up log file

### DIFF
--- a/data/forcegenerator/3075.xml
+++ b/data/forcegenerator/3075.xml
@@ -1829,7 +1829,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>FS:4</availability>
             <model name=''>
                 <roles>pocket_warship</roles>

--- a/data/forcegenerator/3078.xml
+++ b/data/forcegenerator/3078.xml
@@ -1997,7 +1997,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>FS:4</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -2005,7 +2005,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>General:7</availability>
+                <availability>FS:7</availability>
             </model>
         </chassis>
         <chassis name='Assassin' unitType='Mek'>

--- a/data/forcegenerator/3082.xml
+++ b/data/forcegenerator/3082.xml
@@ -1774,7 +1774,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:2,ROS:2,MERC:1+,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -1786,7 +1786,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>IS:7</availability>
+                <availability>LA:7,ROS:7,MERC:7,FS:7</availability>
             </model>
         </chassis>
         <chassis name='Assassin' unitType='Mek'>

--- a/data/forcegenerator/3085.xml
+++ b/data/forcegenerator/3085.xml
@@ -1804,7 +1804,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:3,ROS:3,MERC:2+,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -1816,7 +1816,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>IS:6</availability>
+                <availability>LA:6,ROS:6,MERC:6,FS:6</availability>
             </model>
         </chassis>
         <chassis name='Arrow IV Assault Vehicle' unitType='Tank'>

--- a/data/forcegenerator/3100.xml
+++ b/data/forcegenerator/3100.xml
@@ -1898,7 +1898,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:4,ROS:4,MERC:3+,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -1910,7 +1910,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>IS:5</availability>
+                <availability>LA:5,ROS:5,MERC:5,FS:5</availability>
             </model>
         </chassis>
         <chassis name='Arrow IV Assault Vehicle' unitType='Tank'>

--- a/data/forcegenerator/3131.xml
+++ b/data/forcegenerator/3131.xml
@@ -2115,7 +2115,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:4,ROS:4,MERC:3+,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -2127,7 +2127,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>IS:4</availability>
+                <availability>LA:4,ROS:4,MERC:4,FS:4</availability>
             </model>
         </chassis>
         <chassis name='Arrow IV Assault Vehicle' unitType='Tank'>

--- a/data/forcegenerator/3145.xml
+++ b/data/forcegenerator/3145.xml
@@ -1934,7 +1934,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:4,ROS:4,MERC:3,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -1946,7 +1946,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>IS:4</availability>
+                <availability>LA:4,ROS:4,MERC:4,FS:4</availability>
             </model>
         </chassis>
         <chassis name='Arrow IV Assault Vehicle' unitType='Tank'>

--- a/data/forcegenerator/3150.xml
+++ b/data/forcegenerator/3150.xml
@@ -1983,7 +1983,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:4,ROS:4,MERC:3,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>
@@ -1995,7 +1995,7 @@
             </model>
             <model name='(SCC)'>
                 <roles>pocket_warship</roles>
-                <availability>IS:4</availability>
+                <availability>LA:4,ROS:4,MERC:4,FS:4</availability>
             </model>
         </chassis>
         <chassis name='Arrow IV Assault Vehicle' unitType='Tank'>

--- a/data/forcegenerator/3150.xml
+++ b/data/forcegenerator/3150.xml
@@ -221,7 +221,7 @@
             <upgradeMargin>13</upgradeMargin>
             <salvage pct='5'>FWL:1,FR:1,DA:10</salvage>
         </faction>
-        <faction key='MalCon'>
+        <faction key='MALC'>
             <omniMargin>16</omniMargin>
             <techMargin>16</techMargin>
             <upgradeMargin>13</upgradeMargin>

--- a/data/forcegenerator/3160.xml
+++ b/data/forcegenerator/3160.xml
@@ -212,7 +212,7 @@
             <upgradeMargin>15</upgradeMargin>
             <salvage pct='5'>FWL:1,FR:1,DA:10</salvage>
         </faction>
-        <faction key='MalCon'>
+        <faction key='MALC'>
             <omniMargin>18</omniMargin>
             <techMargin>18</techMargin>
             <upgradeMargin>15</upgradeMargin>

--- a/data/forcegenerator/3160.xml
+++ b/data/forcegenerator/3160.xml
@@ -1940,7 +1940,7 @@
                 <availability>General:8</availability>
             </model>
         </chassis>
-        <chassis name='Arondight Pocket Warship' unitType='Dropship'>
+        <chassis name='Arondight Pocket WarShip' unitType='Dropship'>
             <availability>LA:4,MERC:3,FS:5</availability>
             <model name=''>
                 <roles>pocket_warship</roles>

--- a/data/rat/(2790 - 2850) - Operation Klondike/Clans/Vehicles/Operations Klondike Clan Medium Vehicle.txt
+++ b/data/rat/(2790 - 2850) - Operation Klondike/Clans/Vehicles/Operations Klondike Clan Medium Vehicle.txt
@@ -25,5 +25,5 @@ Zephyr Hovertank (Standard),6
 Goblin Medium Tank (Standard),5
 Maxim Heavy Hover Transport (Standard),4
 Kanga Medium Hovertank (Standard),3
-Zephyr Hovertank (SRM2),2
+Zephyr Hovertank (Original),2
 Chaparral Missile Artillery Tank (Standard),1

--- a/data/rat/(3064) - FM Periphery/Inner Sphere/Nueva Castille/Vehicles/Medium/3064 Nueva Castille Medium Vehicles.txt
+++ b/data/rat/(3064) - FM Periphery/Inner Sphere/Nueva Castille/Vehicles/Medium/3064 Nueva Castille Medium Vehicles.txt
@@ -16,7 +16,7 @@
 # affiliated with Microsoft.
 
 3064 Castillian/Umayyad Medium Vehicles
-Zephyr Hovertank (SRM2),1
+Zephyr Hovertank (Original),1
 Vedette Medium Tank (Standard),2
 Condor Heavy Hover Tank (Standard),3
 Hetzer Wheeled Assault Gun (SRM),4

--- a/data/rat/(3076 - 3100) - FM 3085/Inner Sphere/Federated Suns/Aerospace/3085 Federated Suns Fleet Dropships.txt
+++ b/data/rat/(3076 - 3100) - FM 3085/Inner Sphere/Federated Suns/Aerospace/3085 Federated Suns Fleet Dropships.txt
@@ -19,11 +19,11 @@
 Leopard CV (3054),1
 Conquistador (3063),2
 Vengeance (3056),3
-Arondight Pocket Warship (SCC),4
+Arondight Pocket WarShip (SCC),4
 Claymore (3054),5
 Avenger (3048),6
-Arondight Pocket Warship (Standard),5
-Arondight Pocket Warship (Refit),4
+Arondight Pocket WarShip (Standard),5
+Arondight Pocket WarShip (Refit),4
 Avenger (3048),3
 Excalibur 'Pocket Warship',2
 Overlord A3,1

--- a/data/rat/(3076 - 3100) - FM 3085/Inner Sphere/Federated Suns/Aerospace/3085 Federated Suns Fleet Dropships.txt
+++ b/data/rat/(3076 - 3100) - FM 3085/Inner Sphere/Federated Suns/Aerospace/3085 Federated Suns Fleet Dropships.txt
@@ -22,7 +22,7 @@ Vengeance (3056),3
 Arondight Pocket WarShip (SCC),4
 Claymore (3054),5
 Avenger (3048),6
-Arondight Pocket WarShip (Standard),5
+Arondight Pocket WarShip,5
 Arondight Pocket WarShip (Refit),4
 Avenger (3048),3
 Excalibur 'Pocket Warship',2

--- a/data/rat/(3130 on) - FM 3145/Inner Sphere/Federated Suns/Aerospace/Fleet DS.txt
+++ b/data/rat/(3130 on) - FM 3145/Inner Sphere/Federated Suns/Aerospace/Fleet DS.txt
@@ -19,11 +19,11 @@
 Aurora (Standard),1
 Overlord (3056),2
 Vengeance (3056),3
-Arondight Pocket Warship (Standard),4
+Arondight Pocket WarShip (Standard),4
 Union (3055),5
-Arondight Pocket Warship (SCC),6
+Arondight Pocket WarShip (SCC),6
 Conquistador (3063),5
 Excalibur 'Pocket Warship',4
-Arondight Pocket Warship (SCC),3
+Arondight Pocket WarShip (SCC),3
 Overlord A3,2
 Conquistador 'Blockade Runner',1

--- a/data/rat/(3130 on) - FM 3145/Inner Sphere/Federated Suns/Aerospace/Fleet DS.txt
+++ b/data/rat/(3130 on) - FM 3145/Inner Sphere/Federated Suns/Aerospace/Fleet DS.txt
@@ -19,7 +19,7 @@
 Aurora (Standard),1
 Overlord (3056),2
 Vengeance (3056),3
-Arondight Pocket WarShip (Standard),4
+Arondight Pocket WarShip,4
 Union (3055),5
 Arondight Pocket WarShip (SCC),6
 Conquistador (3063),5

--- a/data/rat/(3135 - 3150) - ER 3145/IS/Federated Suns/Aerospace/Dropships.txt
+++ b/data/rat/(3135 - 3150) - ER 3145/IS/Federated Suns/Aerospace/Dropships.txt
@@ -21,9 +21,9 @@ Seeker (3054),2
 Union (3055),3
 Avenger (3048),4
 Overlord (3056),5
-Arondight Pocket Warship (Standard),6
-Arondight Pocket Warship (SCC),5
+Arondight Pocket WarShip,6
+Arondight Pocket WarShip (SCC),5
 Excalibur 'Pocket Warship',4
-Arondight Pocket Warship (SCC),3
+Arondight Pocket WarShip (SCC),3
 Overlord A3,2
 Conquistador 'Blockade Runner',1

--- a/data/universe/factions/MALC.yml
+++ b/data/universe/factions/MALC.yml
@@ -29,6 +29,12 @@ yearsActive:
 tags:
   - MINOR
   - IS
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
 color:
   red: 93
   green: 133

--- a/data/universe/factions/VSM.yml
+++ b/data/universe/factions/VSM.yml
@@ -29,6 +29,12 @@ yearsActive:
 tags:
   - MINOR
   - IS
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
 color:
   red: 235
   green: 162


### PR DESCRIPTION
Some minor updates to address errors in log files:

- couple of name changes in availability XMLs and legacy RAT files
- moved a legacy txt RAT file from a 'Mek' folder to appropriate 'Vehicle' folder
- adds standard A-F availability ratings for MALC (Malthus Confederation) and VSM (Vesper Marches) factions