### PR TITLE
Restore 2025-2026 copyright ranges lost in the full resave

### DIFF
--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Air Defense Missile Gun Emplacement External 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Air Defense Missile Gun Emplacement External 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Air Defense Missile Gun Emplacement Fusion 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Air Defense Missile Gun Emplacement Fusion 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Bombard Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Bombard Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Bombard Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Bombard Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Flak Gun Emplacement External 3025.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Flak Gun Emplacement External 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Flak Gun Emplacement Fusion 3025.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Flak Gun Emplacement Fusion 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Laser Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Missile Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement External 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement External 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement Fusion 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Shredder Gun Emplacement Fusion 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Siege Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Siege Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Siege Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Siege Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Assault Turrets/Assault Sniper Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Blaze Gun Emplacement External 3025.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Blaze Gun Emplacement External 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Blaze Gun Emplacement Fusion 3025.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Blaze Gun Emplacement Fusion 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Bombard Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Bombard Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Bombard Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Bombard Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Flak Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Laser Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Missile Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement External 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement External 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement Fusion 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Shredder Gun Emplacement Fusion 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Siege Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Heavy Turrets/Heavy Sniper Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Bombard Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Bombard Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Bombard Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Bombard Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Flak Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Laser Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Laser Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Laser Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Laser Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Missile Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement External 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement External 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement Fusion 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Shredder Gun Emplacement Fusion 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement External 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement External 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement Fusion 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Light Turrets/Light Sniper Gun Emplacement Fusion 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Air Defense Missile Gun Emplacement External 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Air Defense Missile Gun Emplacement External 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Air Defense Missile Gun Emplacement Fusion 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Air Defense Missile Gun Emplacement Fusion 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Blaze Gun Emplacement External 3025.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Blaze Gun Emplacement External 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Blaze Gun Emplacement Fusion 3025.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Blaze Gun Emplacement Fusion 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Bombard Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Bombard Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Bombard Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Bombard Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Command Tower Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement External 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement External 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement Fusion 3050.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Flak Gun Emplacement Fusion 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Laser Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Missile Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement External 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement External 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement Fusion 3057.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Shredder Gun Emplacement Fusion 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement External 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement External 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement Fusion 3039.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Siege Gun Emplacement Fusion 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement External 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement External 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement External 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement External 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement Fusion 2300.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement Fusion 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement Fusion 3075.blk
+++ b/data/mekfiles/advancedbuildings/Migrated Gun Emplacements/Medium Turrets/Medium Sniper Gun Emplacement Fusion 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [David].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [David].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [Flamer].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [Flamer].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [Laser].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [Laser].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [MG].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [MG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [TAG].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [TAG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [WoB].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 4) [WoB].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [David].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [David].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [Flamer].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [Flamer].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [Laser].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [Laser].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [MG].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [MG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [TAG].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [TAG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [WoB].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 5) [WoB].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 6) [David].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqd 6) [David].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [Flamer].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [Flamer].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [Laser].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [Laser].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [MG].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [MG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [TAG].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [TAG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [WoB].blk
+++ b/data/mekfiles/battlearmor/3058Uu/Achileus BA (Sqn 6) [WoB].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [SRM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [SRM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [SRM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [SRM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Cavalier BA [SRM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Cavalier BA [SRM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA (Headhunter) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA (Headhunter) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA (Headhunter) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA (Headhunter) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA (Headhunter) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA (Headhunter) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [APG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [ER Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [HMG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental BA [MicroPL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Elemental Battle Armor (Headhunter)(Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Elemental Battle Armor (Headhunter)(Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [LRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [LRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [LRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [LRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [LRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [LRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [TAG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [TAG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [TAG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [TAG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [TAG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fa Shih BA [TAG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [ERML] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [ERML] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [ERML] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [ERML] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [ERML] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [ERML] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MPL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MPL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MPL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MPL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MPL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [MPL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [Mortar] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [Mortar] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [Mortar] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [Mortar] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [Mortar] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [Mortar] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SPLAS] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SPLAS] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SPLAS] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SPLAS] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SPLAS] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SPLAS] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SRM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SRM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SRM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SRM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SRM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [SRM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [VSP] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [VSP] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [VSP] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [VSP] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Fenrir BA [VSP] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Fenrir BA [VSP] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Bearhunter] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Bearhunter] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Bearhunter] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Bearhunter] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Bearhunter] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Bearhunter] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [MRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [MRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [MRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [MRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [MRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [MRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Pulse] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Pulse] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Pulse] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Pulse] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Pulse] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gnome BA (Upgrade) [Pulse] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Scout (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Scout (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Scout (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Scout (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Scout (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Scout (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [LRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [LRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [LRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [LRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [LRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [LRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [SRM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [SRM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [SRM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [SRM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [SRM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Gray Death Std Suit [SRM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [LRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [LRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [LRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [LRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [LRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [LRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [SRM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [SRM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [SRM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [SRM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/IS Standard BA [SRM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/IS Standard BA [SRM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (SpecOps) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (SpecOps) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (SpecOps) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (SpecOps) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (SpecOps) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (SpecOps) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. I BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sensor) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sensor) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sensor) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sensor) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sensor) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sensor) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Infiltrator Mk. II BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA (DEST) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA (DEST) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA (DEST) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA (DEST) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA (DEST) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA (DEST) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA (Vibro-Claw) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA (Vibro-Claw) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA (Vibro-Claw) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA (Vibro-Claw) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA (Vibro-Claw) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA (Vibro-Claw) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [ECM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [ECM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [ECM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [ECM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [ECM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [ECM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [TAG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [TAG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [TAG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [TAG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kage Light BA [TAG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kage Light BA [TAG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA (Upgrade) [Battle Claw] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA (Upgrade) [Battle Claw] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA (Upgrade) [Battle Claw] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA (Upgrade) [Battle Claw] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA (Upgrade) [Battle Claw] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA (Upgrade) [Battle Claw] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Battle Claw] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Battle Claw] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Battle Claw] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Battle Claw] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Battle Claw] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Battle Claw] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Industrial Drill] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Industrial Drill] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Industrial Drill] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Industrial Drill] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Industrial Drill] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Industrial Drill] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Salvage Arm] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Salvage Arm] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Salvage Arm] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Salvage Arm] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Salvage Arm] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Kanazuchi Assault BA [Salvage Arm] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [David] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [David] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [David] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [David] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [David] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [David] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Longinus BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Longinus BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Narc] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Narc] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Narc] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Narc] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Narc] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [Narc] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [PPC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [PPC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [PPC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [PPC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [PPC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [PPC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [TAG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [TAG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [TAG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [TAG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [TAG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Purifier Adaptive BA [TAG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA (Original) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA (Original) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA (Original) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA (Original) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA (Original) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA (Original) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [MRM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [MRM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [MRM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [MRM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [MRM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [MRM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Tsunami] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Tsunami] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Tsunami] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Tsunami] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Raiden BA [Tsunami] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Raiden BA [Tsunami] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (AI) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (AI) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (AI) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (AI) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (AI) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (AI) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Laser) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Laser) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Laser) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Laser) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Laser) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Laser) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd3).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Salamander BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sloth BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sloth BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sloth BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sloth BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sloth BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sloth BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sylph BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sylph BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sylph BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sylph BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sylph BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sylph BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sylph BA (Upgrade) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sylph BA (Upgrade) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sylph BA (Upgrade) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sylph BA (Upgrade) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Sylph BA (Upgrade) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Sylph BA (Upgrade) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Undine BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Undine BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Undine BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Undine BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Undine BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Undine BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Undine BA (Upgrade) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Undine BA (Upgrade) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Undine BA (Upgrade) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Undine BA (Upgrade) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3058Uu/Undine BA (Upgrade) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3058Uu/Undine BA (Upgrade) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Aerie PA(L) (Salvage) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Aerie PA(L) (Salvage) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Aerie PA(L) (Salvage) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Aerie PA(L) (Salvage) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Aerie PA(L) (Salvage) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Aerie PA(L) (Salvage) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Aerie PA(L) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Aerie PA(L) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Aerie PA(L) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Aerie PA(L) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Aerie PA(L) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Aerie PA(L) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (HH) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (HH) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (HH) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (HH) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (HH) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (HH) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (JF) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (JF) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (JF) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (JF) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (JF) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (JF) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Afreet Med BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Afreet Med BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA (Anti Infantry)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA (Anti Infantry)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA (Anti Infantry)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA (Anti Infantry)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA (Anti Infantry)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA (Anti Infantry)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA (SRM)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA (SRM)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA (SRM)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA (SRM)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA (SRM)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA (SRM)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Asura Med BA(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Asura Med BA(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Naval) (Bar) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Naval) (Bar) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Naval) (Bar) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Naval) (Bar) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Naval) (Bar) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Naval) (Bar) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Rapid) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Rapid) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Rapid) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Rapid) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Rapid) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Rapid) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Volk) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Volk) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Volk) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Volk) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Clan Med BA (Volk) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Clan Med BA (Volk) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Corona Heavy BA (SRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Corona Heavy BA (SRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Corona Heavy BA (SRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Corona Heavy BA (SRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Corona Heavy BA (SRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Corona Heavy BA (SRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Corona Heavy BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Corona Heavy BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Corona Heavy BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Corona Heavy BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Corona Heavy BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Corona Heavy BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Djinn BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Djinn BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Djinn BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Djinn BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Djinn BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Djinn BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Djinn BA (Stealth) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Djinn BA (Stealth) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Djinn BA (Stealth) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Djinn BA (Stealth) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Djinn BA (Stealth) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Djinn BA (Stealth) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Fast Assault) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Fast Assault) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Fast Assault) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Fast Assault) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Fast Assault) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Fast Assault) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Rock Golem) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Rock Golem) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Rock Golem) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Rock Golem) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Rock Golem) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Rock Golem) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Golem AA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Golem AA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [MagShot] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [MagShot] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [MagShot] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [MagShot] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [MagShot] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [MagShot] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [NARC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [NARC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [NARC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [NARC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [NARC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA (HK) [NARC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [LRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [LRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [LRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [LRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [LRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [LRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [MagShot] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [MagShot] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [MagShot] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [MagShot] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [MagShot] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [MagShot] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [SRM SL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [SRM SL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [SRM SL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [SRM SL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [SRM SL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [SRM SL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [TAG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [TAG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [TAG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [TAG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Grenadier BA [TAG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Grenadier BA [TAG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Hauberk BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Hauberk BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Hauberk BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Hauberk BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Hauberk BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Hauberk BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Hauberk II BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Hauberk II BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Hauberk II BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Hauberk II BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Hauberk II BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Hauberk II BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL SPL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL SPL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL SPL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL SPL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL SPL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL SPL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL TAG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL TAG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL TAG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL TAG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [GL TAG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [GL TAG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [SL Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [SL Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [SL Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [SL Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [SL Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [SL Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [SL TAG]  (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [SL TAG]  (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [SL TAG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [SL TAG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Kobold BA [SL TAG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Kobold BA [SL TAG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (CapTeam)[HMG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (CapTeam)[HMG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (CapTeam)[HMG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (CapTeam)[HMG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (CapTeam)[HMG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (CapTeam)[HMG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Gauss) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Gauss) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Gauss) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Gauss) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Gauss) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Gauss) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Narc) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Narc) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Narc) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Narc) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Narc) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Narc) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Seeker) [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Seeker) [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Seeker) [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Seeker) [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Seeker) [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Seeker) [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Sup) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Sup) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Sup) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Sup) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Sup) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA (Sup) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA [Plasma] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA [Plasma] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA [Plasma] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA [Plasma] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nephilim Assault BA [Plasma] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nephilim Assault BA [Plasma] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXI (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXI (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXI (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXI (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXI (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXI (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXII (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXII (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXII (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXII (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXII (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Nighthawk PA(L) Mk. XXII (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (A) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (A) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (A) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (A) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (A) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (A) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (B) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (B) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (B) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (B) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (B) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (B) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (C) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (C) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (C) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (C) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Phalanx BA  (C) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Phalanx BA  (C) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rogue Bear Heavy BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Rogue Bear Heavy BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rogue Bear Heavy BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Rogue Bear Heavy BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rogue Bear Heavy BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Rogue Bear Heavy BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Close) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Close) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Close) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Close) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Close) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Close) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Upgrade) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Upgrade) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Upgrade) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Upgrade) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Rottweiler BA (Upgrade) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Rottweiler BA (Upgrade) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (AI) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (AI) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (AI) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (AI) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (AI) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (AI) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (Capture) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (Capture) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (Capture) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (Capture) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (Capture) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (Capture) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Se'irim Med BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Se'irim Med BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Capture) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Capture) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Capture) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Capture) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Capture) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Capture) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (PPC) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (PPC) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (PPC) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (PPC) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (PPC) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (PPC) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Recon) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Recon) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Recon) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Recon) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Recon) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Recon) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sup) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sup) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sup) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sup) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sup) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Shedu Assault BA (Sup) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (C3i) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (C3i) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (C3i) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (C3i) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (C3i) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (C3i) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (ML) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (ML) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (ML) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (ML) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (ML) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (ML) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Plasma) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Plasma) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Plasma) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Plasma) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Plasma) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Plasma) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (RL) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (RL) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (RL) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (RL) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (RL) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (RL) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Sup) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Sup) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Sup) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Sup) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Sup) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (Sup) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (VSP) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (VSP) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (VSP) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (VSP) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tengu Heavy BA (VSP) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tengu Heavy BA (VSP) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G12 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G12 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G12 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G12 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G12 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G12 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [David] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [David] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [David] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [David] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [David] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [David] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [GL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [GL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [GL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [GL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [GL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [GL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [SL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [SL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [SL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [SL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [SL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G13 [SL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G14 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G14 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G14 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G14 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) G14 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) G14 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) P12 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) P12 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) P12 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) P12 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Tornado PA(L) P12 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Tornado PA(L) P12 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [MRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [MRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [MRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [MRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [MRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [MRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [PPC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [PPC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [PPC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [PPC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [PPC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Asterion) [PPC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus RL)[LRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus RL)[LRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus RL)[LRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus RL)[LRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus RL)[LRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus RL)[LRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus)[MRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus)[MRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus)[MRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus)[MRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus)[MRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Theseus)[MRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Ying Long)(Plasma) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Ying Long)(Plasma) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Ying Long)(Plasma) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Ying Long)(Plasma) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Trinity Med BA (Ying Long)(Plasma) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Trinity Med BA (Ying Long)(Plasma) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (DCA) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (DCA) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (DCA) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (DCA) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (DCA) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (DCA) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (Nova) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (Nova) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (Nova) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (Nova) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (Nova) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (Nova) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3075/Void Med BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3075/Void Med BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit (Recon)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit (Recon)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit (Recon)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit (Recon)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit (Recon)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit (Recon)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Angerona Scout Suit(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Fire) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Fire) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Fire) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Fire) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Fire) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Fire) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ironhold Assault BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (AI) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (AI) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (AI) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (AI) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (AI) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (AI) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Kopis Assault BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ravager Assault BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ravager Assault BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ravager Assault BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ravager Assault BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Ravager Assault BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Ravager Assault BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [APG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [APG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [APG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [APG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [APG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [APG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [ER Laser] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [ER Laser] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [ER Laser] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [ER Laser] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [ER Laser] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [ER Laser] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [Pulse] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [Pulse] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [Pulse] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [Pulse] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [Pulse] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Thunderbird BA [Pulse] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Warg Assault BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Warg Assault BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Warg Assault BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Warg Assault BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/Cutting Edge/Warg Assault BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/Cutting Edge/Warg Assault BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Afreet Med BA (Interdictor)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Afreet Med BA (Interdictor)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Afreet Med BA (Interdictor)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Afreet Med BA (Interdictor)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Afreet Med BA (Interdictor)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Afreet Med BA (Interdictor)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Clan Med BA (Rache)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Clan Med BA (Rache)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Clan Med BA (Rache)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Clan Med BA (Rache)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Clan Med BA (Rache)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Clan Med BA (Rache)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [APG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [APG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [APG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [APG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [APG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [APG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Pulse] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Pulse] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Pulse] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Pulse] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Pulse] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Fire) [Pulse] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Pulse] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Pulse] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Pulse] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Pulse] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Pulse] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Elemental BA (Space) [Pulse] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [King David] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [King David] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [King David] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [King David] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [King David] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [King David] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [Plasma]  (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [Plasma]  (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [Plasma] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [Plasma] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [Plasma] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Fa Shih BA (Sup) [Plasma] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Gnome BA (LRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Gnome BA (LRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Gnome BA (LRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Gnome BA (LRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Gnome BA (LRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Gnome BA (LRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Golem AA (Sup)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Golem AA (Sup)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Golem AA (Sup)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Golem AA (Sup)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Golem AA (Sup)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Golem AA (Sup)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Gray Death Heavy Suit (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Gray Death Heavy Suit (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Gray Death Heavy Suit (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Gray Death Heavy Suit (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Gray Death Heavy Suit (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Gray Death Heavy Suit (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Infiltrator Mk II BA (Mag) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Infiltrator Mk II BA (Mag) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Infiltrator Mk II BA (Mag) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Infiltrator Mk II BA (Mag) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Infiltrator Mk II BA (Mag) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Infiltrator Mk II BA (Mag) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Kage Light BA (Space) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Kage Light BA (Space) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Kage Light BA (Space) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Kage Light BA (Space) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Kage Light BA (Space) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Kage Light BA (Space) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Longinus BA (Mag) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Longinus BA (Mag) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Longinus BA (Mag) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Longinus BA (Mag) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Longinus BA (Mag) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Longinus BA (Mag) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (BH (Sqd1).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (BH (Sqd1).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (BH 3055) (Sqd1).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (BH 3055) (Sqd1).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Nighthawk PA(L) Mk. XXX (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Raiden BA (AI) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Raiden BA (AI) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Raiden BA (AI) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Raiden BA (AI) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Raiden BA (AI) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Raiden BA (AI) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Rottweiler BA (Firedrake) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Rottweiler BA (Firedrake) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Rottweiler BA (Firedrake) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Rottweiler BA (Firedrake) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Rottweiler BA (Firedrake) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Rottweiler BA (Firedrake) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Sloth BA (Interdictor) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Sloth BA (Interdictor) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Sloth BA (Interdictor) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Sloth BA (Interdictor) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Sloth BA (Interdictor) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Sloth BA (Interdictor) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[MRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[MRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[MRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[MRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[MRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[MRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[PPC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[PPC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[PPC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[PPC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[PPC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Asterion Upgrade)[PPC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Theseus Sup) Killshot (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Theseus Sup) Killshot (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Theseus Sup) Killshot (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Theseus Sup) Killshot (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Theseus Sup) Killshot (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3085u/ONN/Trinity Med BA (Theseus Sup) Killshot (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (ER Pulse) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (ER Pulse) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (ER Pulse) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (ER Pulse) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (ER Pulse) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (ER Pulse) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Flamer) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Flamer) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Flamer) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Flamer) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Flamer) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Flamer) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Heavy Mortar) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Heavy Mortar) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Heavy Mortar) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Heavy Mortar) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Heavy Mortar) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Heavy Mortar) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (LBX) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (LBX) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (LBX) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (LBX) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (LBX) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (LBX) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Plasma) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Plasma) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Plasma) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Plasma) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Plasma) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Black Wolf BA (Plasma) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (HK) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (HK) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (HK) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (HK) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (HK) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (HK) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sup) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sup) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sup) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sup) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sup) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Buraq Fast BA (Sup) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (ECM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (ECM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (ECM) (Sqd5)).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (ECM) (Sqd5)).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (ECM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (ECM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (Imp Sensors) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (Imp Sensors) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (Imp Sensors) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (Imp Sensors) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (Imp Sensors) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (Imp Sensors) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (LMG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (LMG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (LMG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (LMG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (LMG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (LMG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (SRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (SRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (SRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (SRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (SRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (SRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (TAG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (TAG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (TAG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (TAG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (TAG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Constable Pacification Suit (TAG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Wraith BA (AI) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Wraith BA (AI) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Wraith BA (AI) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Wraith BA (AI) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Wraith BA (AI) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Wraith BA (AI) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Wraith BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Wraith BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Wraith BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Wraith BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Clans/Wraith BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Clans/Wraith BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Upgraded) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Upgraded) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Upgraded) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Upgraded) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Upgraded) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Fusilier BA (Upgraded) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/PAB-28 Sniper Suit (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/PAB-28 Sniper Suit (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/PAB-28 Sniper Suit (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/PAB-28 Sniper Suit (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/PAB-28 Sniper Suit (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/PAB-28 Sniper Suit (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Sea Fox Amphibious Armor (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Sea Fox Amphibious Armor (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Sea Fox Amphibious Armor (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Sea Fox Amphibious Armor (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Davion/Sea Fox Amphibious Armor (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Davion/Sea Fox Amphibious Armor (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Kishi Ceremonial Armor (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Kishi Ceremonial Armor (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Kishi Ceremonial Armor (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Kishi Ceremonial Armor (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Kishi Ceremonial Armor (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Kishi Ceremonial Armor (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA Bearhunter (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA Bearhunter (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA Bearhunter (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA Bearhunter (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA Bearhunter (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA Bearhunter (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA MRR (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA MRR (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA MRR (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA MRR (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA MRR (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA MRR (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA PPC (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA PPC (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA PPC (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA PPC (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA PPC (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA PPC (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA [Narc] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA [Narc] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA [Narc] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA [Narc] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Oni BA [Narc] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Oni BA [Narc] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (C3) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (C3) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (C3) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (C3) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (C3) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (C3) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Kurita/Zou Heavy BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Amazon BA MRR (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Amazon BA MRR (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Amazon BA MRR (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Amazon BA MRR (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Amazon BA MRR (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Amazon BA MRR (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Amazon BA PPC (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Amazon BA PPC (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Amazon BA PPC (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Amazon BA PPC (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Amazon BA PPC (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Amazon BA PPC (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA David (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA David (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA David (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA David (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA David (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA David (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Interdictor (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Interdictor (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Interdictor (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Interdictor (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Interdictor (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Interdictor (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MG (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MG (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MG (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MG (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MG (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MG (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MRM (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MRM (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MRM (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MRM (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MRM (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA MRM (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Pop Up Mine (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Pop Up Mine (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Pop Up Mine (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Pop Up Mine (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Pop Up Mine (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA Pop Up Mine (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA SRM (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA SRM (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA SRM (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA SRM (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Liao/Shen Long BA SRM (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Liao/Shen Long BA SRM (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (David LGR) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (David LGR) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (David LGR) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (David LGR) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (David LGR) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (David LGR) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (FireDrake) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (FireDrake) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (FireDrake) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (FireDrake) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (FireDrake) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (FireDrake) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (ImpSensors) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (ImpSensors) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (ImpSensors) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (ImpSensors) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (ImpSensors) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (ImpSensors) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (Light TAG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (Light TAG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (Light TAG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (Light TAG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (Light TAG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (Light TAG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (MG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (MG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (MG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (MG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (MG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Leonidas BA (MG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Ogre BA  (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Ogre BA  (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Ogre BA  (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Ogre BA  (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Interdictor)  (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Interdictor)  (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Interdictor)  (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Interdictor)  (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Interdictor) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Interdictor) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Ogre BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA A (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA A (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA A (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA A (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA A (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA A (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA B (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA B (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA B (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA B (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA B (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA B (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA C (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA C (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA C (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA C (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA C (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Marik/Xiphos Assault BA C (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Merc/Marauder BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Merc/Marauder BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Merc/Marauder BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Merc/Marauder BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Merc/Marauder BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Merc/Marauder BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Merc/Spectre Stealth BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Merc/Spectre Stealth BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Merc/Spectre Stealth BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Merc/Spectre Stealth BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Merc/Spectre Stealth BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Merc/Spectre Stealth BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Gray Death Strike Suit (HarJel)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Gray Death Strike Suit (HarJel)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Gray Death Strike Suit (HarJel)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Gray Death Strike Suit (HarJel)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Gray Death Strike Suit (HarJel)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Gray Death Strike Suit (HarJel)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK C3 HRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK C3 HRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK C3 HRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK C3 HRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK C3 HRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK C3 HRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK SVSP Magshot] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK SVSP Magshot] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK SVSP Magshot] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK SVSP Magshot] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK SVSP Magshot] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [HK SVSP Magshot] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [Heavy Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [Heavy Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [Heavy Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [Heavy Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [Heavy Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Grenadier BA [Heavy Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Infiltrator Mk. II BA (Marine) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Infiltrator Mk. II BA (Marine) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Infiltrator Mk. II BA (Marine) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Infiltrator Mk. II BA (Marine) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Infiltrator Mk. II BA (Marine) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Infiltrator Mk. II BA (Marine) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Ironhold Assault BA (Anti-Tank) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Ironhold Assault BA (Anti-Tank) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Ironhold Assault BA (Anti-Tank) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Ironhold Assault BA (Anti-Tank) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Ironhold Assault BA (Anti-Tank) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Ironhold Assault BA (Anti-Tank) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kobold BA IIC (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kobold BA IIC (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kobold BA IIC (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kobold BA IIC (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kobold BA IIC (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kobold BA IIC (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (AI Mk II) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (AI Mk II) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (AI Mk II) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (AI Mk II) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (AI Mk II) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (AI Mk II) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (Mortar) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (Mortar) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (Mortar) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (Mortar) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (Mortar) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA (Mortar) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA AI Mk IIr (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA AI Mk IIr (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA AI Mk IIr (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA AI Mk IIr (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA AI Mk IIr (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Kopis Assault BA AI Mk IIr (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Phalanx BA  (D) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Phalanx BA  (D) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Phalanx BA  (D) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Phalanx BA  (D) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Phalanx BA  (D) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Phalanx BA  (D) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (Flamer) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (Flamer) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (Flamer) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (Flamer) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (Flamer) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (Flamer) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (HMG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (HMG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (HMG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (HMG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (HMG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Raiden BA II (HMG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Ravager Assault BA (LRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Ravager Assault BA (LRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Ravager Assault BA (LRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Ravager Assault BA (LRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Ravager Assault BA (LRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Ravager Assault BA (LRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Rogue Bear Heavy BA (Upgrade)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Rogue Bear Heavy BA (Upgrade)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Rogue Bear Heavy BA (Upgrade)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Rogue Bear Heavy BA (Upgrade)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Rogue Bear Heavy BA (Upgrade)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Rogue Bear Heavy BA (Upgrade)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Sloth BA (Huntsman) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Sloth BA (Huntsman) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Sloth BA (Huntsman) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Sloth BA (Huntsman) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Sloth BA (Huntsman) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Sloth BA (Huntsman) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [ER] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [ER] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [ER] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [ER] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [ER] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [ER] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [LBX] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [LBX] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [LBX] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [LBX] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [LBX] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [LBX] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [Pulse] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [Pulse] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [Pulse] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [Pulse] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [Pulse] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Thunderbird BA (Upgrade) [Pulse] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Warg Assault BA (Reactive)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Warg Assault BA (Reactive)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Warg Assault BA (Reactive)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Warg Assault BA (Reactive)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/NTNU RS/Warg Assault BA (Reactive)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/NTNU RS/Warg Assault BA (Reactive)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Centaur BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Centaur BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Centaur BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Centaur BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Centaur BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Centaur BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (David LGR) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (David LGR) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (David LGR) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (David LGR) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (David LGR) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (David LGR) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (GL) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (GL) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (GL) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (GL) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (GL) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (GL) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (MG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (MG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (MG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (MG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (MG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Quirinus BA (MG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (Flamer) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (Flamer) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (Flamer) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (Flamer) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (Flamer) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (Flamer) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (HMG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (HMG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (HMG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (HMG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (HMG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (HMG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (LRR) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (LRR) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (LRR) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (LRR) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (LRR) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (LRR) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (SL) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (SL) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (SL) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (SL) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Simian BA (SL) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Simian BA (SL) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Taranis BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Taranis BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Taranis BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Taranis BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Republic/Taranis BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Republic/Taranis BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Cuchulainn SA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Cuchulainn SA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Cuchulainn SA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Cuchulainn SA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Cuchulainn SA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Cuchulainn SA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (AI) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (AI) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (AI) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (AI) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (AI) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (AI) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (LRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (LRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (LRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (LRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (LRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (LRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (ML) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (ML) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (ML) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (ML) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (ML) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (ML) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (MRR) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (MRR) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (MRR) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (MRR) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (MRR) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (MRR) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (SRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (SRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (SRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (SRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (SRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/Fenrir II Assault BA (SRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Firedrake) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Firedrake) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Firedrake) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Firedrake) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Firedrake) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Firedrake) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (ISensors) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (ISensors) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (ISensors) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (ISensors) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (ISensors) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (ISensors) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Light TAG) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Light TAG) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Light TAG) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Light TAG) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Light TAG) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Light TAG) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Mine) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Mine) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Mine) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Mine) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Mine) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Mine) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Remote Sensors) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Remote Sensors) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Remote Sensors) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Remote Sensors) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Remote Sensors) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3145/Steiner/GD Infiltrator Suit (Remote Sensors) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[MRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[MRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[MRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[MRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[MRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[MRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[PPC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[PPC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[PPC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[PPC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[PPC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[PPC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[SRM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[SRM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[SRM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[SRM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Cavalier II BA[SRM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Cavalier II BA[SRM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [LRR](Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [LRR](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [LRR](Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [LRR](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [LRR](Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [LRR](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [SL](Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [SL](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [SL](Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [SL](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [SL](sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Baka) [SL](sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [David](Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [David](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [David](Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [David](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [David](Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [David](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [MG](Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [MG](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [MG](Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [MG](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [MG](Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/IS Standard BA (Fa Sure) [MG](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Kanazuchi Assault BA (Support)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Kanazuchi Assault BA (Support)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Kanazuchi Assault BA (Support)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Kanazuchi Assault BA (Support)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Kanazuchi Assault BA (Support)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Kanazuchi Assault BA (Support)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Longinus C BA [MRR] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Longinus C BA [MRR] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Longinus C BA [MRR] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Longinus C BA [MRR] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Longinus C BA [MRR] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Longinus C BA [MRR] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Longinus C BA [PPC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/3150/Longinus C BA [PPC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Longinus C BA [PPC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/3150/Longinus C BA [PPC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/3150/Longinus C BA [PPC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/3150/Longinus C BA [PPC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Golden Century/Rhino BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Rhino BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Golden Century/Rhino BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Rhino BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Golden Century/Rhino BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Rhino BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Golden Century/Water Elemental Mining Suit (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Jihad FR/Machina Domini Interface Armor.blk
+++ b/data/mekfiles/battlearmor/Jihad FR/Machina Domini Interface Armor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/OTP/Fronc Reaches/TinStar BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/OTP/Fronc Reaches/TinStar BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/OTP/Fronc Reaches/TinStar BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/OTP/Fronc Reaches/TinStar BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/OTP/Fronc Reaches/TinStar BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/OTP/Fronc Reaches/TinStar BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Elemental II BA Standard (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Elemental II BA Standard (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Elemental II BA Standard (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Elemental II BA Standard (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Elemental II BA Standard (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Elemental II BA Standard (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gladiator-S Exo (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Gray Death SA Production (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gray Death SA Production (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Gray Death SA Production (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gray Death SA Production (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Gray Death SA Production (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Gray Death SA Production (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Hauberk BA Commando (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Hauberk BA Commando (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Hauberk BA Commando (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Hauberk BA Commando (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Hauberk BA Commando (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Hauberk BA Commando (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Rogue Bear Heavy BA Hybrid (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Rogue Bear Heavy BA Hybrid (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Rogue Bear Heavy BA Hybrid (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Rogue Bear Heavy BA Hybrid (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Rogue Bear Heavy BA Hybrid (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Rogue Bear Heavy BA Hybrid (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Sylph BA Enhanced (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Sylph BA Enhanced (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Sylph BA Enhanced (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Sylph BA Enhanced (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Sylph BA Enhanced (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Sylph BA Enhanced (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Void Med BA Minelayer (Sqd4).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Void Med BA Minelayer (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Void Med BA Minelayer (Sqd5).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Void Med BA Minelayer (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ProtoTypes/Void Med BA Minelayer (Sqd6).blk
+++ b/data/mekfiles/battlearmor/ProtoTypes/Void Med BA Minelayer (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 28/TinStar BattleArmor (Original)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 28/TinStar BattleArmor (Original)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 28/TinStar BattleArmor (Original)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 28/TinStar BattleArmor (Original)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 28/TinStar BattleArmor (Original)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 28/TinStar BattleArmor (Original)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Advanced)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Advanced)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Advanced)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Advanced)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Advanced)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Advanced)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 29/Dragoon Battle Armor (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Jade Falcon) (Sqd 4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Jade Falcon) (Sqd 4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Jade Falcon) (Sqd 5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Jade Falcon) (Sqd 5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Jade Falcon) (Sqd 6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Jade Falcon) (Sqd 6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 30/Stormbird Battle Armor (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [Bearhunter](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [Bearhunter](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [Bearhunter](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [Bearhunter](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [Bearhunter](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [Bearhunter](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [ER Laser](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [ER Laser](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [ER Laser](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [ER Laser](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [ER Laser](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [ER Laser](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [HMG](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [HMG](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [HMG](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [HMG](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [HMG](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto A BA [HMG](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [MRR](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [MRR](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [MRR](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [MRR](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [MRR](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [MRR](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [SRM](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [SRM](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [SRM](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [SRM](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [SRM](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 31/Callisto B BA [SRM](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 32/IS Standard Battle Armor [Magnetic](Sqd4).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 32/IS Standard Battle Armor [Magnetic](Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 32/IS Standard Battle Armor [Magnetic](Sqd5).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 32/IS Standard Battle Armor [Magnetic](Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 32/IS Standard Battle Armor [Magnetic](Sqd6).blk
+++ b/data/mekfiles/battlearmor/Rec Guides ilClan/Vol 32/IS Standard Battle Armor [Magnetic](Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Shrapnel/Vol 8/Gray Death Scout Suit (Reaper)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/Shrapnel/Vol 8/Gray Death Scout Suit (Reaper)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Shrapnel/Vol 8/Gray Death Scout Suit (Reaper)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/Shrapnel/Vol 8/Gray Death Scout Suit (Reaper)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/Shrapnel/Vol 8/Gray Death Scout Suit (Reaper)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/Shrapnel/Vol 8/Gray Death Scout Suit (Reaper)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Ailette Zero-G Engineering Exo (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Ailette Zero-G Engineering Exo (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Ailette Zero-G Engineering Exo (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Ailette Zero-G Engineering Exo (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Ailette Zero-G Engineering Exo (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Ailette Zero-G Engineering Exo (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [AG]  (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [AG]  (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [AG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [AG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [AG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [AG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [BC ID]  (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [BC ID]  (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [BC ID] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [BC ID] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [BC ID] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gladiator Exo [BC ID] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gorilla Exo 'Falcata' (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gorilla Exo 'Falcata' (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gorilla Exo 'Falcata' (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gorilla Exo 'Falcata' (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gorilla Exo 'Falcata' (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gorilla Exo 'Falcata' (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gorilla Exo PEX-2B (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gorilla Exo PEX-2B (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gorilla Exo PEX-2B (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gorilla Exo PEX-2B (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Gorilla Exo PEX-2B (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Gorilla Exo PEX-2B (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [AG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [AG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [AG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [AG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [AG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [AG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [BM] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [BM] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [BM] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [BM] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [BM] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [BM] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [CL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [CL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [CL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [CL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [CL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [CL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [ID] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [ID] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [ID] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [ID] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [ID] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [ID] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [MC] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [MC] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [MC] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [MC] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [MC] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [MC] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [SA] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [SA] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [SA] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [SA] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [SA] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Groundhog Exo CEX-205 [SA] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/HeavyHauler Exo (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Krise PA(L) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/PowerLoader Exo P-5000 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/PowerLoader Exo P-5000 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/PowerLoader Exo P-5000 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/PowerLoader Exo P-5000 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/PowerLoader Exo P-5000 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/PowerLoader Exo P-5000 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Interdictor) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Interdictor) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Interdictor) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Interdictor) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Interdictor) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Interdictor) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Scout) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Scout) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Scout) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Scout) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Scout) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Scout) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Spotter) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Spotter) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Spotter) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Spotter) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Spotter) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Spotter) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sup) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sup) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sup) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sup) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sup) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Resgate PA(L) (Sup) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Mine Clearance] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Mine Clearance] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Mine Clearance] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Mine Clearance] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Mine Clearance] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Mine Clearance] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Salvage Arm] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Salvage Arm] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Salvage Arm] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Salvage Arm] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Salvage Arm] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Salrilla Exo [Salvage Arm] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) II (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) II (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) II (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) II (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) II (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) II (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) III (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) III (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) III (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) III (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) III (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothdavid PA(L) III (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothgoliath PA(L) II (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothgoliath PA(L) II (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothgoliath PA(L) II (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothgoliath PA(L) II (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Smoothgoliath PA(L) II (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Smoothgoliath PA(L) II (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [AG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [ID] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [ID] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [ID] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [ID] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [ID] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo I [ID] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [AG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [AG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [AG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [AG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [AG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [AG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [ID] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [ID] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [ID] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [ID] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [ID] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo II [ID] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [AG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [AG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [AG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [AG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [AG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [AG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [ID] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [ID] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [ID] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [ID] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [ID] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo III [ID] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-GL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-GL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-GL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-GL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-GL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-GL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-LMG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-LMG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-LMG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-LMG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-LMG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [AG-LMG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-GL] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-GL] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-GL] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-GL] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-GL] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-GL] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-LMG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-LMG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-LMG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-LMG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-LMG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/TRO VA/Tunnel Rat Mining Exo IV [BC-LMG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ToS/Kandersteg/Hantu AIX-210(Sqd4).blk
+++ b/data/mekfiles/battlearmor/ToS/Kandersteg/Hantu AIX-210(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ToS/Kandersteg/Hantu AIX-210(Sqd5).blk
+++ b/data/mekfiles/battlearmor/ToS/Kandersteg/Hantu AIX-210(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/ToS/Kandersteg/Hantu AIX-210(Sqd6).blk
+++ b/data/mekfiles/battlearmor/ToS/Kandersteg/Hantu AIX-210(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Elemental II BA X (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Elemental II BA X (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Elemental II BA X (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Elemental II BA X (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Elemental II BA X (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Elemental II BA X (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Rogue Bear Heavy BA HR (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Rogue Bear Heavy BA HR (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Rogue Bear Heavy BA HR (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Rogue Bear Heavy BA HR (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Rogue Bear Heavy BA HR (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Rogue Bear Heavy BA HR (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Sylph XR (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Sylph XR (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Sylph XR (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Sylph XR (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Clans/Sylph XR (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Clans/Sylph XR (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Comstar/Kobold X-C3 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Comstar/Kobold X-C3 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Comstar/Kobold X-C3 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Comstar/Kobold X-C3 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Comstar/Kobold X-C3 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Comstar/Kobold X-C3 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Comstar/Tornado PA(L) P17 Hurricane (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Comstar/Tornado PA(L) P17 Hurricane (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Comstar/Tornado PA(L) P17 Hurricane (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Comstar/Tornado PA(L) P17 Hurricane (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Comstar/Tornado PA(L) P17 Hurricane (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Comstar/Tornado PA(L) P17 Hurricane (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Davion/Hauberk BA U15 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Davion/Hauberk BA U15 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Davion/Hauberk BA U15 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Davion/Hauberk BA U15 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Davion/Hauberk BA U15 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Davion/Hauberk BA U15 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Davion/Infiltrator Mk. II BA Coral Intent (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Davion/Infiltrator Mk. II BA Coral Intent (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Davion/Infiltrator Mk. II BA Coral Intent (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Davion/Infiltrator Mk. II BA Coral Intent (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Davion/Infiltrator Mk. II BA Coral Intent (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Davion/Infiltrator Mk. II BA Coral Intent (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Gladiator Exo The Spider (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Gladiator Exo The Spider (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Gladiator Exo The Spider (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Gladiator Exo The Spider (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Gladiator Exo The Spider (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Gladiator Exo The Spider (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Gray Death Scout Suit The Willow Wisps (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Gray Death Scout Suit The Willow Wisps (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Gray Death Scout Suit The Willow Wisps (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Gray Death Scout Suit The Willow Wisps (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Gray Death Scout Suit The Willow Wisps (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Gray Death Scout Suit The Willow Wisps (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/IS Standard BA [Hive] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/IS Standard BA [Hive] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/IS Standard BA [Hive] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/IS Standard BA [Hive] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/IS Standard BA [Hive] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/IS Standard BA [Hive] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Kanazuchi Assault BA Cyclops (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Kanazuchi Assault BA Cyclops (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Kanazuchi Assault BA Cyclops (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Kanazuchi Assault BA Cyclops (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Gladiator/Kanazuchi Assault BA Cyclops (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Gladiator/Kanazuchi Assault BA Cyclops (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Kurita/Kage Light BA C (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Kurita/Kage Light BA C (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Kurita/Kage Light BA C (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Kurita/Kage Light BA C (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Kurita/Kage Light BA C (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Kurita/Kage Light BA C (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Kurita/Void Med BA Caltrop (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Kurita/Void Med BA Caltrop (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Kurita/Void Med BA Caltrop (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Kurita/Void Med BA Caltrop (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Kurita/Void Med BA Caltrop (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Kurita/Void Med BA Caltrop (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Liao/Fa Shih BA 2 [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Liao/Fa Shih BA 2 [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Liao/Fa Shih BA 2 [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Liao/Fa Shih BA 2 [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Liao/Fa Shih BA 2 [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Liao/Fa Shih BA 2 [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Liao/Trinity Med BA (Ying Long BC3)[David] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Liao/Trinity Med BA (Ying Long BC3)[David] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Liao/Trinity Med BA (Ying Long BC3)[David] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Liao/Trinity Med BA (Ying Long BC3)[David] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Liao/Trinity Med BA (Ying Long BC3)[David] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Liao/Trinity Med BA (Ying Long BC3)[David] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [David] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [David] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [David] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [David] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [David] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [David] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [MG] (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [MG] (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [MG] (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [MG] (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [MG] (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Marik/Longinus BA Hacked [MG] (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer Flamer (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer Flamer (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer Flamer (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer Flamer (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer Flamer (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer Flamer (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer MG (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer MG (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer MG (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer MG (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer MG (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer MG (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer SL (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer SL (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer SL (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer SL (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer SL (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Djinn BA (Reflec) Terrorizer SL (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Most Wanted/Groundhog Exo Master Thief (Sqd1).blk
+++ b/data/mekfiles/battlearmor/XTRs/Most Wanted/Groundhog Exo Master Thief (Sqd1).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Periphery/Ailette Rescue PA(L)(Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Periphery/Ailette Rescue PA(L)(Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Periphery/Ailette Rescue PA(L)(Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Periphery/Ailette Rescue PA(L)(Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Periphery/Ailette Rescue PA(L)(Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Periphery/Ailette Rescue PA(L)(Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra APG (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra APG (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra APG (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra APG (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra APG (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra APG (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra ER Small (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra ER Small (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra ER Small (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra ER Small (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra ER Small (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra ER Small (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra MRR (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra MRR (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra MRR (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra MRR (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra MRR (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra MRR (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra SPulse (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra SPulse (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra SPulse (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra SPulse (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra SPulse (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Purifier BA Terra SPulse (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Tornado PA(L) G17 (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Tornado PA(L) G17 (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Tornado PA(L) G17 (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Tornado PA(L) G17 (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Phantoms/Tornado PA(L) G17 (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Phantoms/Tornado PA(L) G17 (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic I/Surat Solahma Suit (Grey Death) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic I/Surat Solahma Suit (Grey Death) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic I/Surat Solahma Suit (Grey Death) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic I/Surat Solahma Suit (Grey Death) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic I/Surat Solahma Suit (Grey Death) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic I/Surat Solahma Suit (Grey Death) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Thunderbird II BA (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Thunderbird II BA (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Thunderbird II BA (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Thunderbird II BA (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Thunderbird II BA (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Thunderbird II BA (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (C3) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (C3) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (C3) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (C3) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (C3) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (C3) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (LRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (LRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (LRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (LRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (LRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (LRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (SRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (SRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (SRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (SRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (SRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (SRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (aSRM) (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (aSRM) (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (aSRM) (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (aSRM) (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (aSRM) (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic II/Tortoise II (aSRM) (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Aegis Point Defense Suit (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Aegis Point Defense Suit (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Aegis Point Defense Suit (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Aegis Point Defense Suit (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Aegis Point Defense Suit (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Aegis Point Defense Suit (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Clan Interface Armor (Sqd1).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Clan Interface Armor (Sqd1).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA A (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA A (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA A (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA A (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA A (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA A (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA B (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA C (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Republic III/Grenadier II BA D (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Royal Fantasy/Gnome BA 'Dwarf_.blk
+++ b/data/mekfiles/battlearmor/XTRs/Royal Fantasy/Gnome BA 'Dwarf_.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Royal Fantasy/Sylph BA 'TinkerBelle'.blk
+++ b/data/mekfiles/battlearmor/XTRs/Royal Fantasy/Sylph BA 'TinkerBelle'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Royal Fantasy/Undine BA 'Sebastian'.blk
+++ b/data/mekfiles/battlearmor/XTRs/Royal Fantasy/Undine BA 'Sebastian'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Steiner/Fenrir BA Longshot (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Steiner/Fenrir BA Longshot (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Steiner/Fenrir BA Longshot (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Steiner/Fenrir BA Longshot (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Steiner/Fenrir BA Longshot (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Steiner/Fenrir BA Longshot (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Steiner/Gray Death SA Prototype (Sqd4).blk
+++ b/data/mekfiles/battlearmor/XTRs/Steiner/Gray Death SA Prototype (Sqd4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Steiner/Gray Death SA Prototype (Sqd5).blk
+++ b/data/mekfiles/battlearmor/XTRs/Steiner/Gray Death SA Prototype (Sqd5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/battlearmor/XTRs/Steiner/Gray Death SA Prototype (Sqd6).blk
+++ b/data/mekfiles/battlearmor/XTRs/Steiner/Gray Death SA Prototype (Sqd6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Boeing Jump Bomber.blk
+++ b/data/mekfiles/convfighter/3039u/Boeing Jump Bomber.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Boomerang Spotter Plane.blk
+++ b/data/mekfiles/convfighter/3039u/Boomerang Spotter Plane.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Guardian Fighter B.blk
+++ b/data/mekfiles/convfighter/3039u/Guardian Fighter B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Guardian Fighter C.blk
+++ b/data/mekfiles/convfighter/3039u/Guardian Fighter C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Guardian Fighter D.blk
+++ b/data/mekfiles/convfighter/3039u/Guardian Fighter D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Guardian Fighter.blk
+++ b/data/mekfiles/convfighter/3039u/Guardian Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Bat Hawk.blk
+++ b/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Bat Hawk.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Inseki II.blk
+++ b/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Inseki II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Inseki.blk
+++ b/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Inseki.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Meteor-G.blk
+++ b/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Meteor-G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Meteor-U.blk
+++ b/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Meteor-U.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Meteor.blk
+++ b/data/mekfiles/convfighter/3039u/Heavy Strike Fighter Meteor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Andurien.blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Andurien.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Angel (Upgrade).blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Angel (Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Angel.blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Angel.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Comet.blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Comet.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Owl II.blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Owl II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Owl III.blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Owl III.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Owl.blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Owl.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Light Strike Fighter Suzume (Sparrow).blk
+++ b/data/mekfiles/convfighter/3039u/Light Strike Fighter Suzume (Sparrow).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Mechbuster (LB-X).blk
+++ b/data/mekfiles/convfighter/3039u/Mechbuster (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Mechbuster (Laser).blk
+++ b/data/mekfiles/convfighter/3039u/Mechbuster (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Mechbuster (SRM).blk
+++ b/data/mekfiles/convfighter/3039u/Mechbuster (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Mechbuster.blk
+++ b/data/mekfiles/convfighter/3039u/Mechbuster.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Crane).blk
+++ b/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Crane).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Defender II).blk
+++ b/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Defender II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Defender).blk
+++ b/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Defender).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Kaiseradler).blk
+++ b/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Kaiseradler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Steinadler).blk
+++ b/data/mekfiles/convfighter/3039u/Medium Strike Fighter (Steinadler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Planetlifter Air Transport (SuperPelican - Waddle).blk
+++ b/data/mekfiles/convfighter/3039u/Planetlifter Air Transport (SuperPelican - Waddle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3039u/Planetlifter Air Transport.blk
+++ b/data/mekfiles/convfighter/3039u/Planetlifter Air Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3075U/Stork Light Refueling Craft (Original).blk
+++ b/data/mekfiles/convfighter/3075U/Stork Light Refueling Craft (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3075U/Stork Light Refueling Craft (Standard ).blk
+++ b/data/mekfiles/convfighter/3075U/Stork Light Refueling Craft (Standard ).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3145 NTNU/Medium Strike Fighter Defender II C.blk
+++ b/data/mekfiles/convfighter/3145 NTNU/Medium Strike Fighter Defender II C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/3145/Liao/Saroyan Jump Bomber.blk
+++ b/data/mekfiles/convfighter/3145/Liao/Saroyan Jump Bomber.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/HBHL/Katya Ground Assault Craft (RL10).blk
+++ b/data/mekfiles/convfighter/HBHL/Katya Ground Assault Craft (RL10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/HBHL/Katya Ground Assault Craft (RL15).blk
+++ b/data/mekfiles/convfighter/HBHL/Katya Ground Assault Craft (RL15).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/HBHL/Katya Ground Assault Craft (RL20).blk
+++ b/data/mekfiles/convfighter/HBHL/Katya Ground Assault Craft (RL20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/HBHS/Raubvogel Aerobomber AB-18C.blk
+++ b/data/mekfiles/convfighter/HBHS/Raubvogel Aerobomber AB-18C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/HBMPS/Bluehawk Combat Support Fighter MSF-42.blk
+++ b/data/mekfiles/convfighter/HBMPS/Bluehawk Combat Support Fighter MSF-42.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/HBMPS/Protector Combat Support Fighter ASF-23.blk
+++ b/data/mekfiles/convfighter/HBMPS/Protector Combat Support Fighter ASF-23.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/ProtoTypes/Bullet Suicide Drone.blk
+++ b/data/mekfiles/convfighter/ProtoTypes/Bullet Suicide Drone.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/ProtoTypes/Drake Medium Stealth Fighter.blk
+++ b/data/mekfiles/convfighter/ProtoTypes/Drake Medium Stealth Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/ProtoTypes/Planetlifter Tactical Support.blk
+++ b/data/mekfiles/convfighter/ProtoTypes/Planetlifter Tactical Support.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/ProtoTypes/Seabuster Strike Fighter (Production).blk
+++ b/data/mekfiles/convfighter/ProtoTypes/Seabuster Strike Fighter (Production).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Chariot High-Speed Medevac.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Chariot High-Speed Medevac.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Comet Airliner ACL-800.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Comet Airliner ACL-800.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Delta Air Cruiser.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Delta Air Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Graceful Crane Air Bus.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Graceful Crane Air Bus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Jetta Coruna 4X.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Jetta Coruna 4X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/King Karnov Transport KC-6.blk
+++ b/data/mekfiles/convfighter/TRO VAr/King Karnov Transport KC-6.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/King Karnov Transport.blk
+++ b/data/mekfiles/convfighter/TRO VAr/King Karnov Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Longhaul Cargo Aircraft FB-335.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Longhaul Cargo Aircraft FB-335.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Mosquito Radar Plane IX.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Mosquito Radar Plane IX.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Protector High-Speed Medevac.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Protector High-Speed Medevac.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/S 2772 Airplane.blk
+++ b/data/mekfiles/convfighter/TRO VAr/S 2772 Airplane.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Stratos Airliner WK-1000.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Stratos Airliner WK-1000.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber (Original).blk
+++ b/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Torrent Heavy Bomber.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/TRO VAr/Zanadu Air Bus.blk
+++ b/data/mekfiles/convfighter/TRO VAr/Zanadu Air Bus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Boondocks/Drake Medium Strike Fighter.blk
+++ b/data/mekfiles/convfighter/XTRs/Boondocks/Drake Medium Strike Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Corporations/Planetlifter Support Aircraft.blk
+++ b/data/mekfiles/convfighter/XTRs/Corporations/Planetlifter Support Aircraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Periphery/SeaBuster Strike Fighter (Early).blk
+++ b/data/mekfiles/convfighter/XTRs/Periphery/SeaBuster Strike Fighter (Early).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Primitives I/Hurricane Conventional Fighter.blk
+++ b/data/mekfiles/convfighter/XTRs/Primitives I/Hurricane Conventional Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Primitives III/Vendetta Medium Fighter.blk
+++ b/data/mekfiles/convfighter/XTRs/Primitives III/Vendetta Medium Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Primitives IV/Mustang Fighter.blk
+++ b/data/mekfiles/convfighter/XTRs/Primitives IV/Mustang Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Primitives V/Colt Medium Fighter (LRM).blk
+++ b/data/mekfiles/convfighter/XTRs/Primitives V/Colt Medium Fighter (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Primitives V/Colt Medium Fighter (SRM).blk
+++ b/data/mekfiles/convfighter/XTRs/Primitives V/Colt Medium Fighter (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/convfighter/XTRs/Succession Wars/Tsuru VIP Aircraft.blk
+++ b/data/mekfiles/convfighter/XTRs/Succession Wars/Tsuru VIP Aircraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBHK/Gaajian System Patrol Boat (2485).blk
+++ b/data/mekfiles/dropships/HBHK/Gaajian System Patrol Boat (2485).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBHK/Gaajian System Patrol Boat (3060).blk
+++ b/data/mekfiles/dropships/HBHK/Gaajian System Patrol Boat (3060).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBHK/Hoshiryokou Tug Boat.blk
+++ b/data/mekfiles/dropships/HBHK/Hoshiryokou Tug Boat.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBHK/Hoshiryokou.blk
+++ b/data/mekfiles/dropships/HBHK/Hoshiryokou.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBMPS/Aqueduct Liquid Carrier.blk
+++ b/data/mekfiles/dropships/HBMPS/Aqueduct Liquid Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBMPS/Princess Luxury Liner (Cargo).blk
+++ b/data/mekfiles/dropships/HBMPS/Princess Luxury Liner (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/HBMPS/Princess Luxury Liner.blk
+++ b/data/mekfiles/dropships/HBMPS/Princess Luxury Liner.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (2756 Cargo).blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (2756 Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (2756 Carrier).blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (2756 Carrier).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (2756 Troop Transport).blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (2756 Troop Transport).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (BattleMech Carrier).blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Lee (BattleMech Carrier).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/M3 Drone CASPAR.blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/M3 Drone CASPAR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Model 96C 'Howdah' .blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Model 96C 'Howdah' .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Pueblo (2673).blk
+++ b/data/mekfiles/dropships/Historicals/Liberation of Terra I and II/Pueblo (2673).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Reunification War/Jumbo.blk
+++ b/data/mekfiles/dropships/Historicals/Reunification War/Jumbo.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Historicals/Wars of the Republic Era/Polaris.blk
+++ b/data/mekfiles/dropships/Historicals/Wars of the Republic Era/Polaris.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/JHS - Terra/Cockatrice Monitor Platform (Drone).blk
+++ b/data/mekfiles/dropships/JHS - Terra/Cockatrice Monitor Platform (Drone).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/JHS - Terra/Dragau Assault Interceptor (CASPAR II Drone).blk
+++ b/data/mekfiles/dropships/JHS - Terra/Dragau Assault Interceptor (CASPAR II Drone).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/JHS - Terra/Tiamat Pocket Warship (CASPAR II Drone).blk
+++ b/data/mekfiles/dropships/JHS - Terra/Tiamat Pocket Warship (CASPAR II Drone).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Jihad Secrets - Blake Documents/Danais.blk
+++ b/data/mekfiles/dropships/Jihad Secrets - Blake Documents/Danais.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Jihad Secrets - Blake Documents/Trojan (Blockade Runner).blk
+++ b/data/mekfiles/dropships/Jihad Secrets - Blake Documents/Trojan (Blockade Runner).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Mingo.blk
+++ b/data/mekfiles/dropships/Mingo.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Other/Buccaneer Rezak.blk
+++ b/data/mekfiles/dropships/Other/Buccaneer Rezak.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Other/Lion (3052) (WD).blk
+++ b/data/mekfiles/dropships/Other/Lion (3052) (WD).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Other/Rose (Bara no Ryu) (Hive).blk
+++ b/data/mekfiles/dropships/Other/Rose (Bara no Ryu) (Hive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/Other/Union (3070).blk
+++ b/data/mekfiles/dropships/Other/Union (3070).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/ProtoTypes/Clan/Outpost (Defender).blk
+++ b/data/mekfiles/dropships/ProtoTypes/Clan/Outpost (Defender).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/ProtoTypes/Clan/Titan (Monitor).blk
+++ b/data/mekfiles/dropships/ProtoTypes/Clan/Titan (Monitor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/ProtoTypes/IS/Claymore V3.blk
+++ b/data/mekfiles/dropships/ProtoTypes/IS/Claymore V3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/ProtoTypes/IS/Lung Wang P2.blk
+++ b/data/mekfiles/dropships/ProtoTypes/IS/Lung Wang P2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/ProtoTypes/IS/Merlin R1.blk
+++ b/data/mekfiles/dropships/ProtoTypes/IS/Merlin R1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/ProtoTypes/IS/Vengeance DC.blk
+++ b/data/mekfiles/dropships/ProtoTypes/IS/Vengeance DC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Behemoth C (2848).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Behemoth C (2848).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Behemoth C (Arcship).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Behemoth C (Arcship).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Broadsword (2979).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Broadsword (2979).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Carrier (2882).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Carrier (2882).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Confederate C (3048).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Confederate C (3048).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Lion (2835).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Lion (2835).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Lion (3005) (WD).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Lion (3005) (WD).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Miraborg (3053).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Miraborg (3053).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Mule C (2842).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Mule C (2842).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Noruff (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Noruff (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Overlord C (2818) (Tank).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Overlord C (2818) (Tank).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Overlord C (2818).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Overlord C (2818).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Sassanid (2875).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Sassanid (2875).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Titan (2953).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Titan (2953).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Union C (2829) (Tank).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Union C (2829) (Tank).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Union C (2829).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Union C (2829).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/Clan/Union C (2840) (Cargo).blk
+++ b/data/mekfiles/dropships/TRO3057R/Clan/Union C (2840) (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Achilles (2582).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Achilles (2582).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Achilles (2721).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Achilles (2721).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Achilles (2721b).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Achilles (2721b).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Achilles (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Achilles (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Avenger (2816).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Avenger (2816).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Avenger (3048).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Avenger (3048).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Behemoth (2658).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Behemoth (2658).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Behemoth (2782).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Behemoth (2782).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Buccaneer (2708).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Buccaneer (2708).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Buccaneer (2709).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Buccaneer (2709).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Buccaneer (2792).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Buccaneer (2792).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Cargo King (2790).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Cargo King (2790).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Cargomaster (2790).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Cargomaster (2790).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Claymore (3054).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Claymore (3054).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Condor (2801).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Condor (2801).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Condor (3035)Dove.blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Condor (3035)Dove.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Condor (3054).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Condor (3054).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Condor (3079).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Condor (3079).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Confederate (2602).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Confederate (2602).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Confederate (2602)Mech.blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Confederate (2602)Mech.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Excalibur (2786).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Excalibur (2786).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Excalibur (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Excalibur (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Fortress (2613).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Fortress (2613).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Fortress (3058).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Fortress (3058).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Fury (2638).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Fury (2638).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Fury (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Fury (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Gazelle (2531).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Gazelle (2531).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Gazelle (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Gazelle (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Gazelle (Heavy Vehicle).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Gazelle (Heavy Vehicle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Hamilcar (3054).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Hamilcar (3054).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Hamilcar (3084).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Hamilcar (3084).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Hannibal (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Hannibal (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Hercules (3053).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Hercules (3053).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Intruder (2655).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Intruder (2655).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Intruder (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Intruder (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Kuan Ti (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Kuan Ti (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Leopard (2537).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Leopard (2537).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Leopard (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Leopard (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Leopard CV (2581).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Leopard CV (2581).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Leopard CV (3054).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Leopard CV (3054).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Lion (2595).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Lion (2595).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Lung Wang (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Lung Wang (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Mammoth (2658).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Mammoth (2658).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Mammoth (2808).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Mammoth (2808).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Model 97 'Octopus' (3051).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Model 97 'Octopus' (3051).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Monarch (2759).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Monarch (2759).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Mule 'Q-Ship'.blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Mule 'Q-Ship'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Mule (2737).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Mule (2737).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Nagumo (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Nagumo (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Okinawa (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Okinawa (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Okinawa (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Okinawa (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Overlord (2762).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Overlord (2762).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Overlord (2762b).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Overlord (2762b).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Overlord (2775) (Combined Arms).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Overlord (2775) (Combined Arms).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Overlord (2809) (Klondike).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Overlord (2809) (Klondike).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Overlord (2817) (Command).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Overlord (2817) (Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Overlord (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Overlord (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Rose (Bara no Ryu) (3054).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Rose (Bara no Ryu) (3054).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Seeker (2815).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Seeker (2815).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Seeker (2815M).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Seeker (2815M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Seeker (3054).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Seeker (3054).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Titan (2647).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Titan (2647).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Titan (2647b).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Titan (2647b).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Triumph (2593).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Triumph (2593).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Triumph (2593b).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Triumph (2593b).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Triumph (3057).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Triumph (3057).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Union (2708) (Cargo).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Union (2708) (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Union (2708).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Union (2708).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Union (2708b).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Union (2708b).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Union (2709).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Union (2709).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Union (2710).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Union (2710).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Union (3055).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Union (3055).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Vengeance (2682).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Vengeance (2682).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3057R/IS/Vengeance (3056).blk
+++ b/data/mekfiles/dropships/TRO3057R/IS/Vengeance (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/Clan/Arcadia (3066).blk
+++ b/data/mekfiles/dropships/TRO3067/Clan/Arcadia (3066).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/Clan/Arcadia (3080).blk
+++ b/data/mekfiles/dropships/TRO3067/Clan/Arcadia (3080).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/Clan/Mercer (3065).blk
+++ b/data/mekfiles/dropships/TRO3067/Clan/Mercer (3065).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/Clan/Outpost (3063).blk
+++ b/data/mekfiles/dropships/TRO3067/Clan/Outpost (3063).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/Clan/Outpost (3070).blk
+++ b/data/mekfiles/dropships/TRO3067/Clan/Outpost (3070).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Conquistador (3063).blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Conquistador (3063).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Conquistador (Avalon One).blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Conquistador (Avalon One).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Merlin (3063).blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Merlin (3063).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Nekohono'o.blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Nekohono'o.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Overlord A3.blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Overlord A3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Overlord A3A.blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Overlord A3A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Union-X (3065).blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Union-X (3065).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3067/IS/Union-X (3071).blk
+++ b/data/mekfiles/dropships/TRO3067/IS/Union-X (3071).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Colossus Mk I.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Colossus Mk I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Colossus.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Colossus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Dictator (Command).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Dictator (Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Dictator.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Dictator.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Manatee (Cargo).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Manatee (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Manatee.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Manatee.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Model 96 'Elephant' Mk I.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Model 96 'Elephant' Mk I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Model 96 'Elephant'.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Model 96 'Elephant'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Mule (Star League Pocket Warship).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Mule (Star League Pocket Warship).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Pentagon 'Pocket Warship'.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Pentagon 'Pocket Warship'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Pentagon (2751).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Pentagon (2751).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Pentagon Mk I.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Pentagon Mk I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Pentagon.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Pentagon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Vampire.blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Vampire.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Vulture (2312).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Vulture (2312).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Vulture (2405).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Vulture (2405).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Age of War/Vulture (Cargo).blk
+++ b/data/mekfiles/dropships/TRO3075/Age of War/Vulture (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (BA).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (BA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (CV).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (CV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Cargo).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Combined Arms).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Combined Arms).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Gunship).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Gunship).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Tanker).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Tanker).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Vehicle).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora (Vehicle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora.blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Aurora.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Excalibur 'Pocket Warship'.blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Excalibur 'Pocket Warship'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Leopard 'Pocket Warship'.blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Leopard 'Pocket Warship'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Mule 'Pocket Warship'.blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Mule 'Pocket Warship'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Mule (Armored Pocket Warship).blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Mule (Armored Pocket Warship).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3075/Cutting Edge/Union 'Pocket Warship'.blk
+++ b/data/mekfiles/dropships/TRO3075/Cutting Edge/Union 'Pocket Warship'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/Clan/Aesir Assault Dropship.blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/Clan/Aesir Assault Dropship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/Clan/Isegrim Assault DropShip.blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/Clan/Isegrim Assault DropShip.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/Clan/Vanir Assault Dropship.blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/Clan/Vanir Assault Dropship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Arondight Pocket Warship (Refit).blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Arondight Pocket Warship (Refit).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Arondight Pocket Warship (SCC).blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Arondight Pocket Warship (SCC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Arondight Pocket Warship.blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Arondight Pocket Warship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Interdictor Pocket Warship (SCC).blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Interdictor Pocket Warship (SCC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Interdictor Pocket Warship (Sub-Capital).blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Interdictor Pocket Warship (Sub-Capital).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Interdictor Pocket Warship.blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Interdictor Pocket Warship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Taihou Assault Dropship.blk
+++ b/data/mekfiles/dropships/TRO3085/Cutting Edge/IS/Taihou Assault Dropship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/ONN/Nekohono'o (SCL).blk
+++ b/data/mekfiles/dropships/TRO3085/ONN/Nekohono'o (SCL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Supplemental/Dragau II Assault Interceptor.blk
+++ b/data/mekfiles/dropships/TRO3085/Supplemental/Dragau II Assault Interceptor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3085/Supplemental/Tiamat Pocket Warship.blk
+++ b/data/mekfiles/dropships/TRO3085/Supplemental/Tiamat Pocket Warship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/Marik/Gorgon Carrier.blk
+++ b/data/mekfiles/dropships/TRO3145/Marik/Gorgon Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/Marik/Seleucus Infantry Transport.blk
+++ b/data/mekfiles/dropships/TRO3145/Marik/Seleucus Infantry Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/Merc/Nagasawa.blk
+++ b/data/mekfiles/dropships/TRO3145/Merc/Nagasawa.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/NTNU RS/Achilles (3088).blk
+++ b/data/mekfiles/dropships/TRO3145/NTNU RS/Achilles (3088).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/NTNU RS/Dragau II (3097).blk
+++ b/data/mekfiles/dropships/TRO3145/NTNU RS/Dragau II (3097).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/NTNU RS/Interdictor Pocket Warship (3115).blk
+++ b/data/mekfiles/dropships/TRO3145/NTNU RS/Interdictor Pocket Warship (3115).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/NTNU RS/Tiamat II (3112).blk
+++ b/data/mekfiles/dropships/TRO3145/NTNU RS/Tiamat II (3112).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/NTNU RS/Vampire III.blk
+++ b/data/mekfiles/dropships/TRO3145/NTNU RS/Vampire III.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/Republic/Duat Military Transport.blk
+++ b/data/mekfiles/dropships/TRO3145/Republic/Duat Military Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3145/Steiner/Trutzburg.blk
+++ b/data/mekfiles/dropships/TRO3145/Steiner/Trutzburg.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/TRO3150/Castrum Pocket WarShip.blk
+++ b/data/mekfiles/dropships/TRO3150/Castrum Pocket WarShip.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Davion/Conquistador Blockade Runner.blk
+++ b/data/mekfiles/dropships/XTRs/Davion/Conquistador Blockade Runner.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Kurita/Nekohonoo HQ.blk
+++ b/data/mekfiles/dropships/XTRs/Kurita/Nekohonoo HQ.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Liao/Lung Wang Predator.blk
+++ b/data/mekfiles/dropships/XTRs/Liao/Lung Wang Predator.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Marik/Merlin Ngake.blk
+++ b/data/mekfiles/dropships/XTRs/Marik/Merlin Ngake.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Periphery/Vengeance Pocket Warship Prototype.blk
+++ b/data/mekfiles/dropships/XTRs/Periphery/Vengeance Pocket Warship Prototype.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Phantoms/Vampire II.blk
+++ b/data/mekfiles/dropships/XTRs/Phantoms/Vampire II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Pirates/Leopard PA.blk
+++ b/data/mekfiles/dropships/XTRs/Pirates/Leopard PA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives II/Black Eagle Dropship.blk
+++ b/data/mekfiles/dropships/XTRs/Primitives II/Black Eagle Dropship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives III/Czar Dropship (Armored Carrier).blk
+++ b/data/mekfiles/dropships/XTRs/Primitives III/Czar Dropship (Armored Carrier).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives III/Czar Dropship (Mech Carrier).blk
+++ b/data/mekfiles/dropships/XTRs/Primitives III/Czar Dropship (Mech Carrier).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives III/Czar Dropship.blk
+++ b/data/mekfiles/dropships/XTRs/Primitives III/Czar Dropship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives IV/DroST IIa (2445).blk
+++ b/data/mekfiles/dropships/XTRs/Primitives IV/DroST IIa (2445).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives IV/DroST IIa (2470).blk
+++ b/data/mekfiles/dropships/XTRs/Primitives IV/DroST IIa (2470).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives IV/Drost IIb (2445).blk
+++ b/data/mekfiles/dropships/XTRs/Primitives IV/Drost IIb (2445).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives IV/Drost IIb (2470).blk
+++ b/data/mekfiles/dropships/XTRs/Primitives IV/Drost IIb (2470).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Primitives V/Saturn Patrol Ship.blk
+++ b/data/mekfiles/dropships/XTRs/Primitives V/Saturn Patrol Ship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/dropships/XTRs/Steiner/Claymore Interceptor.blk
+++ b/data/mekfiles/dropships/XTRs/Steiner/Claymore Interceptor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Era Digests/Age of War/Firebird FR-1.blk
+++ b/data/mekfiles/fighters/Era Digests/Age of War/Firebird FR-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/FR 2765/Kurita/Star Dagger S-2B.blk
+++ b/data/mekfiles/fighters/FR 2765/Kurita/Star Dagger S-2B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/FR 2765/Liao/Thrush TR-5.blk
+++ b/data/mekfiles/fighters/FR 2765/Liao/Thrush TR-5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/FR 2765/Liao/Transit TR-9.blk
+++ b/data/mekfiles/fighters/FR 2765/Liao/Transit TR-9.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Chippewa IIC 2.blk
+++ b/data/mekfiles/fighters/Golden Century/Chippewa IIC 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Chippewa IIC.blk
+++ b/data/mekfiles/fighters/Golden Century/Chippewa IIC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Goth A.blk
+++ b/data/mekfiles/fighters/Golden Century/Goth A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Goth B.blk
+++ b/data/mekfiles/fighters/Golden Century/Goth B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Goth C.blk
+++ b/data/mekfiles/fighters/Golden Century/Goth C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Goth D.blk
+++ b/data/mekfiles/fighters/Golden Century/Goth D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Goth Prime.blk
+++ b/data/mekfiles/fighters/Golden Century/Goth Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Ironsides IRN-SD1b-EC.blk
+++ b/data/mekfiles/fighters/Golden Century/Ironsides IRN-SD1b-EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Issedone A.blk
+++ b/data/mekfiles/fighters/Golden Century/Issedone A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Issedone B.blk
+++ b/data/mekfiles/fighters/Golden Century/Issedone B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Issedone C.blk
+++ b/data/mekfiles/fighters/Golden Century/Issedone C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Issedone D.blk
+++ b/data/mekfiles/fighters/Golden Century/Issedone D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Issedone Prime.blk
+++ b/data/mekfiles/fighters/Golden Century/Issedone Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Kublai E.blk
+++ b/data/mekfiles/fighters/Golden Century/Kublai E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Kublai F.blk
+++ b/data/mekfiles/fighters/Golden Century/Kublai F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Kublai G.blk
+++ b/data/mekfiles/fighters/Golden Century/Kublai G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Ogotai A.blk
+++ b/data/mekfiles/fighters/Golden Century/Ogotai A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Ogotai B.blk
+++ b/data/mekfiles/fighters/Golden Century/Ogotai B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Ogotai Prime.blk
+++ b/data/mekfiles/fighters/Golden Century/Ogotai Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Pella.blk
+++ b/data/mekfiles/fighters/Golden Century/Pella.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Qasar A.blk
+++ b/data/mekfiles/fighters/Golden Century/Qasar A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Qasar B.blk
+++ b/data/mekfiles/fighters/Golden Century/Qasar B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Qasar C.blk
+++ b/data/mekfiles/fighters/Golden Century/Qasar C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Qasar D.blk
+++ b/data/mekfiles/fighters/Golden Century/Qasar D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Qasar Prime.blk
+++ b/data/mekfiles/fighters/Golden Century/Qasar Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Rapier RPR-100b-EC.blk
+++ b/data/mekfiles/fighters/Golden Century/Rapier RPR-100b-EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Sabre SB-27b-EC.blk
+++ b/data/mekfiles/fighters/Golden Century/Sabre SB-27b-EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Golden Century/Tomahawk THK-63-EC.blk
+++ b/data/mekfiles/fighters/Golden Century/Tomahawk THK-63-EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Hist LofT/Voidseeker Mk 39-004 Interceptor.blk
+++ b/data/mekfiles/fighters/Hist LofT/Voidseeker Mk 39-004 Interceptor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Hist LofT/Voidseeker Mk 39-007 Striker.blk
+++ b/data/mekfiles/fighters/Hist LofT/Voidseeker Mk 39-007 Striker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Hist Reunification War/MM-1 Dragonfly.blk
+++ b/data/mekfiles/fighters/Hist Reunification War/MM-1 Dragonfly.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Interstellar Players 2/Blackwasp Mk 30.blk
+++ b/data/mekfiles/fighters/Interstellar Players 2/Blackwasp Mk 30.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/JHS Terra/Aeshna Heavy Drone Fighter.blk
+++ b/data/mekfiles/fighters/JHS Terra/Aeshna Heavy Drone Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/JHS Terra/Scarab Medium Drone Fighter.blk
+++ b/data/mekfiles/fighters/JHS Terra/Scarab Medium Drone Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/JHS Terra/Tabanid Light Drone Fighter.blk
+++ b/data/mekfiles/fighters/JHS Terra/Tabanid Light Drone Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Chippewa CHP-W5b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Chippewa CHP-W5b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Corsair CSR-V12b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Corsair CSR-V12b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Eagle EGL-R6b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Eagle EGL-R6b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Hellcat II HCT-213C.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Hellcat II HCT-213C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Lightning LTN-G15b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Lightning LTN-G15b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Sabre SB-27b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Sabre SB-27b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Stuka STU-K5b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Stuka STU-K5b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Stuka STU-K5b2.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Stuka STU-K5b2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Thunderbird TRB-D36b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Thunderbird TRB-D36b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Operation Klondike/Zero ZRO-116b.blk
+++ b/data/mekfiles/fighters/Operation Klondike/Zero ZRO-116b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Cheetah OF-17A-R.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Cheetah OF-17A-R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Corax C.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Corax C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Corsair CSR-12D.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Corsair CSR-12D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Hydaspes 3.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Hydaspes 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Lucifer III  LCR-3.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Lucifer III  LCR-3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Persepolis.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Persepolis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Rapier RPR-300S.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Rapier RPR-300S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Sabre SB-31D.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Sabre SB-31D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Suzaku SU-14.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Suzaku SU-14.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Transit TR-13G.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Transit TR-13G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Tyre 3.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Tyre 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Umbra RF-1.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Umbra RF-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Wildkatze WKT-1S.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Wildkatze WKT-1S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/ProtoTypes/Wildkatze WKT-2S.blk
+++ b/data/mekfiles/fighters/ProtoTypes/Wildkatze WKT-2S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Chippewa Manfred.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Chippewa Manfred.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Corsair Bob.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Corsair Bob.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Hydaspes Algar.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Hydaspes Algar.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Issus Erika.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Issus Erika.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Seydlitz Mary.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Seydlitz Mary.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Slayer SL-15 Eric.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Slayer SL-15 Eric.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Stingray Michael.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Stingray Michael.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Thrush Maximillian.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Thrush Maximillian.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/RSUniqueFighters/Tyre Michiko.blk
+++ b/data/mekfiles/fighters/RSUniqueFighters/Tyre Michiko.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Somerset Strikers/Banshee BSE-X2.blk
+++ b/data/mekfiles/fighters/Somerset Strikers/Banshee BSE-X2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-10.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-11-R.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-11-R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-11-RR.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-11-RR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-11.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-11.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-12-S.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-12-S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-13.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-13.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Cheetah F-14-S.blk
+++ b/data/mekfiles/fighters/TRO3039u/Cheetah F-14-S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W10.blk
+++ b/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W5.blk
+++ b/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W7.blk
+++ b/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W7.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W7T.blk
+++ b/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W7T.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W8.blk
+++ b/data/mekfiles/fighters/TRO3039u/Chippewa CHP-W8.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Corsair CSR-V12.blk
+++ b/data/mekfiles/fighters/TRO3039u/Corsair CSR-V12.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Corsair CSR-V12M Regulus.blk
+++ b/data/mekfiles/fighters/TRO3039u/Corsair CSR-V12M Regulus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Corsair CSR-V14.blk
+++ b/data/mekfiles/fighters/TRO3039u/Corsair CSR-V14.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Corsair CSR-V18.blk
+++ b/data/mekfiles/fighters/TRO3039u/Corsair CSR-V18.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Corsair CSR-V20.blk
+++ b/data/mekfiles/fighters/TRO3039u/Corsair CSR-V20.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Lucifer II LCF-R16K.blk
+++ b/data/mekfiles/fighters/TRO3039u/Lucifer II LCF-R16K.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Lucifer II LCF-R16KR.blk
+++ b/data/mekfiles/fighters/TRO3039u/Lucifer II LCF-R16KR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Lucifer LCF-R15.blk
+++ b/data/mekfiles/fighters/TRO3039u/Lucifer LCF-R15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Lucifer LCF-R16.blk
+++ b/data/mekfiles/fighters/TRO3039u/Lucifer LCF-R16.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Lucifer LCF-R20.blk
+++ b/data/mekfiles/fighters/TRO3039u/Lucifer LCF-R20.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Riever F-100.blk
+++ b/data/mekfiles/fighters/TRO3039u/Riever F-100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Riever F-100a.blk
+++ b/data/mekfiles/fighters/TRO3039u/Riever F-100a.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Riever F-100b.blk
+++ b/data/mekfiles/fighters/TRO3039u/Riever F-100b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Riever F-700.blk
+++ b/data/mekfiles/fighters/TRO3039u/Riever F-700.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Riever F-700a.blk
+++ b/data/mekfiles/fighters/TRO3039u/Riever F-700a.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Riever F-700b.blk
+++ b/data/mekfiles/fighters/TRO3039u/Riever F-700b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sai S-3.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sai S-3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sai S-4.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sai S-4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sai S-4C.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sai S-4C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sai S-4X.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sai S-4X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sai S-7.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sai S-7.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sai S-8.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sai S-8.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Samurai SL-25.blk
+++ b/data/mekfiles/fighters/TRO3039u/Samurai SL-25.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Samurai SL-26.blk
+++ b/data/mekfiles/fighters/TRO3039u/Samurai SL-26.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Samurai SL-27.blk
+++ b/data/mekfiles/fighters/TRO3039u/Samurai SL-27.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-21.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-21.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z1.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z2.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z2A.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z2A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z2B.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z2B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z3.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z3A.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z3A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z4.blk
+++ b/data/mekfiles/fighters/TRO3039u/Seydlitz SYD-Z4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Shilone SL-17.blk
+++ b/data/mekfiles/fighters/TRO3039u/Shilone SL-17.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Shilone SL-17AC.blk
+++ b/data/mekfiles/fighters/TRO3039u/Shilone SL-17AC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Shilone SL-17R.blk
+++ b/data/mekfiles/fighters/TRO3039u/Shilone SL-17R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Shilone SL-18.blk
+++ b/data/mekfiles/fighters/TRO3039u/Shilone SL-18.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sholagar SL-21.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sholagar SL-21.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sholagar SL-21L.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sholagar SL-21L.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sholagar SL-22.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sholagar SL-22.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Slayer SL-15.blk
+++ b/data/mekfiles/fighters/TRO3039u/Slayer SL-15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Slayer SL-15A.blk
+++ b/data/mekfiles/fighters/TRO3039u/Slayer SL-15A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Slayer SL-15B.blk
+++ b/data/mekfiles/fighters/TRO3039u/Slayer SL-15B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Slayer SL-15C.blk
+++ b/data/mekfiles/fighters/TRO3039u/Slayer SL-15C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Slayer SL-15K.blk
+++ b/data/mekfiles/fighters/TRO3039u/Slayer SL-15K.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Slayer SL-15R.blk
+++ b/data/mekfiles/fighters/TRO3039u/Slayer SL-15R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-6D.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-6D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-7D.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-7D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-8H.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-8H.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-H5.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-H5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-H5K.blk
+++ b/data/mekfiles/fighters/TRO3039u/Sparrowhawk SPR-H5K.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stingray F-90.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stingray F-90.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stingray F-90S.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stingray F-90S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stingray F-92.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stingray F-92.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stingray F-94.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stingray F-94.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stingray F-95.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stingray F-95.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stuka STU-D6.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stuka STU-D6.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stuka STU-D7.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stuka STU-D7.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stuka STU-K10.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stuka STU-K10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stuka STU-K15.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stuka STU-K15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Stuka STU-K5.blk
+++ b/data/mekfiles/fighters/TRO3039u/Stuka STU-K5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Thrush TR-7.blk
+++ b/data/mekfiles/fighters/TRO3039u/Thrush TR-7.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Thrush TR-7p.blk
+++ b/data/mekfiles/fighters/TRO3039u/Thrush TR-7p.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Thrush TR-8.blk
+++ b/data/mekfiles/fighters/TRO3039u/Thrush TR-8.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transgressor TR-13.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transgressor TR-13.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transgressor TR-13A.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transgressor TR-13A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transgressor TR-14 AC.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transgressor TR-14 AC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transgressor TR-15.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transgressor TR-15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transgressor TR-16.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transgressor TR-16.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transit TR-10.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transit TR-10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transit TR-11.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transit TR-11.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3039u/Transit TR-12.blk
+++ b/data/mekfiles/fighters/TRO3039u/Transit TR-12.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/Clan/Swift C.blk
+++ b/data/mekfiles/fighters/TRO3050U/Clan/Swift C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/Clan/Tomahawk C.blk
+++ b/data/mekfiles/fighters/TRO3050U/Clan/Tomahawk C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/Clan/Tomahawk CH.blk
+++ b/data/mekfiles/fighters/TRO3050U/Clan/Tomahawk CH.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-443.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-443.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-643.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-643.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-MD.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-MD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-X.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ahab AHB-X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-100.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-300.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-400.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-400.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-500.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-500.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-600.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Gotha GTHA-600.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HD.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HE.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HF.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HF.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HG.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Hammerhead HMR-HG.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT212.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT212.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT213B.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT213B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT214.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT214.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT215.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/HellcatII HCT215.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ironsides IRN-SD1.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ironsides IRN-SD1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ironsides IRN-SD2.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ironsides IRN-SD2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Ironsides IRN-SD3.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Ironsides IRN-SD3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-100.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-101.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-101.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-102.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-102.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-200.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-200.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-300.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rapier RPR-300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133E.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133F.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133L.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133L.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133LP.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133LP.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133P.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Rogue RGU-133P.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Spad SPD-502.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Spad SPD-502.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Spad SPD-503.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Spad SPD-503.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Spad SPD-504.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Spad SPD-504.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Swift SWF-606.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Swift SWF-606.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Swift SWF-606R.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Swift SWF-606R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-33.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-33.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-43.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-43.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-53.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-53.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-63.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-63.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-63CS.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Tomahawk THK-63CS.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Trident TRN-3T.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Trident TRN-3T.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Trident TRN-3U.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Trident TRN-3U.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Trident TRN-3V.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Trident TRN-3V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Zero ZRO-114.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Zero ZRO-114.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3050U/IS/Zero ZRO-115.blk
+++ b/data/mekfiles/fighters/TRO3050U/IS/Zero ZRO-115.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Avar A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Avar A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Avar B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Avar B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Avar C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Avar C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Avar D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Avar D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Avar E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Avar E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Avar Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Avar Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Bashkir A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Bashkir A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Bashkir B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Bashkir B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Bashkir C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Bashkir C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Bashkir D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Bashkir D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Bashkir E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Bashkir E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Bashkir Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Bashkir Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Batu A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Batu A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Batu B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Batu B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Batu C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Batu C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Batu D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Batu D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Batu E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Batu E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Batu Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Batu Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jagatai X.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jagatai X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Jengiz X.blk
+++ b/data/mekfiles/fighters/TRO3055U/Jengiz X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Kirghiz A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Kirghiz A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Kirghiz B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Kirghiz B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Kirghiz C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Kirghiz C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Kirghiz D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Kirghiz D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Kirghiz E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Kirghiz E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Kirghiz Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Kirghiz Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sabutai X.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sabutai X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Scytha X.blk
+++ b/data/mekfiles/fighters/TRO3055U/Scytha X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sulla A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sulla A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sulla B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sulla B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sulla C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sulla C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sulla D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sulla D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sulla E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sulla E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Sulla Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Sulla Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Turk A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Turk A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Turk B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Turk B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Turk C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Turk C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Turk D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Turk D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Turk E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Turk E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Turk Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Turk Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Vandal A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Vandal A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Vandal B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Vandal B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Vandal C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Vandal C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Vandal D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Vandal D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Vandal E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Vandal E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Vandal Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Vandal Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth A.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth B.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth C.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth Carew Nygren.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth Carew Nygren.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth D.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth E.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3055U/Visigoth Prime.blk
+++ b/data/mekfiles/fighters/TRO3055U/Visigoth Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Ammon 2.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Ammon 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Chaeronea 2.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Chaeronea 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Chaeronea 3.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Chaeronea 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Chaeronea 4.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Chaeronea 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Hydaspes 2.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Hydaspes 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Issus 2.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Issus 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Issus 3.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Issus 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Xerxes 2.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Xerxes 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Xerxes 3.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Xerxes 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Xerxes.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/Clan Aerospace/Xerxes.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Corax CRX-OD.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Corax CRX-OD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Corax CRX-OR.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Corax CRX-OR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Dagger DARO-1C.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Dagger DARO-1C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Dagger DARO-1D.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Dagger DARO-1D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Defiance DFC-OD.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Defiance DFC-OD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Eisensturm EST-OD.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Eisensturm EST-OD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Huscarl HSCL-1-OD.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Huscarl HSCL-1-OD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Huscarl HSCL-1-OR.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Huscarl HSCL-1-OR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Lancer LX-3.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Lancer LX-3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Shiva SHV-OD.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Shiva SHV-OD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Tatsu MIK-OD.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Tatsu MIK-OD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Tatsu MIK-OE.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Tatsu MIK-OE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Troika CMT-6T.blk
+++ b/data/mekfiles/fighters/TRO3067 Unabridged/IS Aerospace/Troika CMT-6T.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/Clan/Ammon.blk
+++ b/data/mekfiles/fighters/TRO3067/Clan/Ammon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/Clan/Chaeronea.blk
+++ b/data/mekfiles/fighters/TRO3067/Clan/Chaeronea.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/Clan/Hydaspes.blk
+++ b/data/mekfiles/fighters/TRO3067/Clan/Hydaspes.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/Clan/Issus.blk
+++ b/data/mekfiles/fighters/TRO3067/Clan/Issus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/Clan/Tyre 2.blk
+++ b/data/mekfiles/fighters/TRO3067/Clan/Tyre 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/Clan/Tyre.blk
+++ b/data/mekfiles/fighters/TRO3067/Clan/Tyre.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Corax CRX-O.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Corax CRX-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Corax CRX-OA.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Corax CRX-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Corax CRX-OB.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Corax CRX-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Corax CRX-OC.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Corax CRX-OC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Dagger DARO-1.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Dagger DARO-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Dagger DARO-1A.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Dagger DARO-1A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Dagger DARO-1B.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Dagger DARO-1B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-O.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-OA.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-OB.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-OC.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Defiance DFC-OC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-O.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-OA.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-OB.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-OC.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-OC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-R3.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Eisensturm EST-R3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-O.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-OA.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-OB.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-OC.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Huscarl HSCL-1-OC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Lancer LX-2.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Lancer LX-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Lancer LX-2A.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Lancer LX-2A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Oni ON-1.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Oni ON-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Oni ON-2.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Oni ON-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-O.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-OA.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-OB.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-OC.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Shiva SHV-OC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-O.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-OA.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-OB.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-OC.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Tatsu MIK-OC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Troika CMT-3T.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Troika CMT-3T.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3067/IS/Troika CMT-4U.blk
+++ b/data/mekfiles/fighters/TRO3067/IS/Troika CMT-4U.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Centurion CNT-1A.blk
+++ b/data/mekfiles/fighters/TRO3075/Centurion CNT-1A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Centurion CNT-1D.blk
+++ b/data/mekfiles/fighters/TRO3075/Centurion CNT-1D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Centurion CNT-2D.blk
+++ b/data/mekfiles/fighters/TRO3075/Centurion CNT-2D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Centurion CNT-3S.blk
+++ b/data/mekfiles/fighters/TRO3075/Centurion CNT-3S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Deathstalker F-77.blk
+++ b/data/mekfiles/fighters/TRO3075/Deathstalker F-77.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Deathstalker F-77A.blk
+++ b/data/mekfiles/fighters/TRO3075/Deathstalker F-77A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Eagle EGL-R1.blk
+++ b/data/mekfiles/fighters/TRO3075/Eagle EGL-R1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Eagle EGL-R10.blk
+++ b/data/mekfiles/fighters/TRO3075/Eagle EGL-R10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Eagle EGL-R11.blk
+++ b/data/mekfiles/fighters/TRO3075/Eagle EGL-R11.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Eagle EGL-R4.blk
+++ b/data/mekfiles/fighters/TRO3075/Eagle EGL-R4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Eagle EGL-R6.blk
+++ b/data/mekfiles/fighters/TRO3075/Eagle EGL-R6.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Eagle EGL-R9.blk
+++ b/data/mekfiles/fighters/TRO3075/Eagle EGL-R9.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Hellcat HCT-213.blk
+++ b/data/mekfiles/fighters/TRO3075/Hellcat HCT-213.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Hellcat HCT-213D.blk
+++ b/data/mekfiles/fighters/TRO3075/Hellcat HCT-213D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Hellcat HCT-213R.blk
+++ b/data/mekfiles/fighters/TRO3075/Hellcat HCT-213R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Hellcat HCT-213S.blk
+++ b/data/mekfiles/fighters/TRO3075/Hellcat HCT-213S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Hellcat HCT-313.blk
+++ b/data/mekfiles/fighters/TRO3075/Hellcat HCT-313.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G14.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G14.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G15.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G16D.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G16D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G16L.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G16L.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G16O.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G16O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G16S.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G16S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Lightning LTN-G16T.blk
+++ b/data/mekfiles/fighters/TRO3075/Lightning LTN-G16T.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Ahab AHB-443b.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Ahab AHB-443b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Gotha GTHA-500b.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Gotha GTHA-500b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Hammerhead HMR-HDb.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Hammerhead HMR-HDb.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Ironsides IRN-SD1b.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Ironsides IRN-SD1b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Rapier RPR-100b.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Rapier RPR-100b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Rogue RGU-133Eb.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Rogue RGU-133Eb.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Tomahawk THK-63b.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Tomahawk THK-63b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Royals/Trident TRN-3Tb.blk
+++ b/data/mekfiles/fighters/TRO3075/Royals/Trident TRN-3Tb.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Sabre SB-26.blk
+++ b/data/mekfiles/fighters/TRO3075/Sabre SB-26.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Sabre SB-27.blk
+++ b/data/mekfiles/fighters/TRO3075/Sabre SB-27.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Sabre SB-28.blk
+++ b/data/mekfiles/fighters/TRO3075/Sabre SB-28.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Sabre SB-29.blk
+++ b/data/mekfiles/fighters/TRO3075/Sabre SB-29.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-O Invictus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-O Invictus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OA Dominus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OA Dominus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OB Infernus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OB Infernus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OC Comminus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OC Comminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OD Luminos.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OD Luminos.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OE Eminus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Rusalka S-RSL-OE Eminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-O Invictus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-O Invictus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OA Dominus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OA Dominus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OB Infernus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OB Infernus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OC Comminus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OC Comminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OD Luminos.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OD Luminos.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OE Eminus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Shade S-HA-OE Eminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-O Invictus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-O Invictus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OA Dominus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OA Dominus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OB Infernus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OB Infernus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OC Comminus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OC Comminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OD Luminos.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OD Luminos.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OE Eminus.blk
+++ b/data/mekfiles/fighters/TRO3075/Spectrals/Striga S-STR-OE Eminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D36.blk
+++ b/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D36.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D46.blk
+++ b/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D46.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D50.blk
+++ b/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D50.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D56.blk
+++ b/data/mekfiles/fighters/TRO3075/Thunderbird TRB-D56.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Typhoon TFN-2A.blk
+++ b/data/mekfiles/fighters/TRO3075/Typhoon TFN-2A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Typhoon TFN-3A.blk
+++ b/data/mekfiles/fighters/TRO3075/Typhoon TFN-3A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Typhoon TFN-3M.blk
+++ b/data/mekfiles/fighters/TRO3075/Typhoon TFN-3M.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Typhoon TFN-5H.blk
+++ b/data/mekfiles/fighters/TRO3075/Typhoon TFN-5H.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Vulcan VLC-5N.blk
+++ b/data/mekfiles/fighters/TRO3075/Vulcan VLC-5N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Vulcan VLC-6N.blk
+++ b/data/mekfiles/fighters/TRO3075/Vulcan VLC-6N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3075/Vulcan VLC-8N.blk
+++ b/data/mekfiles/fighters/TRO3075/Vulcan VLC-8N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Mengqin MNG-8L.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Mengqin MNG-8L.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1S.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SA.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SB.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SC.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SD.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Morgenstern MR-1SD.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth A.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth B.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth C.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth Prime.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Ostrogoth Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Poignard PGD-L3.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Poignard PGD-L3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Poignard PGD-R3.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Poignard PGD-R3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Poignard PGD-Y3.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Poignard PGD-Y3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Sagittarii SGT-2R.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Sagittarii SGT-2R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Sagittarii SGT-3R.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Sagittarii SGT-3R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun A.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun B.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun C.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun Prime.blk
+++ b/data/mekfiles/fighters/TRO3085u/Cutting Edge/Wusun Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Davion/Cutlass CUT-01D.blk
+++ b/data/mekfiles/fighters/TRO3145/Davion/Cutlass CUT-01D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Davion/Cutlass CUT-01E.blk
+++ b/data/mekfiles/fighters/TRO3145/Davion/Cutlass CUT-01E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Davion/Rondel RDL-01C.blk
+++ b/data/mekfiles/fighters/TRO3145/Davion/Rondel RDL-01C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Kurita/Koroshiya KOS-1A.blk
+++ b/data/mekfiles/fighters/TRO3145/Kurita/Koroshiya KOS-1A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Liao/Yun Y-2.blk
+++ b/data/mekfiles/fighters/TRO3145/Liao/Yun Y-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Marik/Aquila AQA-1M.blk
+++ b/data/mekfiles/fighters/TRO3145/Marik/Aquila AQA-1M.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Marik/Picaroon CSR-F100.blk
+++ b/data/mekfiles/fighters/TRO3145/Marik/Picaroon CSR-F100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Marik/Shikra SKR-4M.blk
+++ b/data/mekfiles/fighters/TRO3145/Marik/Shikra SKR-4M.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Cheetah IIC.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Cheetah IIC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Jengiz F.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Jengiz F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Lucifer III C.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Lucifer III C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Morgenstern MR-1SE.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Morgenstern MR-1SE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Ostrogoth D.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Ostrogoth D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Sagittarii SGT-4R.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Sagittarii SGT-4R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Scytha F.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Scytha F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Seydlitz C.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Seydlitz C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Sparrowhawk SPR-7Dr.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Sparrowhawk SPR-7Dr.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Stingray F-96R.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Stingray F-96R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Sulla F.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Sulla F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Tatsu MIK-OF.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Tatsu MIK-OF.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Thrush TR-9.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Thrush TR-9.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Troika CMT-7T.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Troika CMT-7T.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/NTNU/Wusun D.blk
+++ b/data/mekfiles/fighters/TRO3145/NTNU/Wusun D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Republic/Schrack SCK-O.blk
+++ b/data/mekfiles/fighters/TRO3145/Republic/Schrack SCK-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Republic/Schrack SCK-OA.blk
+++ b/data/mekfiles/fighters/TRO3145/Republic/Schrack SCK-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Republic/Schrack SCK-OB.blk
+++ b/data/mekfiles/fighters/TRO3145/Republic/Schrack SCK-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Republic/Simurgh SMG-O.blk
+++ b/data/mekfiles/fighters/TRO3145/Republic/Simurgh SMG-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Republic/Simurgh SMG-OA.blk
+++ b/data/mekfiles/fighters/TRO3145/Republic/Simurgh SMG-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Republic/Simurgh SMG-OB.blk
+++ b/data/mekfiles/fighters/TRO3145/Republic/Simurgh SMG-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Steiner/Sternensturm STM-O.blk
+++ b/data/mekfiles/fighters/TRO3145/Steiner/Sternensturm STM-O.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Steiner/Sternensturm STM-OA.blk
+++ b/data/mekfiles/fighters/TRO3145/Steiner/Sternensturm STM-OA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3145/Steiner/Sternensturm STM-OB.blk
+++ b/data/mekfiles/fighters/TRO3145/Steiner/Sternensturm STM-OB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/TRO3150/Shikra SKR-4N.blk
+++ b/data/mekfiles/fighters/TRO3150/Shikra SKR-4N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Wars of Reaving/Bashkir Z.blk
+++ b/data/mekfiles/fighters/Wars of Reaving/Bashkir Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Wars of Reaving/Batu Z.blk
+++ b/data/mekfiles/fighters/Wars of Reaving/Batu Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/Wars of Reaving/Sabutai Z.blk
+++ b/data/mekfiles/fighters/Wars of Reaving/Sabutai Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Boondocks/Sangihe Shrike-Thrush Nanook.blk
+++ b/data/mekfiles/fighters/XTRs/Boondocks/Sangihe Shrike-Thrush Nanook.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Boondoggles/Cheetah II F-12A.blk
+++ b/data/mekfiles/fighters/XTRs/Boondoggles/Cheetah II F-12A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Clans/Ammon-XR.blk
+++ b/data/mekfiles/fighters/XTRs/Clans/Ammon-XR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Clans/Scytha-XR.blk
+++ b/data/mekfiles/fighters/XTRs/Clans/Scytha-XR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Comstar/Ironsides CX-19.blk
+++ b/data/mekfiles/fighters/XTRs/Comstar/Ironsides CX-19.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Comstar/Tomahawk CX-11.blk
+++ b/data/mekfiles/fighters/XTRs/Comstar/Tomahawk CX-11.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Comstar/Zero ZRO-CX-3.blk
+++ b/data/mekfiles/fighters/XTRs/Comstar/Zero ZRO-CX-3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Corporations/Sabre SB-31D Defense Special.blk
+++ b/data/mekfiles/fighters/XTRs/Corporations/Sabre SB-31D Defense Special.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Corporations/Sholagar SL-27X.blk
+++ b/data/mekfiles/fighters/XTRs/Corporations/Sholagar SL-27X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Davion/Corsair CSR-X12 Rigid Night.blk
+++ b/data/mekfiles/fighters/XTRs/Davion/Corsair CSR-X12 Rigid Night.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Davion/Dagger DAR4-XP.blk
+++ b/data/mekfiles/fighters/XTRs/Davion/Dagger DAR4-XP.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Gunslingers/Hellcat II HCT-213BC (Herman).blk
+++ b/data/mekfiles/fighters/XTRs/Gunslingers/Hellcat II HCT-213BC (Herman).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Gunslingers/Swift SWF-606 (Aaron).blk
+++ b/data/mekfiles/fighters/XTRs/Gunslingers/Swift SWF-606 (Aaron).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Kurita/Oni ON-2X.blk
+++ b/data/mekfiles/fighters/XTRs/Kurita/Oni ON-2X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Kurita/Shilone Sl-17X.blk
+++ b/data/mekfiles/fighters/XTRs/Kurita/Shilone Sl-17X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Liao/Transit TR-13 Glare.blk
+++ b/data/mekfiles/fighters/XTRs/Liao/Transit TR-13 Glare.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Liao/Troika CMT-3TV (Viktor).blk
+++ b/data/mekfiles/fighters/XTRs/Liao/Troika CMT-3TV (Viktor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Marik/Cheetah OF-17.blk
+++ b/data/mekfiles/fighters/XTRs/Marik/Cheetah OF-17.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Marik/Shiva SHV-S.blk
+++ b/data/mekfiles/fighters/XTRs/Marik/Shiva SHV-S.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Mercenaries/Lucifer LCF-X30.blk
+++ b/data/mekfiles/fighters/XTRs/Mercenaries/Lucifer LCF-X30.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Mercenaries/Seydlitz SYD-45X Starling.blk
+++ b/data/mekfiles/fighters/XTRs/Mercenaries/Seydlitz SYD-45X Starling.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Mercenaries/Slayer SL-CX1.blk
+++ b/data/mekfiles/fighters/XTRs/Mercenaries/Slayer SL-CX1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Periphery/Thunderbird TRB-XTS.blk
+++ b/data/mekfiles/fighters/XTRs/Periphery/Thunderbird TRB-XTS.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Phantoms/Battle Taxi NL-43.blk
+++ b/data/mekfiles/fighters/XTRs/Phantoms/Battle Taxi NL-43.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Phantoms/Deathstalker XF-78.blk
+++ b/data/mekfiles/fighters/XTRs/Phantoms/Deathstalker XF-78.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Pirates/Chippewa CHP-X-P Gladstone.blk
+++ b/data/mekfiles/fighters/XTRs/Pirates/Chippewa CHP-X-P Gladstone.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Pirates/Lightning LTN-G16-P Branson.blk
+++ b/data/mekfiles/fighters/XTRs/Pirates/Lightning LTN-G16-P Branson.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Primitives I/Vulcan VLC-3N.blk
+++ b/data/mekfiles/fighters/XTRs/Primitives I/Vulcan VLC-3N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Primitives IV/Hammerhead HMR-HA.blk
+++ b/data/mekfiles/fighters/XTRs/Primitives IV/Hammerhead HMR-HA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Primitives IV/Hammerhead HMR-HC.blk
+++ b/data/mekfiles/fighters/XTRs/Primitives IV/Hammerhead HMR-HC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Republic II/Persepolis 2.blk
+++ b/data/mekfiles/fighters/XTRs/Republic II/Persepolis 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/RetroTech/Malaika BAM-1A1.blk
+++ b/data/mekfiles/fighters/XTRs/RetroTech/Malaika BAM-1A1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/RetroTech/Sparrowhawk SPR-DH.blk
+++ b/data/mekfiles/fighters/XTRs/RetroTech/Sparrowhawk SPR-DH.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/RetroTech/Star Dagger S-2.blk
+++ b/data/mekfiles/fighters/XTRs/RetroTech/Star Dagger S-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Steiner/Rapier RPR-300X.blk
+++ b/data/mekfiles/fighters/XTRs/Steiner/Rapier RPR-300X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Succession Wars/Starfire SF-1X (Prototype).blk
+++ b/data/mekfiles/fighters/XTRs/Succession Wars/Starfire SF-1X (Prototype).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/fighters/XTRs/Succession Wars/Starfire SF-1X.blk
+++ b/data/mekfiles/fighters/XTRs/Succession Wars/Starfire SF-1X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Additional Turrets/Calliope Turret (2800).blk
+++ b/data/mekfiles/ge/Additional Turrets/Calliope Turret (2800).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Additional Turrets/Calliope Turret (3053).blk
+++ b/data/mekfiles/ge/Additional Turrets/Calliope Turret (3053).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM12 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM3 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM6 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/ATM9 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM12 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM3 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM6 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/ATM/iATM/iATM9 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret (Quadl).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret (Quadl).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/ArrowIV Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Cannon Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Long Tom Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 1 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 2 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Mortar Battery 8.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Cannon Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Sniper Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Cannon Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Artillery/Thumper Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB10X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB20X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB2X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/LBX/AC Turret CLLB5X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Dual) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Dual) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Single) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Single) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO4 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/ProtoAC/CLPROTO8 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Dual) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Dual) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Single) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Single) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/RACs/CLRAC5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Triple) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC10 Turret (Triple) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Triple) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC20 Turret (Triple) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Autocannons/Ultras/CLUAC5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/ER Flamer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Flamer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Flamers/Heavy Flamer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/APGauss Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLGauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG30 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Gauss/CLHAG40 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM10 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM15 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM20 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemis IV/LRM5 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret (Dual) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret (Dual) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret (Quad) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret (Quad) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret (Triple) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret (Triple) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM10 Turret Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret (Dual) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret (Dual) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret (Quad) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret (Quad) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret (Triple) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret (Triple) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM15 Turret Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret (Dual) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret (Dual) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret (Quad) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret (Quad) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret (Triple) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret (Triple) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM20 Turret Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret (Dual) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret (Dual) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret (Quad) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret (Quad) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret (Triple) Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret (Triple) Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret Artemis V.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/LRM w Artemix V/LRM5 Turret Artemis V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM15 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Standard/LRM5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM15 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/LRM/Streak/StreakLRM5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/LargeChemLaser Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/MediumChemLaser Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Chemical/SmallChemLaser Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseLL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER Pulse/CLERPulseSL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERLL w TC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERMicro Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/ER/CLERSL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy LL w TC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy ML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Heavy laser/CLHvy SL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy LL Turret w TC (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy ML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Imp Heavy/CLImpHvy SL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLMicroPulse Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseLL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseMicro Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Laser/Pulse/CLPulseSL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret w Array (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret w Array (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret w Array (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret w Array (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret w Array (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret w Array (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLHeavy MG Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret w Array (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret w Array (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret w Array (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret w Array (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret w Array (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret w Array (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLLight MG Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret w Array (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret w Array (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret w Array (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret w Array (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret w Array (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret w Array (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/MGs/CLMG Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w Cap Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w Cap Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w Cap Turret(Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w Cap Turret(Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w Cap Turret(Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w Cap Turret(Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w CapTurret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/ER PPC w CapTurret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Enhanced PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/PPC/Plasma Cannon Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Dual)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Dual)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Quad)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Quad)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Single)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Single)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Triple)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM2 Turret (Triple)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Dual)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Dual)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Quad)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Quad)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Single)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Single)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Triple)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM4 Turret (Triple)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Dual)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Dual)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Quad)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Quad)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Single)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Single)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Triple)+ArtemisIV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis IV/SRM6 Turret (Triple)+ArtemisIV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Dual)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Dual)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Quad)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Quad)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Single)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Single)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Triple)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM2 Turret (Triple)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Dual)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Dual)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Quad)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Quad)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Single)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Single)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Triple)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM4 Turret (Triple)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Dual)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Dual)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Quad)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Quad)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Single)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Single)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Triple)+ArtemisV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM w Artemis V/SRM6 Turret (Triple)+ArtemisV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM4 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/SRM/SRM6 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/AMS Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/AMS Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/AMS Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/AMS Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/Active Probe Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/Active Probe Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/Angel ECM Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/Angel ECM Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/ECM Suite Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/ECM Suite Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/Laser AMS Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/Laser AMS Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/Laser AMS Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/Laser AMS Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/Light Probe Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/Light Probe Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/NARC Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/NARC Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/NARC Launcher (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/NARC Launcher (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/TAG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/TAG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/TAG Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/TAG Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Dual) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Dual) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Quad) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Quad) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Single) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Single) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Triple) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/VGL (Triple) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Special/Watchdog CEWs Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Special/Watchdog CEWs Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM4 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Clan/Streak SRMs/Streak CLSRM6 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret (Quadl).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret (Quadl).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/ArrowIV Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 120 Launcher.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 50 Launcher.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 70 Launcher.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Cruise Missile 90 Launcher.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Cannon Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Long Tom Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Mortar Battery 8.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Cannon Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Sniper Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Cannon Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Artillery/Thumper Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC10  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC2  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/HVAC/AC Turret HVAC5  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB10X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB20X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB2X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/LBX/AC Turret LB5X  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC2  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Light ACs/AC Turret Light AC5  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Dual) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Dual) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Single) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Single) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/RACs/RAC5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Heavy Rifle Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Light Rifle Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Rifles/Medium Rifle Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Single) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Single) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Standard ACs/AC5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Triple) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC10 Turret (Triple) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Triple) .blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC20 Turret (Triple) .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Autocannons/Ultras/UAC5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/ER Flamer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Flamer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Flamers/Heavy Flamer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Heavy Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Imp_Heavy Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Light Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Magshot Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Gauss/Silver Bullet Gauss Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM15 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Enhanced/Enhanced LRM5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM15 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/Extended/Extended LRM5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM15 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Dual) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Dual) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Quad) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Quad) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Triple) Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Triple) Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/LRM/LRM5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Blazer/Blazer Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Bombast/Bombast Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERLL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/ER/ERSL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseLL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Pulse/PulseSL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE LL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE ML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/RE-Engineered/RE SL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/LL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/ML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/Standard/SL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/TSEMP/TSEMP Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/TSEMP/TSEMP Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/TSEMP/TSEMP Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/TSEMP/TSEMP Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP LL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP ML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/VSP/VSP SL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse LL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse ML Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Laser/XPulse/X-Pulse SL Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret w Array (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret w Array (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret w Array (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret w Array (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret w Array (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret w Array (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Heavy MG Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret w Array (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret w Array (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret w Array (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret w Array (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret w Array (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret w Array (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/Light MG Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret w Array (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret w Array (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret w Array (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret w Array (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret w Array (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret w Array (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MGs/MG Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Dual) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Dual) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Quad) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Quad) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Triple) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Triple) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML3 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Dual) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Dual) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Quad) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Quad) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Triple) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Triple) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Dual) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Dual) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Quad) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Quad) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Triple) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Triple) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML7 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Dual) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Dual) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Quad) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Quad) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Triple) + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Triple) + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret + Artemis IV.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret + Artemis IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MML/MML9 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret w Apollo.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret w Apollo.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret w Apollo.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM30 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret w Apollo.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/MRM/MRM40 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w Cap Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w Cap Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w Cap Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w Cap Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w Cap Turret(Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w Cap Turret(Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w CapTurret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/ER PPC w CapTurret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (Single.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (Single.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC Turret (dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w Cap Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w Cap Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w Cap Turret(Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w Cap Turret(Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w Cap Turret(Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w Cap Turret(Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w CapTurret(Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Heavy PPC w CapTurret(Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/LIght PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/LIght PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC Turret (dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC Turret (dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w Cap Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w Cap Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w Cap Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w Cap Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w CapTurret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w CapTurret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w CapTurret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Light PPC w CapTurret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC Turret (dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w Cap Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w Cap Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w Cap Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w Cap Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w Cap Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w Cap Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w CapTurret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/PPC w CapTurret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma Rifle Turret  (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma Rifle Turret  (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma Rifle Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma Rifle Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma RifleTurret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma RifleTurret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma RifleTurret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/Plasma RifleTurret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/PPC/SN PPC w Cap Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL1 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL1 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL10 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL10 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL15 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL15 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL2 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL2 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL20 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL20 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL3 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL3 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL4 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL4 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL5 Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Rocket Launchers/RL5 Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Dual)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Dual)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Quad)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Quad)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Single)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Single)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Triple)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Triple)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Dual)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Dual)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Quad)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Quad)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Single)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Single)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Triple)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Triple)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM4 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Dual)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Dual)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Quad)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Quad)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Single)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Single)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Triple)+Artemis.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Triple)+Artemis.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/SRM/SRM6 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/AMS Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/AMS Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/AMS Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/AMS Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Active Probe (Beagle) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Active Probe (Beagle) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Angel ECM Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Angel ECM Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Bloodhound Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Bloodhound Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 BM (Dual) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 BM (Dual) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 BM (Single) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 BM (Single) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 BM (Triple) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 BM (Triple) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 Master (Dual) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 Master (Dual) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 Master (Single) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 Master (Single) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 Master (Triple) Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3 Master (Triple) Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3i Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/C3i Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Calliope Turret (2800).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Calliope Turret (2800).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Calliope Turret (3053).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Calliope Turret (3053).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Guardian ECM Bunker.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Guardian ECM Bunker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Laser AMS Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Laser AMS Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Laser AMS Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/Laser AMS Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/NARC Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/NARC Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/NARC Launcher (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/NARC Launcher (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/RISC APDS (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/RISC APDS (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/RISC APDS (SIngle).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/RISC APDS (SIngle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/TAG Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/TAG Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/TAG Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/TAG Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Dual) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Dual) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Quad) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Quad) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Single) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Single) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Triple) Turret.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/VGL (Triple) Turret.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/iNARC Launcher (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/iNARC Launcher (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/iNARC Launcher (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Special/iNARC Launcher (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM2 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM4 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Single).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Single).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Streak SRMs/Streak SRM6 Turret (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 20.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5 (Dual).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5 (Dual).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5 (Quad).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5 (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5 (Triple).blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5 (Triple).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5.blk
+++ b/data/mekfiles/ge/Archive_Turrets/Inner Sphere/Thunderbolt/Thunderbolt Turret 5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Air Defense Missile Emplacement 3075.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Air Defense Missile Emplacement 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Bombard Turret 3050.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Bombard Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Flak Turret 3025.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Flak Turret 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Laser Turret 2300.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Laser Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Laser Turret 3039.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Laser Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Missile Turret 2300.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Missile Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Missile Turret 3039.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Missile Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Shredder Turret 2300.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Shredder Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Shredder Turret 3057.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Shredder Turret 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Siege Turret 3050.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Siege Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Sniper Turret 2300.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Sniper Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Assault Turrets/Assault Sniper Turret 3039.blk
+++ b/data/mekfiles/ge/Assault Turrets/Assault Sniper Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Davion Turrets/Fed Suns Advanced Laser Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Davion Turrets/Fed Suns Advanced Laser Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Davion Turrets/Fed Suns Advanced Shredder Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Davion Turrets/Fed Suns Advanced Shredder Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Kurita Turrets/Draconis Advanced Missile Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Kurita Turrets/Draconis Advanced Missile Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Kurita Turrets/Draconis Advanced Siege Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Kurita Turrets/Draconis Advanced Siege Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Liao Turrets/Capellan Advanced Shredder Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Liao Turrets/Capellan Advanced Shredder Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Liao Turrets/Capellan Advanced Siege Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Liao Turrets/Capellan Advanced Siege Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Lyran Turrets/Lyran Advanced MIssile Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Lyran Turrets/Lyran Advanced MIssile Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Lyran Turrets/Lyran Advanced Shredder Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Lyran Turrets/Lyran Advanced Shredder Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Marik Turrets/FWL Advanced Laser Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Marik Turrets/FWL Advanced Laser Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Faction Turrets/Marik Turrets/FWL Advanced Missile Turret 3075.blk
+++ b/data/mekfiles/ge/Faction Turrets/Marik Turrets/FWL Advanced Missile Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Blaze Turret 3025.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Blaze Turret 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Bombard Turret 3050.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Bombard Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Flak Turret 2300.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Flak Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Flak Turret 3050.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Flak Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Laser Turret 2300.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Laser Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Laser Turret 3039.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Laser Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Missile Turret 2300.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Missile Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Missile Turret 3039.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Missile Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Shredder Turret 2300.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Shredder Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Shredder Turret 3057.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Shredder Turret 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Siege Turret 2300.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Siege Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Siege Turret 3039.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Siege Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Sniper Turret 2300.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Sniper Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Heavy Turrets/Heavy Sniper Turret 3039.blk
+++ b/data/mekfiles/ge/Heavy Turrets/Heavy Sniper Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Bombard Turret 3050.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Bombard Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Flak Turret 2300.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Flak Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Flak Turret 3050.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Flak Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Laser Turret 2300.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Laser Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Missile Turret 2300.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Missile Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Missile Turret 3039.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Missile Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Shredder Turret 2300.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Shredder Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Shredder Turret 3057.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Shredder Turret 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Sniper Turret 2300.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Sniper Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Light Turrets/Light Sniper Turret 3075.blk
+++ b/data/mekfiles/ge/Light Turrets/Light Sniper Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Air Defense Missile Emplacement 3075.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Air Defense Missile Emplacement 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Blaze Turret 3025.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Blaze Turret 3025.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Bombard Turret 3050.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Bombard Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Command Tower 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Command Tower 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Command Tower 3039.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Command Tower 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Flak Turret 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Flak Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Flak Turret 3050.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Flak Turret 3050.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Laser Turret 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Laser Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Laser Turret 3039.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Laser Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Missile Turret 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Missile Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Missile Turret 3039.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Missile Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Shredder Turret 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Shredder Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Shredder Turret 3057.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Shredder Turret 3057.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Siege Turret 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Siege Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Siege Turret 3039.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Siege Turret 3039.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Sniper Turret 2300.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Sniper Turret 2300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/ge/Medium Turrets/Medium Sniper Turret 3075.blk
+++ b/data/mekfiles/ge/Medium Turrets/Medium Sniper Turret 3075.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/ER Medium Laser Weapon.blk
+++ b/data/mekfiles/handheld/ER Medium Laser Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Enhanced LRM Weapon.blk
+++ b/data/mekfiles/handheld/Enhanced LRM Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Flamer Weapon.blk
+++ b/data/mekfiles/handheld/Flamer Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Fluid Gun Weapon.blk
+++ b/data/mekfiles/handheld/Fluid Gun Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy Flamer Weapon.blk
+++ b/data/mekfiles/handheld/Heavy Flamer Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy LB-X Weapon (Cluster).blk
+++ b/data/mekfiles/handheld/Heavy LB-X Weapon (Cluster).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy LB-X Weapon (Solid).blk
+++ b/data/mekfiles/handheld/Heavy LB-X Weapon (Solid).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy LRM Weapon.blk
+++ b/data/mekfiles/handheld/Heavy LRM Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy Rotary AC Weapon.blk
+++ b/data/mekfiles/handheld/Heavy Rotary AC Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy Streak Weapon.blk
+++ b/data/mekfiles/handheld/Heavy Streak Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Heavy Thunderbolt Weapon.blk
+++ b/data/mekfiles/handheld/Heavy Thunderbolt Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/LRM Weapon.blk
+++ b/data/mekfiles/handheld/LRM Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Light Anti-Infantry Weapon.blk
+++ b/data/mekfiles/handheld/Light Anti-Infantry Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Light Autocannon Weapon.blk
+++ b/data/mekfiles/handheld/Light Autocannon Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Light Laser Weapon.blk
+++ b/data/mekfiles/handheld/Light Laser Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Light Machine Gun Weapon.blk
+++ b/data/mekfiles/handheld/Light Machine Gun Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/MML Weapon.blk
+++ b/data/mekfiles/handheld/MML Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Machine Gun Weapon.blk
+++ b/data/mekfiles/handheld/Machine Gun Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Magshot Gauss Weapon.blk
+++ b/data/mekfiles/handheld/Magshot Gauss Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Nail_Rivet Gun Tool.blk
+++ b/data/mekfiles/handheld/Nail_Rivet Gun Tool.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Rocket Launcher Weapon.blk
+++ b/data/mekfiles/handheld/Rocket Launcher Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Small Laser Weapon.blk
+++ b/data/mekfiles/handheld/Small Laser Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Streak SRM Weapon.blk
+++ b/data/mekfiles/handheld/Streak SRM Weapon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/handheld/Triple Nail_Rivet Gun Tool.blk
+++ b/data/mekfiles/handheld/Triple Nail_Rivet Gun Tool.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Clan/Clan Anti-Infantry Clan Jade Falcon Police.blk
+++ b/data/mekfiles/infantry/3085/Clan/Clan Anti-Infantry Clan Jade Falcon Police.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Clan/Clan Heavy Foot Infantry Ebon Keshik Point.blk
+++ b/data/mekfiles/infantry/3085/Clan/Clan Heavy Foot Infantry Ebon Keshik Point.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Clan/Clan Space Marine Clan Snow Raven Space Marines.blk
+++ b/data/mekfiles/infantry/3085/Clan/Clan Space Marine Clan Snow Raven Space Marines.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Clan/Motorized Infantry Dark Caste Bandits.blk
+++ b/data/mekfiles/infantry/3085/Clan/Motorized Infantry Dark Caste Bandits.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Comstar/Motorized XCT Infantry Explorer Corps Hostile Environment.blk
+++ b/data/mekfiles/infantry/3085/Comstar/Motorized XCT Infantry Explorer Corps Hostile Environment.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Comstar/Space Marine Com Guards Warship Fleet Marine.blk
+++ b/data/mekfiles/infantry/3085/Comstar/Space Marine Com Guards Warship Fleet Marine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Comstar/Surveillance Specialist Com Guards Battlefield Data Miners.blk
+++ b/data/mekfiles/infantry/3085/Comstar/Surveillance Specialist Com Guards Battlefield Data Miners.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Corporations/Heavy Support Infantry Irian Technologies SWAT Team.blk
+++ b/data/mekfiles/infantry/3085/Corporations/Heavy Support Infantry Irian Technologies SWAT Team.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Corporations/Hover Assault Infantry Johnston Industries Rapid Response Force.blk
+++ b/data/mekfiles/infantry/3085/Corporations/Hover Assault Infantry Johnston Industries Rapid Response Force.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Corporations/VTOL Infantry Hachiman Taro Enterprise Extraction Force.blk
+++ b/data/mekfiles/infantry/3085/Corporations/VTOL Infantry Hachiman Taro Enterprise Extraction Force.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Davion/Frogmen Blue Water Marine Response Teams (Frogmen).blk
+++ b/data/mekfiles/infantry/3085/Davion/Frogmen Blue Water Marine Response Teams (Frogmen).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Davion/Mountaineer 45th Cerulean Mountain Infantry.blk
+++ b/data/mekfiles/infantry/3085/Davion/Mountaineer 45th Cerulean Mountain Infantry.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Davion/SpecOps Paratrooper MI6 Extraction Team.blk
+++ b/data/mekfiles/infantry/3085/Davion/SpecOps Paratrooper MI6 Extraction Team.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/FRR/Anti-Mech Jump Infantry Third Ueda Infantry.blk
+++ b/data/mekfiles/infantry/3085/FRR/Anti-Mech Jump Infantry Third Ueda Infantry.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/FRR/Clan Assault Infantry Ghost Bear Heavy Solahma Infantry.blk
+++ b/data/mekfiles/infantry/3085/FRR/Clan Assault Infantry Ghost Bear Heavy Solahma Infantry.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/FRR/Clan Mechanized Infantry MimirWatch Counter Insurgency Point.blk
+++ b/data/mekfiles/infantry/3085/FRR/Clan Mechanized Infantry MimirWatch Counter Insurgency Point.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/FRR/Motorized Heavy Infantry MotstandMimir Troop.blk
+++ b/data/mekfiles/infantry/3085/FRR/Motorized Heavy Infantry MotstandMimir Troop.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Hell Horses/AA Mechanized Infantry Mechanized AA Infantry.blk
+++ b/data/mekfiles/infantry/3085/Hell Horses/AA Mechanized Infantry Mechanized AA Infantry.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Hell Horses/Clan Foot Infantry Ad Hoc Point.blk
+++ b/data/mekfiles/infantry/3085/Hell Horses/Clan Foot Infantry Ad Hoc Point.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Hell Horses/Clan Heavy Jump Infantry Heavy Infantry Point.blk
+++ b/data/mekfiles/infantry/3085/Hell Horses/Clan Heavy Jump Infantry Heavy Infantry Point.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Hell Horses/Fast Recon Cavalry Point.blk
+++ b/data/mekfiles/infantry/3085/Hell Horses/Fast Recon Cavalry Point.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Kurita/Ceremonial Guard Otomo Guard.blk
+++ b/data/mekfiles/infantry/3085/Kurita/Ceremonial Guard Otomo Guard.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Kurita/Heavy Jump Infantry DEST Heavy Response Platoon.blk
+++ b/data/mekfiles/infantry/3085/Kurita/Heavy Jump Infantry DEST Heavy Response Platoon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Kurita/Mechanized Field Artillery 71st Mechanized.blk
+++ b/data/mekfiles/infantry/3085/Kurita/Mechanized Field Artillery 71st Mechanized.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Kurita/Recon Infantry Recon Battalion 201st Pesht Assault Team 3rd Proserpina Hussars.blk
+++ b/data/mekfiles/infantry/3085/Kurita/Recon Infantry Recon Battalion 201st Pesht Assault Team 3rd Proserpina Hussars.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Liao/Commando CCAF Battlefield Infiltration Units.blk
+++ b/data/mekfiles/infantry/3085/Liao/Commando CCAF Battlefield Infiltration Units.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Liao/Missile Artillery Infantry Kommando Special Forces.blk
+++ b/data/mekfiles/infantry/3085/Liao/Missile Artillery Infantry Kommando Special Forces.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Liao/Sniper House Dai Da Chi Snipers.blk
+++ b/data/mekfiles/infantry/3085/Liao/Sniper House Dai Da Chi Snipers.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Marik/AA Jump Infantry 292nd League Regulars.blk
+++ b/data/mekfiles/infantry/3085/Marik/AA Jump Infantry 292nd League Regulars.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Marik/Beast Infantry (Aerial).blk
+++ b/data/mekfiles/infantry/3085/Marik/Beast Infantry (Aerial).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Marik/Heavy Jump Infantry Royal Gurkha Battalion.blk
+++ b/data/mekfiles/infantry/3085/Marik/Heavy Jump Infantry Royal Gurkha Battalion.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Marik/Xenoplanetary Infantry Eagle Corps Eyrie Defense Force.blk
+++ b/data/mekfiles/infantry/3085/Marik/Xenoplanetary Infantry Eagle Corps Eyrie Defense Force.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Mercenary/Scout Infantry The Battle Corps - Baker Street Irregulars.blk
+++ b/data/mekfiles/infantry/3085/Mercenary/Scout Infantry The Battle Corps - Baker Street Irregulars.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Mercenary/Submersible Mechanized Infantry Kraken Unleashed - The Mermen.blk
+++ b/data/mekfiles/infantry/3085/Mercenary/Submersible Mechanized Infantry Kraken Unleashed - The Mermen.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Mercenary/TAG Spotter Infantry Stalwart Support - Spotter Infantry.blk
+++ b/data/mekfiles/infantry/3085/Mercenary/TAG Spotter Infantry Stalwart Support - Spotter Infantry.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/MoC/Assault Commando Ebon Magistrate Shock Troops.blk
+++ b/data/mekfiles/infantry/3085/MoC/Assault Commando Ebon Magistrate Shock Troops.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/MoC/Field Medic Magistracy Medical Corp.blk
+++ b/data/mekfiles/infantry/3085/MoC/Field Medic Magistracy Medical Corp.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/MoC/Foot Infantry Raventhir's Infantry Guard.blk
+++ b/data/mekfiles/infantry/3085/MoC/Foot Infantry Raventhir's Infantry Guard.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/MoC/Heavy Mountain Infantry Magistracy Cavaliers.blk
+++ b/data/mekfiles/infantry/3085/MoC/Heavy Mountain Infantry Magistracy Cavaliers.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Periphery Pirate/Assassin Skaret Assassins.blk
+++ b/data/mekfiles/infantry/3085/Periphery Pirate/Assassin Skaret Assassins.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Periphery Pirate/Ceremonial Guard Caesars Royal Guard Marion Hegemony.blk
+++ b/data/mekfiles/infantry/3085/Periphery Pirate/Ceremonial Guard Caesars Royal Guard Marion Hegemony.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Periphery Pirate/Pirate Lady Death's Pacification Squads.blk
+++ b/data/mekfiles/infantry/3085/Periphery Pirate/Pirate Lady Death's Pacification Squads.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/RAF/Foot Ballistic Rifle Hastati V.blk
+++ b/data/mekfiles/infantry/3085/RAF/Foot Ballistic Rifle Hastati V.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/RAF/Jump Laser Infantry Principes III 103rd Jump Battalion.blk
+++ b/data/mekfiles/infantry/3085/RAF/Jump Laser Infantry Principes III 103rd Jump Battalion.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/RAF/Motorized MG Galatean Support Wheels.blk
+++ b/data/mekfiles/infantry/3085/RAF/Motorized MG Galatean Support Wheels.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/RAF/Special Forces Stone's Trackers.blk
+++ b/data/mekfiles/infantry/3085/RAF/Special Forces Stone's Trackers.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Steiner/Anti-Infantry Unit Second Lyran Armored Infantry.blk
+++ b/data/mekfiles/infantry/3085/Steiner/Anti-Infantry Unit Second Lyran Armored Infantry.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Steiner/Combat Engineer Royal Engineers 1st Lyran Royal Guards RCT.blk
+++ b/data/mekfiles/infantry/3085/Steiner/Combat Engineer Royal Engineers 1st Lyran Royal Guards RCT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Steiner/HALO Paratrooper Lyran Paratrooper Corps.blk
+++ b/data/mekfiles/infantry/3085/Steiner/HALO Paratrooper Lyran Paratrooper Corps.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Steiner/Heavy Infantry Heavy Urban Response Platoon.blk
+++ b/data/mekfiles/infantry/3085/Steiner/Heavy Infantry Heavy Urban Response Platoon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Taurian/Field Gun Infantry Motorized Batteries.blk
+++ b/data/mekfiles/infantry/3085/Taurian/Field Gun Infantry Motorized Batteries.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Taurian/Minesweepers Thirty-fifth Cluster Support Force Red Chasseurs.blk
+++ b/data/mekfiles/infantry/3085/Taurian/Minesweepers Thirty-fifth Cluster Support Force Red Chasseurs.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Taurian/SRM Foot Infantry Taurian Citizens' Militia.blk
+++ b/data/mekfiles/infantry/3085/Taurian/SRM Foot Infantry Taurian Citizens' Militia.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Taurian/XCT Marine Special Asteroid Support Forces.blk
+++ b/data/mekfiles/infantry/3085/Taurian/XCT Marine Special Asteroid Support Forces.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Word of Blake/Mechanized Assault XCT Word of Blake Militia NBC.blk
+++ b/data/mekfiles/infantry/3085/Word of Blake/Mechanized Assault XCT Word of Blake Militia NBC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Word of Blake/Riot Police Word of Blake Protectorate Militia Pacification Unit.blk
+++ b/data/mekfiles/infantry/3085/Word of Blake/Riot Police Word of Blake Protectorate Militia Pacification Unit.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Word of Blake/Tau Wraith Manei Domini Recon Squad.blk
+++ b/data/mekfiles/infantry/3085/Word of Blake/Tau Wraith Manei Domini Recon Squad.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/3085/Word of Blake/Tau Zombie Manei Domini Attack Squad.blk
+++ b/data/mekfiles/infantry/3085/Word of Blake/Tau Zombie Manei Domini Attack Squad.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Arrow IV 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Arrow IV 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Sniper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Sniper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Thumper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Thumper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Motorized Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Arrow IV 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Arrow IV 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Sniper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Sniper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Thumper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Thumper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Tracked Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Arrow IV 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Arrow IV 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Sniper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Sniper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Thumper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Thumper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Artillery Platoon (AFFS) (Wheeled Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized AC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized LBX5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized RAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized RAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized RAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized RAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Motorized UAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked AC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked LBX5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked RAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked RAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked RAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked RAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Tracked UAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled AC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled LBX5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled RAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled RAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled RAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled RAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC10 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC10 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC2 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC2 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC20 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC20 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC5 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Field Gun Platoon (AFFS) (Wheeled UAC5 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Flamer 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Flamer 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (LRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (LRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser Marine 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser Marine 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser Paratrooper 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser Paratrooper 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser XCT 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Laser XCT 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (MG 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (MG 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Recoilless 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Recoilless 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Rifle 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Rifle 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Rifle AA 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Rifle AA 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Rifle Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Rifle Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Riot Police 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Riot Police 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Sniper Detachment 2505+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (Sniper Detachment 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SpecOps Fireteam 2860+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SpecOps Fireteam 2860+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SpecOps Fireteam 3028+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SpecOps Fireteam 3028+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SpecOps Fireteam 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Foot Platoon (AFFS) (SpecOps Fireteam 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Flamer 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Flamer 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (LRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (LRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Laser 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Laser 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Laser Anti-Mek 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Laser Anti-Mek 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (MG 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (MG 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Rifle 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Rifle 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Rifle Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (Rifle Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (SRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Jump Platoon (AFFS) (SRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Flamer 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Flamer 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (LRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (LRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Laser 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Laser 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Laser Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Laser Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (MG 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (MG 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Rifle 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (Rifle 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (SRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Hover Platoon (AFFS) (SRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Combat Engineers 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Combat Engineers 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Flamer 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Flamer 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (LRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (LRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Laser 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Laser 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (MG 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (MG 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Rifle 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Rifle 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Rifle AA 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Rifle AA 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Rifle Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Rifle Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (SRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (SRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Tracked Platoon (AFFS) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Combat Engineers 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Combat Engineers 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Flamer 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Flamer 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (LRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (LRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Laser 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Laser 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Laser XCT 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Laser XCT 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (MG 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (MG 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Recoilless 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Recoilless 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Rifle 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Rifle 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Rifle AA 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Rifle AA 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Rifle Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (Rifle Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (SRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Mechanized Wheeled Platoon (AFFS) (SRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Combat Engineers 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Combat Engineers 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Flamer 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Flamer 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Gauss 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Gauss 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (LRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (LRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Laser 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Laser 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Laser Anti-Mek 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Laser Anti-Mek 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Laser XCT 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Laser XCT 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (MG 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (MG 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Recoilless 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Recoilless 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Rifle 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Rifle 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Rifle AA 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Rifle AA 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Rifle Heavy 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Rifle Heavy 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Riot Police 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Riot Police 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (SRM 3067+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (SRM 3067+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/AFFS/Motorized Platoon (AFFS) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Auto Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Auto Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Branth/Beast Infantry (Branth)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Auto Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Auto Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Camel/Beast Infantry (Camel)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Auto Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Auto Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Coventry Kangaroo/Beast Infantry (Kangaroo)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Auto Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Auto Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Donkey/Beast Infantry (Donkey)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Auto-Rifle_MG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Auto-Rifle_MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Gyrojet_GL).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Gyrojet_GL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Laser Rifle_MRR).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Laser Rifle_MRR).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Laser Rifle_Support PPC).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Laser Rifle_Support PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Needler_SRM).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Needler_SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Pistol_Mortar).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Pistol_Mortar).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Pulse Laser_Plasma Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Pulse Laser_Plasma Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Pulse Laser_Support Pulse).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Elephant/Beast Infantry (Elephant)(Pulse Laser_Support Pulse).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_Auto-Cannon).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_Auto-Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_LRR).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_LRR).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_SRM).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_Support MG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Auto-Rifle_Support MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Laser Rifle_GL).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(Laser Rifle_GL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(SMG_GL).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Hipposaur/Beast Infantry (Hipposaur)(SMG_GL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Auto Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Auto Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Horse/Beast Infantry (Horse)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Auto-Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Auto-Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Odessan Raxx/Beast Infantry (Odessan Raxx)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Orca/Beast Infantry (Orca)(Gyrojet_Support Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Orca/Beast Infantry (Orca)(Gyrojet_Support Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Orca/Beast Infantry (Orca)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Orca/Beast Infantry (Orca)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Auto Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Auto Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tabiranth/Beast Infantry (Tabiranth)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Auto-Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Auto-Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Gyrojet).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Gyrojet).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Laser Rifle).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Laser Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Needler).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Needler).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Pulse Laser).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Pulse Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(SMG).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(SMG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Shotgun).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Shotgun).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Sniper).blk
+++ b/data/mekfiles/infantry/Beast Mounted/Tariq/Beast Infantry (Tariq)(Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Arrow IV 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Arrow IV 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Arrow IV 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Arrow IV 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Motorized Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Arrow IV 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Arrow IV 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Arrow IV 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Arrow IV 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Tracked Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Arrow IV 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Arrow IV 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Arrow IV 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Arrow IV 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Artillery Platoon (CCAF) (Wheeled Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC10 2465+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC10 2465+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC10 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC10 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC10 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC10 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC2 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC2 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC2 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC2 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC2 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC2 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC20 2502+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC20 2502+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC20 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC20 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC20 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC20 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC5 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC5 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC5 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC5 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC5 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized AC5 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized HVAC10 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized HVAC10 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized HVAC2 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized HVAC2 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized HVAC5 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized HVAC5 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized Heavy Cannon 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized Heavy Cannon 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized LAC2 3070+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized LAC2 3070+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized LAC5 3070+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized LAC5 3070+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized Medium Cannon 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Motorized Medium Cannon 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC10 2465+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC10 2465+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC10 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC10 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC10 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC10 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC2 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC2 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC2 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC2 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC2 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC2 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC20 2502+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC20 2502+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC20 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC20 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC20 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC20 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC5 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC5 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC5 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC5 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC5 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked AC5 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked HVAC10 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked HVAC10 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked HVAC2 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked HVAC2 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked HVAC5 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked HVAC5 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked Heavy Cannon 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked Heavy Cannon 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX10 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX10 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX2 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX20 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX5 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked Medium Cannon 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked Medium Cannon 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC10 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC10 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC2 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC20 3061+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC20 3061+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC5 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Tracked UAC5 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC10 2465+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC10 2465+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC10 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC10 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC10 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC10 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC2 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC2 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC2 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC2 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC2 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC2 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC20 2502+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC20 2502+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC20 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC20 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC20 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC20 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC5 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC5 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC5 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC5 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC5 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled AC5 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled HVAC10 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled HVAC10 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled HVAC2 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled HVAC2 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled HVAC5 3059+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled HVAC5 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled Heavy Cannon 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled Heavy Cannon 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX10 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX10 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX2 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX20 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX5 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled Medium Cannon 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled Medium Cannon 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC10 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC10 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC2 3060+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC20 3061+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC20 3061+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC5 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Field Gun Platoon (CCAF) (Wheeled UAC5 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Flamer 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Flamer 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Flamer 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Flamer 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Flamer 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Flamer 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (LRM 3057+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (LRM 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser Marine 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser Marine 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser XCT 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser XCT 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser XCT 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Laser XCT 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (MG 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (MG 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (MG 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (MG 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (MG 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (MG 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Mortar 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Mortar 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Plasma 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Plasma 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Recoilless 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Recoilless 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Recoilless 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Recoilless 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle AA 2590+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle AA 2590+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Riot Police 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Riot Police 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Riot Police 3030+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Riot Police 3030+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Riot Police 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Riot Police 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SRM 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SRM 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SRM 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SRM 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SRM 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SRM 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Sappers 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Sappers 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Sniper Detachment 2505+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Sniper Detachment 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Sniper Detachment 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (Sniper Detachment 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Demoteam 3028+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Demoteam 3028+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Demoteam 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Demoteam 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Fireteam 2505+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Fireteam 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Fireteam 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Fireteam 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Fireteam 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Foot Platoon (CCAF) (SpecOps Fireteam 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (ER Laser 3052+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (ER Laser 3052+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Flamer 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Flamer 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Flamer 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Flamer 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Flamer 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Flamer 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Gauss 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Gauss 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (LRM 3057+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (LRM 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser 2500+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (MG 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (MG 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (MG 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (MG 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (MG 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (MG 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Plasma 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Plasma 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 2500+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (Rifle 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (SRM 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (SRM 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (SRM 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (SRM 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (SRM 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Jump Platoon (CCAF) (SRM 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Flamer 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Flamer 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Flamer 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Flamer 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Flamer 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Flamer 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Gauss 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Gauss 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (LRM 3057+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (LRM 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Laser 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Laser 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Laser 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Laser 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (MG 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (MG 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (MG 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (MG 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (MG 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (MG 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Plasma 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Plasma 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Rifle 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Rifle 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Rifle 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Rifle 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Rifle 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (Rifle 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (SRM 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (SRM 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (SRM 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (SRM 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (SRM 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Hover Platoon (CCAF) (SRM 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Combat Engineers 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Combat Engineers 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Combat Engineers 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Combat Engineers 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Flamer 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Flamer 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Flamer 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Flamer 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Flamer 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Flamer 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Gauss 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Gauss 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (LRM 3057+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (LRM 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Laser 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Laser 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Laser 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Laser 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (MG 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (MG 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (MG 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (MG 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (MG 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (MG 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Mortar 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Mortar 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Plasma 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Plasma 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Recoilless 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Recoilless 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle AA 2590+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle AA 2590+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (SRM 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (SRM 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (SRM 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (SRM 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (SRM 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (SRM 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Sappers 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Tracked Platoon (CCAF) (Sappers 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Combat Engineers 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Combat Engineers 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Combat Engineers 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Combat Engineers 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Flamer 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Flamer 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Flamer 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Flamer 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Flamer 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Flamer 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Gauss 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Gauss 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (LRM 3057+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (LRM 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser XCT 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser XCT 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser XCT 2380+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Laser XCT 2380+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (MG 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (MG 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (MG 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (MG 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (MG 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (MG 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Mortar 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Mortar 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Plasma 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Plasma 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Recoilless 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Recoilless 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Recoilless 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Recoilless 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle AA 2590+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle AA 2590+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (SRM 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (SRM 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (SRM 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (SRM 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (SRM 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Mechanized Wheeled Platoon (CCAF) (SRM 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Combat Engineers 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Combat Engineers 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Combat Engineers 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Combat Engineers 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Flamer 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Flamer 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Flamer 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Flamer 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Flamer 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Flamer 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Gauss 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Gauss 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (LRM 3057+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (LRM 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser 2500+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser XCT 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser XCT 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser XCT 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Laser XCT 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (MG 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (MG 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (MG 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (MG 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (MG 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (MG 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Mortar 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Mortar 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Plasma 3063+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Plasma 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Recoilless 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Recoilless 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Recoilless 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Recoilless 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 2500+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle AA 2590+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle AA 2590+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Riot Police 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Riot Police 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Riot Police 3030+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Riot Police 3030+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Riot Police 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Riot Police 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (SRM 2400+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (SRM 2400+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (SRM 3045+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (SRM 3045+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (SRM 3055+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (SRM 3055+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Sappers 2367+).blk
+++ b/data/mekfiles/infantry/CCAF/Motorized Platoon (CCAF) (Sappers 2367+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Tracked Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Tracked Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Tracked Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Tracked Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Tracked Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Tracked Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Wheeled Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Wheeled Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Wheeled Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Wheeled Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Wheeled Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (ComGuards) (Wheeled Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Tracked Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Tracked Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Tracked Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Tracked Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Tracked Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Tracked Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Wheeled Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Wheeled Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Wheeled Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Wheeled Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Wheeled Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Level I (WOBM) (Wheeled Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Tracked Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Tracked Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Tracked Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Tracked Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Tracked Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Tracked Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Wheeled Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Wheeled Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Wheeled Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Wheeled Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Wheeled Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery Platoon (ComStar) (Wheeled Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (ComGuards) (Motorized Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (ComGuards) (Motorized Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (ComGuards) (Motorized Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (ComGuards) (Motorized Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (ComGuards) (Motorized Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (ComGuards) (Motorized Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (WOBM) (Motorized Arrow IV).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (WOBM) (Motorized Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (WOBM) (Motorized Sniper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (WOBM) (Motorized Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (WOBM) (Motorized Thumper).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Artillery demi-I (WOBM) (Motorized Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked Light Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked RAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked RAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Tracked UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled Light Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled RAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled RAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (ComGuards) (Wheeled UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked Light Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked RAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked RAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Tracked UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled Light Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled RAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled RAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Level I (WOBM) (Wheeled UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Tracked UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun Platoon (ComStar) (Wheeled UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized Light Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized RAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized RAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (ComGuards) (Motorized UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized Light Gauss).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized RAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized RAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC10).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC2).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC20).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC5).blk
+++ b/data/mekfiles/infantry/CS WOB/Field Gun demi-I (WOBM) (Motorized UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot Platoon (ComStar) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (ComGuards) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (Laser Scout).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (Laser Scout).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (Domini) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Foot demi-I (WOBM) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (ComGuards) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Level I (WOBM) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Hover Platoon (ComStar) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (ComGuards) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (Domini) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (Domini) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (Domini) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (Domini) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (Domini) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (Domini) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Level I (WOBM) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Jump Platoon (ComStar) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized Platoon (ComStar) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (ComGuards) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (Laser Scout).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (Laser Scout).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (Domini) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Motorized demi-I (WOBM) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (ComGuards) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Level I (WOBM) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Tracked Platoon (ComStar) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (ComGuards) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (LRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Level I (WOBM) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (Flamer).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (Laser).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (MG).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (Rifle).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (SRM).blk
+++ b/data/mekfiles/infantry/CS WOB/Wheeled Platoon (ComStar) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Arrow IV).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Sniper).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Thumper).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Arrow IV).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Sniper).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Thumper).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AP Gauss Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AP Gauss Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC4 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC4 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC8 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC8 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked LBX10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked LBX10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC4 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC4 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC8 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC8 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked UAC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked UAC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled LBX10 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled LBX10 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC2 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC2 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC4 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC4 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC8 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC8 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled UAC5 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled UAC5 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (LRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (LRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Marine).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Marine).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (MG Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (MG Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (MG Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (MG Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Mauser 960 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Mauser 960 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Light).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Light).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Foot Point (Watch Detachment Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Foot Point (Watch Detachment Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (LRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (LRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (MG Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (MG Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (MG Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (MG Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser IIC Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser IIC Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (ER Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (ER Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (LRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (LRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Mauser IIC Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Mauser IIC Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (ER Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (ER Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (LRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (LRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser 960 Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser 960 Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser IIC Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser IIC Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (LRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (LRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Mauser IIC Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Mauser IIC Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Bearhunter Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Bearhunter Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (LRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (LRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Light).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Light).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Advanced).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Advanced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Basic).blk
+++ b/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Arrow IV 3044+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Arrow IV 3044+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Sniper 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Sniper 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Thumper 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Thumper 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Motorized Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Arrow IV 3044+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Arrow IV 3044+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Sniper 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Sniper 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Thumper 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Thumper 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Tracked Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Arrow IV 3044+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Arrow IV 3044+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Sniper 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Sniper 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Thumper 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Thumper 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Artillery Platoon (DCMS) (Wheeled Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC10 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC10 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC2 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC2 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC20 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC20 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC5 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized AC5 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized LAC2 3070+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized LAC2 3070+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized LAC5 3070+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Motorized LAC5 3070+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC10 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC10 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC2 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC2 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC20 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC20 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC5 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked AC5 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked Gauss 3040+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked Gauss 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX10 3040+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX10 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX2 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX20 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX5 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC10 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC10 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC2 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC20 3061+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC20 3061+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC5 3040+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Tracked UAC5 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC10 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC10 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC2 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC2 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC20 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC20 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC5 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled AC5 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled Gauss 3040+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled Gauss 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX10 3040+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX10 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX2 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX20 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX5 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC10 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC10 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC2 3060+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC20 3061+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC20 3061+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC5 3040+).blk
+++ b/data/mekfiles/infantry/DCMS/Field Gun Platoon (DCMS) (Wheeled UAC5 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Flamer 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Flamer 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Gauss 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Gauss 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Laser 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Laser 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Laser Marine 2460+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Laser Marine 2460+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Laser XCT 2460+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Laser XCT 2460+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (MG 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (MG 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (MRM 3063+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (MRM 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Rifle 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Rifle 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Rifle AA 3057+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Rifle AA 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Rifle Light 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Rifle Light 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Riot Police 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Riot Police 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (SRM 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (SRM 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Sniper Detachment 2500+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Sniper Detachment 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Sniper Detachment 2785+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (Sniper Detachment 2785+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (SpecOps Fireteam 2500+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (SpecOps Fireteam 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (SpecOps Fireteam 2785+).blk
+++ b/data/mekfiles/infantry/DCMS/Foot Platoon (DCMS) (SpecOps Fireteam 2785+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Flamer 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Flamer 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Gauss 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Gauss 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Laser 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Laser 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (MG 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (MG 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Rifle 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (Rifle 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (SRM 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Jump Platoon (DCMS) (SRM 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Flamer 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Flamer 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Gauss 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Gauss 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Laser 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Laser 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (MG 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (MG 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (MRM 3063+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (MRM 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Rifle 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (Rifle 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (SRM 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Hover Platoon (DCMS) (SRM 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Combat Engineers 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Combat Engineers 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Flamer 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Flamer 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Gauss 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Gauss 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Laser 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Laser 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (MG 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (MG 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (MG Support 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (MG Support 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (MRM 3063+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (MRM 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (PPC 3075+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (PPC 3075+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Rifle 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Rifle 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Rifle AA 3057+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Rifle AA 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (SRM 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (SRM 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (SRM Support 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (SRM Support 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Tracked Platoon (DCMS) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Combat Engineers 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Combat Engineers 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Flamer 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Flamer 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Gauss 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Gauss 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Laser 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Laser 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Laser XCT 2460+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Laser XCT 2460+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (MG 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (MG 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (MRM 3063+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (MRM 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Rifle 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Rifle 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Rifle AA 3057+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (Rifle AA 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (SRM 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Mechanized Wheeled Platoon (DCMS) (SRM 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Combat Engineers 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Combat Engineers 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Flamer 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Flamer 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Gauss 3053+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Gauss 3053+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Laser 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Laser 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Laser XCT 2460+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Laser XCT 2460+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (MG 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (MG 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (MRM 3063+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (MRM 3063+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Rifle 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Rifle 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Rifle AA 3057+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Rifle AA 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Rifle Light 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Rifle Light 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Riot Police 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Riot Police 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (SRM 2620+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (SRM 2620+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/DCMS/Motorized Platoon (DCMS) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Motorized Arrow IV 3044+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Motorized Arrow IV 3044+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Motorized Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Motorized Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Motorized Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Motorized Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Arrow IV 3044+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Arrow IV 3044+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Sniper 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Sniper 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Thumper 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Thumper 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Tracked Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Arrow IV 3044+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Arrow IV 3044+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Sniper 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Sniper 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Thumper 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Thumper 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Artillery Platoon (FWLM) (Wheeled Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC10 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC10 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC2 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC2 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC20 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC20 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC5 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized AC5 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized LAC2 3070+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized LAC2 3070+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized LAC5 3070+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Motorized LAC5 3070+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC10 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC10 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC2 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC2 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC20 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC20 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC5 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked AC5 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked Gauss 3040+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked Gauss 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX10 3040+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX10 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX2 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX20 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX5 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked Light Gauss 3056+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked Light Gauss 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC10 3057+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC10 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC2 3057+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC2 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC20 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC5 3040+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Tracked UAC5 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC10 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC10 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC2 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC2 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC20 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC20 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC5 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled AC5 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled Gauss 3040+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled Gauss 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX10 3040+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX10 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX2 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX20 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX5 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled Light Gauss 3056+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled Light Gauss 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC10 3057+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC10 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC2 3057+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC2 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC20 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC5 3040+).blk
+++ b/data/mekfiles/infantry/FWLM/Field Gun Platoon (FWLM) (Wheeled UAC5 3040+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Flamer 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Flamer 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Gauss 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Gauss 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (LRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (LRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Laser 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Laser 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Laser Marine 2880+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Laser Marine 2880+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Laser XCT 2880+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Laser XCT 2880+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (MG 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (MG 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Rifle 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Rifle 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Riot Police 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Riot Police 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (SRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (SRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Sniper Detachment 2505+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (Sniper Detachment 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (SpecOps Fireteam 2505+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (SpecOps Fireteam 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (SpecOps Fireteam 3050+).blk
+++ b/data/mekfiles/infantry/FWLM/Foot Platoon (FWLM) (SpecOps Fireteam 3050+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Flamer 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Flamer 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Gauss 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Gauss 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (LRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (LRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser 2500+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser Anti-Mek 3052+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser Anti-Mek 3052+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser TAG 3051+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Laser TAG 3051+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (MG 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (MG 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Rifle 2500+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Rifle 2500+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Rifle 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (Rifle 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (SRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Jump Platoon (FWLM) (SRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (ER Laser 3052+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (ER Laser 3052+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Flamer 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Flamer 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Gauss 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Gauss 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (LRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (LRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Laser 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Laser 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (MG 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (MG 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Rifle 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (Rifle 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (SRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Hover Platoon (FWLM) (SRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Combat Engineers 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Combat Engineers 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (ER Laser Heavy 3059+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (ER Laser Heavy 3059+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Flamer 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Flamer 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Gauss 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Gauss 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (LRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (LRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Laser 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Laser 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (MG 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (MG 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Rifle 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Rifle 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (SRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (SRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Tracked Platoon (FWLM) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Combat Engineers 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Combat Engineers 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Flamer 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Flamer 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Gauss 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Gauss 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (LRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (LRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Laser 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Laser 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Laser XCT 2880+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Laser XCT 2880+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (MG 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (MG 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Rifle 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Rifle 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (SRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Mechanized Wheeled Platoon (FWLM) (SRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Combat Engineers 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Combat Engineers 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Flamer 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Flamer 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Gauss 3060+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Gauss 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (LRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (LRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Laser 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Laser 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Laser XCT 2880+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Laser XCT 2880+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (MG 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (MG 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Rifle 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Rifle 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Rifle AA 3056+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Rifle AA 3056+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Riot Police 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Riot Police 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (SRM 3035+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (SRM 3035+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Sappers 2315+).blk
+++ b/data/mekfiles/infantry/FWLM/Motorized Platoon (FWLM) (Sappers 2315+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Artillery (ArrowIV).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Artillery (ArrowIV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Artillery (Sniper).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Artillery (Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Artillery (Thumper).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Artillery (Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (Gauss).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX10).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX20).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (RAC2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (RAC5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC10).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC20).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Clan Field Gunners (UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Artillery (Arrow IV).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Artillery (Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Artillery (Sniper).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Artillery (Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Artillery (Thumper).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Artillery (Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (AC10).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (AC2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (AC20).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (AC5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (Gauss).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (LAC2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (LAC5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX10).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX20).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (LBX5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (Light Gauss).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (RAC2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (RAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (RAC5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (RAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC10).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC2).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC20).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC5).blk
+++ b/data/mekfiles/infantry/Field Gunners/Field Gunners (UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHD/Foot Platoon (Gauss).blk
+++ b/data/mekfiles/infantry/HBHD/Foot Platoon (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHD/Jump Platoon (Gauss).blk
+++ b/data/mekfiles/infantry/HBHD/Jump Platoon (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHD/Motorized Platoon (Gauss).blk
+++ b/data/mekfiles/infantry/HBHD/Motorized Platoon (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHM/Foot Platoon (Rifle AA).blk
+++ b/data/mekfiles/infantry/HBHM/Foot Platoon (Rifle AA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHM/Jump Platoon (Rifle AA).blk
+++ b/data/mekfiles/infantry/HBHM/Jump Platoon (Rifle AA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHM/Mechanized Hover Platoon (Rifle AA).blk
+++ b/data/mekfiles/infantry/HBHM/Mechanized Hover Platoon (Rifle AA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHM/Mechanized Tracked Platoon (Rifle AA).blk
+++ b/data/mekfiles/infantry/HBHM/Mechanized Tracked Platoon (Rifle AA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHM/Mechanized Wheeled Platoon (Rifle AA).blk
+++ b/data/mekfiles/infantry/HBHM/Mechanized Wheeled Platoon (Rifle AA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHM/Motorized Platoon (Rifle AA).blk
+++ b/data/mekfiles/infantry/HBHM/Motorized Platoon (Rifle AA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHS/Foot Platoon (Flechette).blk
+++ b/data/mekfiles/infantry/HBHS/Foot Platoon (Flechette).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/HBHS/Motorized Platoon (Flechette).blk
+++ b/data/mekfiles/infantry/HBHS/Motorized Platoon (Flechette).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Arrow IV 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Arrow IV 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Sniper 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Sniper 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Thumper 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Thumper 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Motorized Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Arrow IV 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Arrow IV 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Sniper 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Sniper 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Thumper 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Thumper 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Tracked Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Arrow IV 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Arrow IV 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Sniper 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Sniper 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Sniper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Sniper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Thumper 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Thumper 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Thumper Cannon 3079+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Artillery Platoon (LCAF) (Wheeled Thumper Cannon 3079+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC10 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC10 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC2 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC2 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC20 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC20 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC5 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized AC5 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized RAC2 3071+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized RAC2 3071+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized RAC5 3071+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Motorized RAC5 3071+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC10 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC10 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC2 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC2 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC20 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC20 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC5 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked AC5 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked Gauss 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked Gauss 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX10 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX10 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX2 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX20 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX5 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked SB Gauss 3080+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked SB Gauss 3080+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC10 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC10 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC2 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC20 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC5 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Tracked UAC5 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC10 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC10 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC2 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC2 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC20 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC20 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC5 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled AC5 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled Gauss 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled Gauss 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX10 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX10 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX2 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX20 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX5 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled LBX5 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled SB Gauss 3080+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled SB Gauss 3080+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC10 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC10 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC2 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC2 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC20 3060+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC20 3060+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC5 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Field Gun Platoon (LCAF) (Wheeled UAC5 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Flamer 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Flamer 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Flechette 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Flechette 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Gauss 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Gauss 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Laser 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Laser 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Laser Marine 2341+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Laser Marine 2341+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Laser XCT 3057+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Laser XCT 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (MG 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (MG 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Rifle 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Rifle 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Rifle AA 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Rifle AA 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Riot Police 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Riot Police 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (SRM 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (SRM 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Sappers 2341+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Sappers 2341+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Sniper Detachment 2505+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (Sniper Detachment 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (SpecOps Fireteam 2505+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (SpecOps Fireteam 2505+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (SpecOps Fireteam 3057+).blk
+++ b/data/mekfiles/infantry/LCAF/Foot Platoon (LCAF) (SpecOps Fireteam 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Flamer 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Flamer 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Gauss 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Gauss 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Laser 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Laser 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (MG 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (MG 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Rifle 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (Rifle 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (SRM 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Jump Platoon (LCAF) (SRM 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Flamer 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Flamer 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Gauss 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Gauss 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Laser 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Laser 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (MG 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (MG 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Rifle 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (Rifle 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (SRM 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Hover Platoon (LCAF) (SRM 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Combat Engineers 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Combat Engineers 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Flamer 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Flamer 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Gauss 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Gauss 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Gauss 3074+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Gauss 3074+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Laser 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Laser 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (MG 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (MG 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Rifle 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Rifle 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Rifle AA 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Rifle AA 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (SRM 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (SRM 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Sappers 2341+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Tracked Platoon (LCAF) (Sappers 2341+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Combat Engineers 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Combat Engineers 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Flamer 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Flamer 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Gauss 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Gauss 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Gauss 3074+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Gauss 3074+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Laser 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Laser 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Laser XCT 3057+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Laser XCT 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (MG 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (MG 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Rifle 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Rifle 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Rifle AA 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (Rifle AA 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (SRM 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Mechanized Wheeled Platoon (LCAF) (SRM 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Combat Engineers 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Combat Engineers 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Flamer 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Flamer 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Flechette 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Flechette 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Gauss 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Gauss 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (LRM 3065+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (LRM 3065+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Laser 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Laser 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Laser XCT 3057+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Laser XCT 3057+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (MG 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (MG 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Rifle 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Rifle 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Rifle AA 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Rifle AA 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Riot Police 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Riot Police 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (SRM 3058+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (SRM 3058+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Sappers 2341+).blk
+++ b/data/mekfiles/infantry/LCAF/Motorized Platoon (LCAF) (Sappers 2341+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Long Tom 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Long Tom 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Long Tom).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Long Tom).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Sniper 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Sniper 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Sniper).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Thumper 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Thumper 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Thumper).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Motorized Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Arrow IV).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Sniper 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Sniper 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Sniper Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Sniper Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Sniper).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Thumper 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Thumper 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Thumper Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Thumper Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Thumper).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Tracked Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Sniper 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Sniper 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Sniper Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Sniper Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Sniper).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Thumper 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Thumper 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Thumper Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Thumper Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Thumper).blk
+++ b/data/mekfiles/infantry/MHAF/Field Artillery Century (MHAF) (Wheeled Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC10 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC10 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC10).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC2 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC2 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC2).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC20 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC20 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC20).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC5 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC5 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC5).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized Heavy Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized Heavy Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized LAC2).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized LAC5).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized Light Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized Light Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized Medium Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Motorized Medium Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC10 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC10 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC10).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC2 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC2 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC2).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC20 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC20 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC20).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC5 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC5 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC5).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked LBX10).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked LBX10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked Light Gauss).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked UAC10).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked UAC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked UAC5).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Tracked UAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC10 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC10 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC10).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC2 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC2 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC2).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC20 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC20 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC20).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC5 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC5 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC5).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled Heavy Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled Heavy Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled LAC2).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled LAC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled LAC5).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled LAC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled Light Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled Light Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled Medium Cannon).blk
+++ b/data/mekfiles/infantry/MHAF/Field Gun Century (MHAF) (Wheeled Medium Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Contubernium (MHAF) (Command 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Contubernium (MHAF) (Command 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Contubernium (MHAF) (Command).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Contubernium (MHAF) (Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Contubernium (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Contubernium (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Duplus Contubernium (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Flamer 3049).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Flamer 3049).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Foot Triplus Contubernium (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Contubernium (MHAF) (Command 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Contubernium (MHAF) (Command 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Contubernium (MHAF) (Command).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Contubernium (MHAF) (Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Duplus Contubernium (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Jump Triplus Contubernium (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Hover Century (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Flamer 3049).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Flamer 3049).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Tracked Century (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Mechanized Wheeled Century (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Duplus Contubernium (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Flamer 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Flamer 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Flamer).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (LRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (LRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (LRM).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Laser 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Laser 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Laser).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (MG 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (MG 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (MG).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Rifle 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Rifle 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Rifle).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (SRM 3049+).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (SRM 3049+).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (SRM).blk
+++ b/data/mekfiles/infantry/MHAF/Motorized Triplus Contubernium (MHAF) (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Mobs/Mob (Huge).blk
+++ b/data/mekfiles/infantry/Mobs/Mob (Huge).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Mobs/Mob (Large).blk
+++ b/data/mekfiles/infantry/Mobs/Mob (Large).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Mobs/Mob (Medium).blk
+++ b/data/mekfiles/infantry/Mobs/Mob (Medium).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Mobs/Mob (Small).blk
+++ b/data/mekfiles/infantry/Mobs/Mob (Small).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TP Vega 3039/Field Gun Infantry AC10.blk
+++ b/data/mekfiles/infantry/TP Vega 3039/Field Gun Infantry AC10.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (Flamer).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (LRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (Laser).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (MG).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (Rifle).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (SRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Point AMT (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (Flamer).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (LRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (Laser).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (MG).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (Rifle).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (SRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Clan Foot Squad AMT (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (Flamer).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (LRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (Laser).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (MG).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (Rifle).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (SRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Platoon AMT (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (Flamer).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (LRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (Laser).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (MG).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (Rifle).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (SRM).blk
+++ b/data/mekfiles/infantry/TW/AntiMek Trained/Foot Squad AMT (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Foot Point (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Jump Point (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Hover Point (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Tracked Point (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Mechanized Wheeled Point (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Points/Clan Motorized Point (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Foot Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Jump Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Hover Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Tracked Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Mechanized Wheeled Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/Clan Squads/Clan Motorized Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Bandit Motorized Point (Rifle).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Bandit Motorized Point (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Ceremonial Platoon (Close Combat).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Ceremonial Platoon (Close Combat).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Ceremonial Platoon (MG Heavy).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Ceremonial Platoon (MG Heavy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (LRM Heavy).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (LRM Heavy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser Heavy XCT).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser Heavy XCT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser Marine).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser Marine).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser TAG).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser XCT).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Laser XCT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Light Scout).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Light Scout).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Rifle Light).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Rifle Light).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Rifle Mountain).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Rifle Mountain).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Rifle Paratrooper).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Platoon (Rifle Paratrooper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Squad (Medic).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Squad (Medic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Stealth Platoon (Rifle Paratrooper).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Stealth Platoon (Rifle Paratrooper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Foot Stealth Squad (Sniper Paratrooper).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Foot Stealth Squad (Sniper Paratrooper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Jump Platoon (Anti-Mech) (Laser).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Jump Platoon (Anti-Mech) (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Jump Platoon (GL).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Jump Platoon (GL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Jump Platoon (Laser Heavy).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Jump Platoon (Laser Heavy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Jump Stealth Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Jump Stealth Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Jump Stealth Platoon (Needler Demolition).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Jump Stealth Platoon (Needler Demolition).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Hover Platoon (Demolition).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Hover Platoon (Demolition).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Sub Platoon (SRM SCUBA).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Sub Platoon (SRM SCUBA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Tracked Platoon (Bridging).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Tracked Platoon (Bridging).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Wheeled Platoon (Laser XCT).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Mechanized Wheeled Platoon (Laser XCT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Fieldworks).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Fieldworks).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Firefighters).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Firefighters).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Gauss Heavy).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Gauss Heavy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Laser XCT).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Laser XCT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Needler Heavy).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Needler Heavy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Nonlethal).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Nonlethal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Plasma Heavy).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Platoon (Plasma Heavy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/Generic Infantry/Motorized Sub Platoon (Laser SCUBA).blk
+++ b/data/mekfiles/infantry/TW/Generic Infantry/Motorized Sub Platoon (Laser SCUBA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Foot Platoon (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Jump Platoon (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Hover Platoon (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Tracked Platoon (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Mechanized Wheeled Platoon (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Platoons/Motorized Platoon (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Foot Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Foot Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Foot Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Foot Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Foot Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Foot Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Foot Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Foot Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Foot Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Foot Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Foot Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Foot Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Jump Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Jump Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Jump Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Jump Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Jump Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Jump Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Jump Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Jump Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Jump Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Jump Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Jump Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Jump Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Hover Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Tracked Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Mechanized Wheeled Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (Flamer).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (LRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (Laser).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (MG).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (Rifle).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (SRM).blk
+++ b/data/mekfiles/infantry/TW/IS Squads/Motorized Squad (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Foot Platoon TC 3047+ (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Jump Platoon TC 3047+ (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Hover Platoon TC 3047+ (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Tracked Platoon TC 3047+ (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Mechanized Wheeled Platoon TC 3047+ (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (Flamer).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (LRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (Laser).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (MG).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (Rifle).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (SRM).blk
+++ b/data/mekfiles/infantry/Taurian Infantry/Motorized Platoon TC 3047+ (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Comitatus JumpShip (2995).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Comitatus JumpShip (2995).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Hunter Jumpship (2832).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Hunter Jumpship (2832).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Hunter Jumpship (2948) (LF).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Hunter Jumpship (2948) (LF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Invader Jumpship (2850).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Invader Jumpship (2850).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Merchant Jumpship (2901).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Merchant Jumpship (2901).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Monolith Jumpship (2839).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Monolith Jumpship (2839).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Odyssey Jumpship (2887).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Odyssey Jumpship (2887).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Scout JumpShip (2895).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Scout JumpShip (2895).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/Clan/Star Lord JumpShip (2841).blk
+++ b/data/mekfiles/jumpships/3057R/Clan/Star Lord JumpShip (2841).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Chimeisho JumpShip (3056).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Chimeisho JumpShip (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Invader Jumpship (2631 LF).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Invader Jumpship (2631 LF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Invader Jumpship (2631 PPC).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Invader Jumpship (2631 PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Invader Jumpship (2631).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Invader Jumpship (2631).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Magellan Jumpship (2960).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Magellan Jumpship (2960).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Merchant Jumpship (2503).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Merchant Jumpship (2503).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Merchant Jumpship (2602).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Merchant Jumpship (2602).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Merchant Jumpship (2602P).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Merchant Jumpship (2602P).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Monolith Jumpship (2776).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Monolith Jumpship (2776).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Quetzalcoatl-Scout JumpShip.blk
+++ b/data/mekfiles/jumpships/3057R/IS/Quetzalcoatl-Scout JumpShip.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Scout JumpShip (2712).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Scout JumpShip (2712).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Star Lord JumpShip (2590 LF).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Star Lord JumpShip (2590 LF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Star Lord JumpShip (2590).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Star Lord JumpShip (2590).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Tramp JumpShip (2754).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Tramp JumpShip (2754).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Tramp JumpShip (2755) (LF).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Tramp JumpShip (2755) (LF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3057R/IS/Tramp JumpShip (3071).blk
+++ b/data/mekfiles/jumpships/3057R/IS/Tramp JumpShip (3071).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3075/Explorer JumpShip (HPG).blk
+++ b/data/mekfiles/jumpships/3075/Explorer JumpShip (HPG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/3075/Explorer JumpShip.blk
+++ b/data/mekfiles/jumpships/3075/Explorer JumpShip.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/XTRs/Primitives III/Liberty Jumpship.blk
+++ b/data/mekfiles/jumpships/XTRs/Primitives III/Liberty Jumpship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/jumpships/XTRs/Primitives V/Levianthan Jumpship.blk
+++ b/data/mekfiles/jumpships/XTRs/Primitives V/Levianthan Jumpship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Archer ARC-2K.mtf
+++ b/data/mekfiles/meks/3039u/Archer ARC-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Archer ARC-2R.mtf
+++ b/data/mekfiles/meks/3039u/Archer ARC-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Archer ARC-2S.mtf
+++ b/data/mekfiles/meks/3039u/Archer ARC-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Archer ARC-2W.mtf
+++ b/data/mekfiles/meks/3039u/Archer ARC-2W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Assassin ASN-101.mtf
+++ b/data/mekfiles/meks/3039u/Assassin ASN-101.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Assassin ASN-21.mtf
+++ b/data/mekfiles/meks/3039u/Assassin ASN-21.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Atlas AS7-D-DC.mtf
+++ b/data/mekfiles/meks/3039u/Atlas AS7-D-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Atlas AS7-D.mtf
+++ b/data/mekfiles/meks/3039u/Atlas AS7-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Atlas AS7-RS.mtf
+++ b/data/mekfiles/meks/3039u/Atlas AS7-RS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Awesome AWS-8Q.mtf
+++ b/data/mekfiles/meks/3039u/Awesome AWS-8Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Awesome AWS-8R.mtf
+++ b/data/mekfiles/meks/3039u/Awesome AWS-8R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Awesome AWS-8T.mtf
+++ b/data/mekfiles/meks/3039u/Awesome AWS-8T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Awesome AWS-8V.mtf
+++ b/data/mekfiles/meks/3039u/Awesome AWS-8V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Banshee BNC-3E.mtf
+++ b/data/mekfiles/meks/3039u/Banshee BNC-3E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Banshee BNC-3M.mtf
+++ b/data/mekfiles/meks/3039u/Banshee BNC-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Banshee BNC-3MC.mtf
+++ b/data/mekfiles/meks/3039u/Banshee BNC-3MC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Banshee BNC-3Q.mtf
+++ b/data/mekfiles/meks/3039u/Banshee BNC-3Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Banshee BNC-3S Reinesblatt.mtf
+++ b/data/mekfiles/meks/3039u/Banshee BNC-3S Reinesblatt.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Banshee BNC-3S.mtf
+++ b/data/mekfiles/meks/3039u/Banshee BNC-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/BattleMaster BLR-1D.mtf
+++ b/data/mekfiles/meks/3039u/BattleMaster BLR-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/BattleMaster BLR-1G-DC.mtf
+++ b/data/mekfiles/meks/3039u/BattleMaster BLR-1G-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/BattleMaster BLR-1G.mtf
+++ b/data/mekfiles/meks/3039u/BattleMaster BLR-1G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/BattleMaster BLR-1S.mtf
+++ b/data/mekfiles/meks/3039u/BattleMaster BLR-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Black Knight BL-7-KNT-L.mtf
+++ b/data/mekfiles/meks/3039u/Black Knight BL-7-KNT-L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Black Knight BL-7-KNT.mtf
+++ b/data/mekfiles/meks/3039u/Black Knight BL-7-KNT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Blackjack BJ-1.mtf
+++ b/data/mekfiles/meks/3039u/Blackjack BJ-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Blackjack BJ-1DB.mtf
+++ b/data/mekfiles/meks/3039u/Blackjack BJ-1DB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Blackjack BJ-1DC.mtf
+++ b/data/mekfiles/meks/3039u/Blackjack BJ-1DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Blackjack BJ-1X.mtf
+++ b/data/mekfiles/meks/3039u/Blackjack BJ-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Bombardier BMB-10D.mtf
+++ b/data/mekfiles/meks/3039u/Bombardier BMB-10D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cataphract CTF-1X.mtf
+++ b/data/mekfiles/meks/3039u/Cataphract CTF-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cataphract CTF-2X.mtf
+++ b/data/mekfiles/meks/3039u/Cataphract CTF-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Catapult CPLT-A1.mtf
+++ b/data/mekfiles/meks/3039u/Catapult CPLT-A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Catapult CPLT-C1 Jenny.mtf
+++ b/data/mekfiles/meks/3039u/Catapult CPLT-C1 Jenny.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Catapult CPLT-C1.mtf
+++ b/data/mekfiles/meks/3039u/Catapult CPLT-C1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Catapult CPLT-C1b.mtf
+++ b/data/mekfiles/meks/3039u/Catapult CPLT-C1b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Catapult CPLT-C4.mtf
+++ b/data/mekfiles/meks/3039u/Catapult CPLT-C4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Catapult CPLT-K2.mtf
+++ b/data/mekfiles/meks/3039u/Catapult CPLT-K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Centurion CN9-A.mtf
+++ b/data/mekfiles/meks/3039u/Centurion CN9-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Centurion CN9-AH.mtf
+++ b/data/mekfiles/meks/3039u/Centurion CN9-AH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Centurion CN9-AL.mtf
+++ b/data/mekfiles/meks/3039u/Centurion CN9-AL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Centurion CN9-YLW Yen Lo Wang.mtf
+++ b/data/mekfiles/meks/3039u/Centurion CN9-YLW Yen Lo Wang.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Champion CHP-1N2.mtf
+++ b/data/mekfiles/meks/3039u/Champion CHP-1N2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Champion CHP-2N.mtf
+++ b/data/mekfiles/meks/3039u/Champion CHP-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Charger CGR-1A1.mtf
+++ b/data/mekfiles/meks/3039u/Charger CGR-1A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Charger CGR-1A5.mtf
+++ b/data/mekfiles/meks/3039u/Charger CGR-1A5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Charger CGR-1A9.mtf
+++ b/data/mekfiles/meks/3039u/Charger CGR-1A9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Charger CGR-1L.mtf
+++ b/data/mekfiles/meks/3039u/Charger CGR-1L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Charger CGR-SB.mtf
+++ b/data/mekfiles/meks/3039u/Charger CGR-SB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cicada CDA-2A.mtf
+++ b/data/mekfiles/meks/3039u/Cicada CDA-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cicada CDA-2B.mtf
+++ b/data/mekfiles/meks/3039u/Cicada CDA-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cicada CDA-3C.mtf
+++ b/data/mekfiles/meks/3039u/Cicada CDA-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Clint CLNT-1-2R.mtf
+++ b/data/mekfiles/meks/3039u/Clint CLNT-1-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Clint CLNT-2-3T Denton.mtf
+++ b/data/mekfiles/meks/3039u/Clint CLNT-2-3T Denton.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Clint CLNT-2-3T.mtf
+++ b/data/mekfiles/meks/3039u/Clint CLNT-2-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Clint CLNT-2-4T.mtf
+++ b/data/mekfiles/meks/3039u/Clint CLNT-2-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Commando COM-1D.mtf
+++ b/data/mekfiles/meks/3039u/Commando COM-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Commando COM-2D.mtf
+++ b/data/mekfiles/meks/3039u/Commando COM-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Commando COM-3A.mtf
+++ b/data/mekfiles/meks/3039u/Commando COM-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Crab CRB-20.mtf
+++ b/data/mekfiles/meks/3039u/Crab CRB-20.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Crockett CRK-5003-0.mtf
+++ b/data/mekfiles/meks/3039u/Crockett CRK-5003-0.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Crusader CRD-3D.mtf
+++ b/data/mekfiles/meks/3039u/Crusader CRD-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Crusader CRD-3K.mtf
+++ b/data/mekfiles/meks/3039u/Crusader CRD-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Crusader CRD-3L.mtf
+++ b/data/mekfiles/meks/3039u/Crusader CRD-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Crusader CRD-3R.mtf
+++ b/data/mekfiles/meks/3039u/Crusader CRD-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cyclops CP-10-HQ.mtf
+++ b/data/mekfiles/meks/3039u/Cyclops CP-10-HQ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cyclops CP-10-Q.mtf
+++ b/data/mekfiles/meks/3039u/Cyclops CP-10-Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Cyclops CP-10-Z.mtf
+++ b/data/mekfiles/meks/3039u/Cyclops CP-10-Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Daboku DCMS-MX90-D.mtf
+++ b/data/mekfiles/meks/3039u/Daboku DCMS-MX90-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Dervish DV-6M.mtf
+++ b/data/mekfiles/meks/3039u/Dervish DV-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Dragon DRG-1C.mtf
+++ b/data/mekfiles/meks/3039u/Dragon DRG-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Dragon DRG-1N.mtf
+++ b/data/mekfiles/meks/3039u/Dragon DRG-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Enforcer ENF-4R.mtf
+++ b/data/mekfiles/meks/3039u/Enforcer ENF-4R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Falcon FLC-4N.mtf
+++ b/data/mekfiles/meks/3039u/Falcon FLC-4N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Firestarter FS9-A.mtf
+++ b/data/mekfiles/meks/3039u/Firestarter FS9-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Firestarter FS9-H.mtf
+++ b/data/mekfiles/meks/3039u/Firestarter FS9-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Firestarter FS9-K.mtf
+++ b/data/mekfiles/meks/3039u/Firestarter FS9-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Firestarter FS9-M Mirage.mtf
+++ b/data/mekfiles/meks/3039u/Firestarter FS9-M Mirage.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Flashman FLS-7K.mtf
+++ b/data/mekfiles/meks/3039u/Flashman FLS-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Flea FLE-15.mtf
+++ b/data/mekfiles/meks/3039u/Flea FLE-15.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Flea FLE-4.mtf
+++ b/data/mekfiles/meks/3039u/Flea FLE-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Goliath GOL-1H.mtf
+++ b/data/mekfiles/meks/3039u/Goliath GOL-1H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Grand Dragon DRG-1G.mtf
+++ b/data/mekfiles/meks/3039u/Grand Dragon DRG-1G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Grasshopper GHR-5H.mtf
+++ b/data/mekfiles/meks/3039u/Grasshopper GHR-5H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Griffin GRF-1E Sparky.mtf
+++ b/data/mekfiles/meks/3039u/Griffin GRF-1E Sparky.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Griffin GRF-1N.mtf
+++ b/data/mekfiles/meks/3039u/Griffin GRF-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Griffin GRF-1S.mtf
+++ b/data/mekfiles/meks/3039u/Griffin GRF-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Guillotine GLT-4L.mtf
+++ b/data/mekfiles/meks/3039u/Guillotine GLT-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Guillotine GLT-4P.mtf
+++ b/data/mekfiles/meks/3039u/Guillotine GLT-4P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hatamoto-Chi HTM-26T.mtf
+++ b/data/mekfiles/meks/3039u/Hatamoto-Chi HTM-26T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hatchetman HCT-3F.mtf
+++ b/data/mekfiles/meks/3039u/Hatchetman HCT-3F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hermes HER-1A.mtf
+++ b/data/mekfiles/meks/3039u/Hermes HER-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hermes HER-1B.mtf
+++ b/data/mekfiles/meks/3039u/Hermes HER-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hermes II HER-2M Mercury.mtf
+++ b/data/mekfiles/meks/3039u/Hermes II HER-2M Mercury.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hermes II HER-2S.mtf
+++ b/data/mekfiles/meks/3039u/Hermes II HER-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hermes II HER-4K Hermes III.mtf
+++ b/data/mekfiles/meks/3039u/Hermes II HER-4K Hermes III.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Highlander HGN-733.mtf
+++ b/data/mekfiles/meks/3039u/Highlander HGN-733.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Highlander HGN-733C.mtf
+++ b/data/mekfiles/meks/3039u/Highlander HGN-733C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Highlander HGN-733P.mtf
+++ b/data/mekfiles/meks/3039u/Highlander HGN-733P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hornet HNT-151.mtf
+++ b/data/mekfiles/meks/3039u/Hornet HNT-151.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hornet HNT-152.mtf
+++ b/data/mekfiles/meks/3039u/Hornet HNT-152.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hunchback HBK-4G.mtf
+++ b/data/mekfiles/meks/3039u/Hunchback HBK-4G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hunchback HBK-4H.mtf
+++ b/data/mekfiles/meks/3039u/Hunchback HBK-4H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hunchback HBK-4J.mtf
+++ b/data/mekfiles/meks/3039u/Hunchback HBK-4J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hunchback HBK-4N.mtf
+++ b/data/mekfiles/meks/3039u/Hunchback HBK-4N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hunchback HBK-4P.mtf
+++ b/data/mekfiles/meks/3039u/Hunchback HBK-4P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hunchback HBK-4SP.mtf
+++ b/data/mekfiles/meks/3039u/Hunchback HBK-4SP.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hussar HSR-300-D.mtf
+++ b/data/mekfiles/meks/3039u/Hussar HSR-300-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Hussar HSR-350-D.mtf
+++ b/data/mekfiles/meks/3039u/Hussar HSR-350-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/JagerMech JM6-A.mtf
+++ b/data/mekfiles/meks/3039u/JagerMech JM6-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/JagerMech JM6-S.mtf
+++ b/data/mekfiles/meks/3039u/JagerMech JM6-S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Javelin JVN-10F Fire Javelin.mtf
+++ b/data/mekfiles/meks/3039u/Javelin JVN-10F Fire Javelin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Javelin JVN-10N.mtf
+++ b/data/mekfiles/meks/3039u/Javelin JVN-10N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Jenner JR7-A.mtf
+++ b/data/mekfiles/meks/3039u/Jenner JR7-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Jenner JR7-D.mtf
+++ b/data/mekfiles/meks/3039u/Jenner JR7-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Jenner JR7-F.mtf
+++ b/data/mekfiles/meks/3039u/Jenner JR7-F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/King Crab KGC-0000.mtf
+++ b/data/mekfiles/meks/3039u/King Crab KGC-0000.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/King Crab KGC-010.mtf
+++ b/data/mekfiles/meks/3039u/King Crab KGC-010.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Kintaro KTO-18.mtf
+++ b/data/mekfiles/meks/3039u/Kintaro KTO-18.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Lancelot LNC25-01X.mtf
+++ b/data/mekfiles/meks/3039u/Lancelot LNC25-01X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Lancelot LNC25-02.mtf
+++ b/data/mekfiles/meks/3039u/Lancelot LNC25-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Locust LCT-1E.mtf
+++ b/data/mekfiles/meks/3039u/Locust LCT-1E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Locust LCT-1L.mtf
+++ b/data/mekfiles/meks/3039u/Locust LCT-1L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Locust LCT-1M.mtf
+++ b/data/mekfiles/meks/3039u/Locust LCT-1M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Locust LCT-1S.mtf
+++ b/data/mekfiles/meks/3039u/Locust LCT-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Locust LCT-1V.mtf
+++ b/data/mekfiles/meks/3039u/Locust LCT-1V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Locust LCT-3V.mtf
+++ b/data/mekfiles/meks/3039u/Locust LCT-3V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Longbow LGB-0W.mtf
+++ b/data/mekfiles/meks/3039u/Longbow LGB-0W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Marauder II MAD-4A.mtf
+++ b/data/mekfiles/meks/3039u/Marauder II MAD-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Marauder MAD-3D.mtf
+++ b/data/mekfiles/meks/3039u/Marauder MAD-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Marauder MAD-3L.mtf
+++ b/data/mekfiles/meks/3039u/Marauder MAD-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Marauder MAD-3M.mtf
+++ b/data/mekfiles/meks/3039u/Marauder MAD-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Marauder MAD-3R.mtf
+++ b/data/mekfiles/meks/3039u/Marauder MAD-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Mercury MCY-98.mtf
+++ b/data/mekfiles/meks/3039u/Mercury MCY-98.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Mongoose MON-67.mtf
+++ b/data/mekfiles/meks/3039u/Mongoose MON-67.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Mongoose MON-68.mtf
+++ b/data/mekfiles/meks/3039u/Mongoose MON-68.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Orion ON1-K.mtf
+++ b/data/mekfiles/meks/3039u/Orion ON1-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Orion ON1-V-DC.mtf
+++ b/data/mekfiles/meks/3039u/Orion ON1-V-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Orion ON1-V.mtf
+++ b/data/mekfiles/meks/3039u/Orion ON1-V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Orion ON1-VA.mtf
+++ b/data/mekfiles/meks/3039u/Orion ON1-VA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostroc OSR-2C.mtf
+++ b/data/mekfiles/meks/3039u/Ostroc OSR-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostroc OSR-2L.mtf
+++ b/data/mekfiles/meks/3039u/Ostroc OSR-2L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostroc OSR-2M.mtf
+++ b/data/mekfiles/meks/3039u/Ostroc OSR-2M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostroc OSR-3C.mtf
+++ b/data/mekfiles/meks/3039u/Ostroc OSR-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostscout OTT-7J.mtf
+++ b/data/mekfiles/meks/3039u/Ostscout OTT-7J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostsol OTL-4D.mtf
+++ b/data/mekfiles/meks/3039u/Ostsol OTL-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Ostsol OTL-4F.mtf
+++ b/data/mekfiles/meks/3039u/Ostsol OTL-4F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Panther PNT-8Z.mtf
+++ b/data/mekfiles/meks/3039u/Panther PNT-8Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Panther PNT-9R.mtf
+++ b/data/mekfiles/meks/3039u/Panther PNT-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Phoenix Hawk PXH-1.mtf
+++ b/data/mekfiles/meks/3039u/Phoenix Hawk PXH-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Phoenix Hawk PXH-1D.mtf
+++ b/data/mekfiles/meks/3039u/Phoenix Hawk PXH-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Phoenix Hawk PXH-1K.mtf
+++ b/data/mekfiles/meks/3039u/Phoenix Hawk PXH-1K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Quickdraw QKD-4G.mtf
+++ b/data/mekfiles/meks/3039u/Quickdraw QKD-4G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Quickdraw QKD-4H.mtf
+++ b/data/mekfiles/meks/3039u/Quickdraw QKD-4H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Quickdraw QKD-5A.mtf
+++ b/data/mekfiles/meks/3039u/Quickdraw QKD-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Raven RVN-1X.mtf
+++ b/data/mekfiles/meks/3039u/Raven RVN-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Raven RVN-2X.mtf
+++ b/data/mekfiles/meks/3039u/Raven RVN-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Raven RVN-3X.mtf
+++ b/data/mekfiles/meks/3039u/Raven RVN-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Raven RVN-4X.mtf
+++ b/data/mekfiles/meks/3039u/Raven RVN-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Rifleman RFL-3C.mtf
+++ b/data/mekfiles/meks/3039u/Rifleman RFL-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Rifleman RFL-3N.mtf
+++ b/data/mekfiles/meks/3039u/Rifleman RFL-3N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Rifleman RFL-4D.mtf
+++ b/data/mekfiles/meks/3039u/Rifleman RFL-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Scorpion SCP-1N (Wednall).mtf
+++ b/data/mekfiles/meks/3039u/Scorpion SCP-1N (Wednall).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Scorpion SCP-1N.mtf
+++ b/data/mekfiles/meks/3039u/Scorpion SCP-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Sentinel STN-1S.mtf
+++ b/data/mekfiles/meks/3039u/Sentinel STN-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Sentinel STN-3K.mtf
+++ b/data/mekfiles/meks/3039u/Sentinel STN-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Sentinel STN-3KA.mtf
+++ b/data/mekfiles/meks/3039u/Sentinel STN-3KA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Sentinel STN-3KB.mtf
+++ b/data/mekfiles/meks/3039u/Sentinel STN-3KB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Shadow Hawk SHD-2D.mtf
+++ b/data/mekfiles/meks/3039u/Shadow Hawk SHD-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Shadow Hawk SHD-2H.mtf
+++ b/data/mekfiles/meks/3039u/Shadow Hawk SHD-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Shadow Hawk SHD-2K.mtf
+++ b/data/mekfiles/meks/3039u/Shadow Hawk SHD-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Spider SDR-5D.mtf
+++ b/data/mekfiles/meks/3039u/Spider SDR-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Spider SDR-5K.mtf
+++ b/data/mekfiles/meks/3039u/Spider SDR-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Spider SDR-5V.mtf
+++ b/data/mekfiles/meks/3039u/Spider SDR-5V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Stalker STK-3F.mtf
+++ b/data/mekfiles/meks/3039u/Stalker STK-3F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Stalker STK-3H.mtf
+++ b/data/mekfiles/meks/3039u/Stalker STK-3H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Stalker STK-4N.mtf
+++ b/data/mekfiles/meks/3039u/Stalker STK-4N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Stalker STK-4P.mtf
+++ b/data/mekfiles/meks/3039u/Stalker STK-4P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Stinger STG-3G.mtf
+++ b/data/mekfiles/meks/3039u/Stinger STG-3G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Stinger STG-3R.mtf
+++ b/data/mekfiles/meks/3039u/Stinger STG-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thorn THE-F.mtf
+++ b/data/mekfiles/meks/3039u/Thorn THE-F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thorn THE-S.mtf
+++ b/data/mekfiles/meks/3039u/Thorn THE-S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thorn THE-T.mtf
+++ b/data/mekfiles/meks/3039u/Thorn THE-T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thug THG-10E.mtf
+++ b/data/mekfiles/meks/3039u/Thug THG-10E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thunderbolt TDR-5S.mtf
+++ b/data/mekfiles/meks/3039u/Thunderbolt TDR-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thunderbolt TDR-5SE.mtf
+++ b/data/mekfiles/meks/3039u/Thunderbolt TDR-5SE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Thunderbolt TDR-5SS.mtf
+++ b/data/mekfiles/meks/3039u/Thunderbolt TDR-5SS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Trebuchet TBT-5J.mtf
+++ b/data/mekfiles/meks/3039u/Trebuchet TBT-5J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Trebuchet TBT-5N.mtf
+++ b/data/mekfiles/meks/3039u/Trebuchet TBT-5N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Trebuchet TBT-5S.mtf
+++ b/data/mekfiles/meks/3039u/Trebuchet TBT-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Trebuchet TBT-7K.mtf
+++ b/data/mekfiles/meks/3039u/Trebuchet TBT-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/UrbanMech UM-R60.mtf
+++ b/data/mekfiles/meks/3039u/UrbanMech UM-R60.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/UrbanMech UM-R60L.mtf
+++ b/data/mekfiles/meks/3039u/UrbanMech UM-R60L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Valkyrie VLK-QA.mtf
+++ b/data/mekfiles/meks/3039u/Valkyrie VLK-QA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Valkyrie VLK-QF.mtf
+++ b/data/mekfiles/meks/3039u/Valkyrie VLK-QF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Victor VTR-9A.mtf
+++ b/data/mekfiles/meks/3039u/Victor VTR-9A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Victor VTR-9A1.mtf
+++ b/data/mekfiles/meks/3039u/Victor VTR-9A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Victor VTR-9B.mtf
+++ b/data/mekfiles/meks/3039u/Victor VTR-9B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Victor VTR-9S.mtf
+++ b/data/mekfiles/meks/3039u/Victor VTR-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vindicator VND-1AA Avenging Angel.mtf
+++ b/data/mekfiles/meks/3039u/Vindicator VND-1AA Avenging Angel.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vindicator VND-1R Vong.mtf
+++ b/data/mekfiles/meks/3039u/Vindicator VND-1R Vong.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vindicator VND-1R.mtf
+++ b/data/mekfiles/meks/3039u/Vindicator VND-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vindicator VND-1SIC.mtf
+++ b/data/mekfiles/meks/3039u/Vindicator VND-1SIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vindicator VND-1X.mtf
+++ b/data/mekfiles/meks/3039u/Vindicator VND-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vulcan VL-2T.mtf
+++ b/data/mekfiles/meks/3039u/Vulcan VL-2T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Vulcan VL-5T.mtf
+++ b/data/mekfiles/meks/3039u/Vulcan VL-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Warhammer WHM-6D.mtf
+++ b/data/mekfiles/meks/3039u/Warhammer WHM-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Warhammer WHM-6K.mtf
+++ b/data/mekfiles/meks/3039u/Warhammer WHM-6K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Warhammer WHM-6L.mtf
+++ b/data/mekfiles/meks/3039u/Warhammer WHM-6L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Warhammer WHM-6R.mtf
+++ b/data/mekfiles/meks/3039u/Warhammer WHM-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wasp WSP-1A.mtf
+++ b/data/mekfiles/meks/3039u/Wasp WSP-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wasp WSP-1D.mtf
+++ b/data/mekfiles/meks/3039u/Wasp WSP-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wasp WSP-1K.mtf
+++ b/data/mekfiles/meks/3039u/Wasp WSP-1K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wasp WSP-1L.mtf
+++ b/data/mekfiles/meks/3039u/Wasp WSP-1L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wasp WSP-1W.mtf
+++ b/data/mekfiles/meks/3039u/Wasp WSP-1W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Whitworth WTH-0.mtf
+++ b/data/mekfiles/meks/3039u/Whitworth WTH-0.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Whitworth WTH-1.mtf
+++ b/data/mekfiles/meks/3039u/Whitworth WTH-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Whitworth WTH-1S.mtf
+++ b/data/mekfiles/meks/3039u/Whitworth WTH-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wolfhound WLF-1.mtf
+++ b/data/mekfiles/meks/3039u/Wolfhound WLF-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wolfhound WLF-1A.mtf
+++ b/data/mekfiles/meks/3039u/Wolfhound WLF-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wolfhound WLF-1B.mtf
+++ b/data/mekfiles/meks/3039u/Wolfhound WLF-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wolverine WVR-6K.mtf
+++ b/data/mekfiles/meks/3039u/Wolverine WVR-6K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wolverine WVR-6M.mtf
+++ b/data/mekfiles/meks/3039u/Wolverine WVR-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wolverine WVR-6R.mtf
+++ b/data/mekfiles/meks/3039u/Wolverine WVR-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Wyvern WVE-6N.mtf
+++ b/data/mekfiles/meks/3039u/Wyvern WVE-6N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Zeus ZEU-5S.mtf
+++ b/data/mekfiles/meks/3039u/Zeus ZEU-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Zeus ZEU-5T.mtf
+++ b/data/mekfiles/meks/3039u/Zeus ZEU-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Zeus ZEU-6S.mtf
+++ b/data/mekfiles/meks/3039u/Zeus ZEU-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3039u/Zeus ZEU-6T.mtf
+++ b/data/mekfiles/meks/3039u/Zeus ZEU-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Annihilator ANH-1A.mtf
+++ b/data/mekfiles/meks/3050U/Annihilator ANH-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Annihilator ANH-2A.mtf
+++ b/data/mekfiles/meks/3050U/Annihilator ANH-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Annihilator ANH-3A.mtf
+++ b/data/mekfiles/meks/3050U/Annihilator ANH-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Annihilator ANH-4A.mtf
+++ b/data/mekfiles/meks/3050U/Annihilator ANH-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Annihilator C.mtf
+++ b/data/mekfiles/meks/3050U/Annihilator C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Assassin ASN-23.mtf
+++ b/data/mekfiles/meks/3050U/Assassin ASN-23.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Assassin ASN-30.mtf
+++ b/data/mekfiles/meks/3050U/Assassin ASN-30.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Assassin ASN-99.mtf
+++ b/data/mekfiles/meks/3050U/Assassin ASN-99.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Assassin Servitor.mtf
+++ b/data/mekfiles/meks/3050U/Assassin Servitor.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Atlas AS7-C.mtf
+++ b/data/mekfiles/meks/3050U/Atlas AS7-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Atlas AS7-CM.mtf
+++ b/data/mekfiles/meks/3050U/Atlas AS7-CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Atlas AS7-K.mtf
+++ b/data/mekfiles/meks/3050U/Atlas AS7-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Atlas AS7-S.mtf
+++ b/data/mekfiles/meks/3050U/Atlas AS7-S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Atlas AS7-S2.mtf
+++ b/data/mekfiles/meks/3050U/Atlas AS7-S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Awesome AWS-10KM.mtf
+++ b/data/mekfiles/meks/3050U/Awesome AWS-10KM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Awesome AWS-9M.mtf
+++ b/data/mekfiles/meks/3050U/Awesome AWS-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Awesome AWS-9Ma.mtf
+++ b/data/mekfiles/meks/3050U/Awesome AWS-9Ma.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Awesome AWS-9Q (Klatt).mtf
+++ b/data/mekfiles/meks/3050U/Awesome AWS-9Q (Klatt).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Awesome AWS-9Q.mtf
+++ b/data/mekfiles/meks/3050U/Awesome AWS-9Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Axman AXM-1N.mtf
+++ b/data/mekfiles/meks/3050U/Axman AXM-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Axman AXM-2N.mtf
+++ b/data/mekfiles/meks/3050U/Axman AXM-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Axman AXM-4D.mtf
+++ b/data/mekfiles/meks/3050U/Axman AXM-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Banshee BNC-5S (Sawyer).mtf
+++ b/data/mekfiles/meks/3050U/Banshee BNC-5S (Sawyer).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Banshee BNC-5S (Vandergriff).mtf
+++ b/data/mekfiles/meks/3050U/Banshee BNC-5S (Vandergriff).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Banshee BNC-5S.mtf
+++ b/data/mekfiles/meks/3050U/Banshee BNC-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Banshee BNC-6S.mtf
+++ b/data/mekfiles/meks/3050U/Banshee BNC-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Banshee BNC-7S.mtf
+++ b/data/mekfiles/meks/3050U/Banshee BNC-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Banshee BNC-8S.mtf
+++ b/data/mekfiles/meks/3050U/Banshee BNC-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) A.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) B.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) C.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) D.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) E.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) F.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) H.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Hawk (Nova) S.mtf
+++ b/data/mekfiles/meks/3050U/Black Hawk (Nova) S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Knight BL-12-KNT.mtf
+++ b/data/mekfiles/meks/3050U/Black Knight BL-12-KNT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Knight BL-6-KNT.mtf
+++ b/data/mekfiles/meks/3050U/Black Knight BL-6-KNT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Knight BL-6-RR.mtf
+++ b/data/mekfiles/meks/3050U/Black Knight BL-6-RR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Black Knight BL6b-KNT.mtf
+++ b/data/mekfiles/meks/3050U/Black Knight BL6b-KNT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Blackjack BJ-2.mtf
+++ b/data/mekfiles/meks/3050U/Blackjack BJ-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Blackjack BJ-3.mtf
+++ b/data/mekfiles/meks/3050U/Blackjack BJ-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Blackjack BJ-4.mtf
+++ b/data/mekfiles/meks/3050U/Blackjack BJ-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Bombardier BMB-05A.mtf
+++ b/data/mekfiles/meks/3050U/Bombardier BMB-05A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Bombardier BMB-12D.mtf
+++ b/data/mekfiles/meks/3050U/Bombardier BMB-12D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Bombardier BMB-14C.mtf
+++ b/data/mekfiles/meks/3050U/Bombardier BMB-14C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Bombardier BMB-14K.mtf
+++ b/data/mekfiles/meks/3050U/Bombardier BMB-14K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Caesar CES-3R Archangel.mtf
+++ b/data/mekfiles/meks/3050U/Caesar CES-3R Archangel.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Caesar CES-3R Gertrude.mtf
+++ b/data/mekfiles/meks/3050U/Caesar CES-3R Gertrude.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Caesar CES-3R.mtf
+++ b/data/mekfiles/meks/3050U/Caesar CES-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Caesar CES-3S.mtf
+++ b/data/mekfiles/meks/3050U/Caesar CES-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Caesar CES-4R.mtf
+++ b/data/mekfiles/meks/3050U/Caesar CES-4R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Caesar CES-4S.mtf
+++ b/data/mekfiles/meks/3050U/Caesar CES-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cataphract CTF-3D.mtf
+++ b/data/mekfiles/meks/3050U/Cataphract CTF-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cataphract CTF-3L.mtf
+++ b/data/mekfiles/meks/3050U/Cataphract CTF-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cataphract CTF-3LL.mtf
+++ b/data/mekfiles/meks/3050U/Cataphract CTF-3LL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cataphract CTF-4L.mtf
+++ b/data/mekfiles/meks/3050U/Cataphract CTF-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cataphract CTF-4X.mtf
+++ b/data/mekfiles/meks/3050U/Cataphract CTF-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cataphract CTF-5D.mtf
+++ b/data/mekfiles/meks/3050U/Cataphract CTF-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-C2.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-C2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-C3.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-C3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-C4C.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-C4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-C5.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-C5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-C6.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-C6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-H2.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-H2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-K2K.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-K2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-K3.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-K3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-K4.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-K4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Catapult CPLT-K5.mtf
+++ b/data/mekfiles/meks/3050U/Catapult CPLT-K5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN10-B.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN10-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-D.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-D3.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-D3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-D3D.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-D3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-D4D.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-D4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-D5.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-D5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-D9.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-D9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-Da.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-Da.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Centurion CN9-YLW2.mtf
+++ b/data/mekfiles/meks/3050U/Centurion CN9-YLW2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Champion C.mtf
+++ b/data/mekfiles/meks/3050U/Champion C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Champion CHP-1N.mtf
+++ b/data/mekfiles/meks/3050U/Champion CHP-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Champion CHP-3N.mtf
+++ b/data/mekfiles/meks/3050U/Champion CHP-3N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Champion CHP-3P.mtf
+++ b/data/mekfiles/meks/3050U/Champion CHP-3P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Charger CGR-2A2.mtf
+++ b/data/mekfiles/meks/3050U/Charger CGR-2A2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Charger CGR-3K.mtf
+++ b/data/mekfiles/meks/3050U/Charger CGR-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Charger CGR-C.mtf
+++ b/data/mekfiles/meks/3050U/Charger CGR-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Charger CGR-KMZ.mtf
+++ b/data/mekfiles/meks/3050U/Charger CGR-KMZ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Charger CGR-SA5.mtf
+++ b/data/mekfiles/meks/3050U/Charger CGR-SA5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cicada CDA-3F.mtf
+++ b/data/mekfiles/meks/3050U/Cicada CDA-3F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cicada CDA-3G.mtf
+++ b/data/mekfiles/meks/3050U/Cicada CDA-3G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cicada CDA-3M.mtf
+++ b/data/mekfiles/meks/3050U/Cicada CDA-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cicada CDA-3MA.mtf
+++ b/data/mekfiles/meks/3050U/Cicada CDA-3MA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cicada CDA-3P.mtf
+++ b/data/mekfiles/meks/3050U/Cicada CDA-3P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Clint CLNT-2-3U.mtf
+++ b/data/mekfiles/meks/3050U/Clint CLNT-2-3U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Clint CLNT-2-3UL.mtf
+++ b/data/mekfiles/meks/3050U/Clint CLNT-2-3UL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Clint CLNT-3-3T.mtf
+++ b/data/mekfiles/meks/3050U/Clint CLNT-3-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Clint CLNT-5U.mtf
+++ b/data/mekfiles/meks/3050U/Clint CLNT-5U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Clint CLNT-6S.mtf
+++ b/data/mekfiles/meks/3050U/Clint CLNT-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Commando COM-1B.mtf
+++ b/data/mekfiles/meks/3050U/Commando COM-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Commando COM-1C.mtf
+++ b/data/mekfiles/meks/3050U/Commando COM-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Commando COM-4H.mtf
+++ b/data/mekfiles/meks/3050U/Commando COM-4H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Commando COM-5S.mtf
+++ b/data/mekfiles/meks/3050U/Commando COM-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Commando COM-7B.mtf
+++ b/data/mekfiles/meks/3050U/Commando COM-7B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crab CRB-27.mtf
+++ b/data/mekfiles/meks/3050U/Crab CRB-27.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crab CRB-30.mtf
+++ b/data/mekfiles/meks/3050U/Crab CRB-30.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crab CRB-45.mtf
+++ b/data/mekfiles/meks/3050U/Crab CRB-45.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crab CRB-C.mtf
+++ b/data/mekfiles/meks/3050U/Crab CRB-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crockett CRK-5003-1.mtf
+++ b/data/mekfiles/meks/3050U/Crockett CRK-5003-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crockett CRK-5003-3.mtf
+++ b/data/mekfiles/meks/3050U/Crockett CRK-5003-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crockett CRK-5004-1.mtf
+++ b/data/mekfiles/meks/3050U/Crockett CRK-5004-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Crockett CRK-5005-1.mtf
+++ b/data/mekfiles/meks/3050U/Crockett CRK-5005-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cyclops CP-11-A-DC.mtf
+++ b/data/mekfiles/meks/3050U/Cyclops CP-11-A-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cyclops CP-11-A.mtf
+++ b/data/mekfiles/meks/3050U/Cyclops CP-11-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cyclops CP-11-C.mtf
+++ b/data/mekfiles/meks/3050U/Cyclops CP-11-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cyclops CP-11-G.mtf
+++ b/data/mekfiles/meks/3050U/Cyclops CP-11-G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cyclops CP-11-H.mtf
+++ b/data/mekfiles/meks/3050U/Cyclops CP-11-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Cyclops CP-12-K.mtf
+++ b/data/mekfiles/meks/3050U/Cyclops CP-12-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) A.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) B.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) C.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) D.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) H.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Hohiro.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Hohiro.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Prometheus.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Prometheus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) S.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) W.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Widowmaker.mtf
+++ b/data/mekfiles/meks/3050U/Daishi (Dire Wolf) Widowmaker.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) A.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) B.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) C.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) D.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) E.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) F.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) H.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) K.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dasher (Fire Moth) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Dasher (Fire Moth) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dervish DV-7D.mtf
+++ b/data/mekfiles/meks/3050U/Dervish DV-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dervish DV-8D.mtf
+++ b/data/mekfiles/meks/3050U/Dervish DV-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dervish DV-9D.mtf
+++ b/data/mekfiles/meks/3050U/Dervish DV-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragon DRG-5N.mtf
+++ b/data/mekfiles/meks/3050U/Dragon DRG-5N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragon DRG-7N.mtf
+++ b/data/mekfiles/meks/3050U/Dragon DRG-7N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) A.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) B.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) C.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) D.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) E.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) F.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) G.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) H.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) I.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Dragonfly (Viper) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Dragonfly (Viper) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Enforcer ENF-5D.mtf
+++ b/data/mekfiles/meks/3050U/Enforcer ENF-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Enforcer III ENF-6G.mtf
+++ b/data/mekfiles/meks/3050U/Enforcer III ENF-6G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Enforcer III ENF-6H.mtf
+++ b/data/mekfiles/meks/3050U/Enforcer III ENF-6H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Enforcer III ENF-6T.mtf
+++ b/data/mekfiles/meks/3050U/Enforcer III ENF-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Exterminator EXT-4A.mtf
+++ b/data/mekfiles/meks/3050U/Exterminator EXT-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Exterminator EXT-4C.mtf
+++ b/data/mekfiles/meks/3050U/Exterminator EXT-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Exterminator EXT-4D.mtf
+++ b/data/mekfiles/meks/3050U/Exterminator EXT-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Exterminator EXT-5E.mtf
+++ b/data/mekfiles/meks/3050U/Exterminator EXT-5E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Exterminator EXT-5F.mtf
+++ b/data/mekfiles/meks/3050U/Exterminator EXT-5F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Falcon FLC-4P.mtf
+++ b/data/mekfiles/meks/3050U/Falcon FLC-4P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Falcon FLC-5P.mtf
+++ b/data/mekfiles/meks/3050U/Falcon FLC-5P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Falcon FLC-6C.mtf
+++ b/data/mekfiles/meks/3050U/Falcon FLC-6C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) A.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) B.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) C.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) D.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) E.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) H.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) L.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Fenris (Ice Ferret) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Fenris (Ice Ferret) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firefly C.mtf
+++ b/data/mekfiles/meks/3050U/Firefly C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firefly FFL-4A.mtf
+++ b/data/mekfiles/meks/3050U/Firefly FFL-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firefly FFL-4B.mtf
+++ b/data/mekfiles/meks/3050U/Firefly FFL-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firefly FFL-4C.mtf
+++ b/data/mekfiles/meks/3050U/Firefly FFL-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firefly FFL-4D.mtf
+++ b/data/mekfiles/meks/3050U/Firefly FFL-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firefly FFL-4DA.mtf
+++ b/data/mekfiles/meks/3050U/Firefly FFL-4DA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-B.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-C.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-P.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-S.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-S1.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-S1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-S2.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Firestarter FS9-S3.mtf
+++ b/data/mekfiles/meks/3050U/Firestarter FS9-S3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flashman FLS-8K.mtf
+++ b/data/mekfiles/meks/3050U/Flashman FLS-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flashman FLS-9B.mtf
+++ b/data/mekfiles/meks/3050U/Flashman FLS-9B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flashman FLS-9C.mtf
+++ b/data/mekfiles/meks/3050U/Flashman FLS-9C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flashman FLS-9M.mtf
+++ b/data/mekfiles/meks/3050U/Flashman FLS-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flashman FLS-C.mtf
+++ b/data/mekfiles/meks/3050U/Flashman FLS-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flea FLE-17.mtf
+++ b/data/mekfiles/meks/3050U/Flea FLE-17.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flea FLE-19.mtf
+++ b/data/mekfiles/meks/3050U/Flea FLE-19.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flea FLE-20.mtf
+++ b/data/mekfiles/meks/3050U/Flea FLE-20.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Flea Fire Ant.mtf
+++ b/data/mekfiles/meks/3050U/Flea Fire Ant.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) A.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) B.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) C.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) D.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) E.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) H.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) K.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) P.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Gladiator (Executioner) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Gladiator (Executioner) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grand Dragon DRG-5K-DC.mtf
+++ b/data/mekfiles/meks/3050U/Grand Dragon DRG-5K-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grand Dragon DRG-5K.mtf
+++ b/data/mekfiles/meks/3050U/Grand Dragon DRG-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grand Dragon DRG-7K.mtf
+++ b/data/mekfiles/meks/3050U/Grand Dragon DRG-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grand Dragon DRG-9KC.mtf
+++ b/data/mekfiles/meks/3050U/Grand Dragon DRG-9KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grand Dragon DRG-C.mtf
+++ b/data/mekfiles/meks/3050U/Grand Dragon DRG-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grasshopper GHR-5J.mtf
+++ b/data/mekfiles/meks/3050U/Grasshopper GHR-5J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grasshopper GHR-5N.mtf
+++ b/data/mekfiles/meks/3050U/Grasshopper GHR-5N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grasshopper GHR-6K.mtf
+++ b/data/mekfiles/meks/3050U/Grasshopper GHR-6K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grasshopper GHR-7K Gravedigger.mtf
+++ b/data/mekfiles/meks/3050U/Grasshopper GHR-7K Gravedigger.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grasshopper GHR-7K.mtf
+++ b/data/mekfiles/meks/3050U/Grasshopper GHR-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Grasshopper GHR-C.mtf
+++ b/data/mekfiles/meks/3050U/Grasshopper GHR-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Guillotine GLT-3N.mtf
+++ b/data/mekfiles/meks/3050U/Guillotine GLT-3N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Guillotine GLT-5M.mtf
+++ b/data/mekfiles/meks/3050U/Guillotine GLT-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Guillotine GLT-6WB.mtf
+++ b/data/mekfiles/meks/3050U/Guillotine GLT-6WB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Guillotine GLT-6WB2.mtf
+++ b/data/mekfiles/meks/3050U/Guillotine GLT-6WB2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Guillotine GLT-6WB3.mtf
+++ b/data/mekfiles/meks/3050U/Guillotine GLT-6WB3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Guillotine GLT-8D.mtf
+++ b/data/mekfiles/meks/3050U/Guillotine GLT-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Chi HTM-27T.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Chi HTM-27T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Chi HTM-28T (Shin).mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Chi HTM-28T (Shin).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Chi HTM-28T.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Chi HTM-28T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Hi HTM-27U.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Hi HTM-27U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Hi HTM-C.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Hi HTM-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Hi HTM-CM.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Hi HTM-CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Kaze HTM-27V.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Kaze HTM-27V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Ku HTM-27W.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Ku HTM-27W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatamoto-Mizo HTM-27Y.mtf
+++ b/data/mekfiles/meks/3050U/Hatamoto-Mizo HTM-27Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatchetman HCT-5D.mtf
+++ b/data/mekfiles/meks/3050U/Hatchetman HCT-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatchetman HCT-5DD.mtf
+++ b/data/mekfiles/meks/3050U/Hatchetman HCT-5DD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatchetman HCT-5K.mtf
+++ b/data/mekfiles/meks/3050U/Hatchetman HCT-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatchetman HCT-5S.mtf
+++ b/data/mekfiles/meks/3050U/Hatchetman HCT-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatchetman HCT-6D.mtf
+++ b/data/mekfiles/meks/3050U/Hatchetman HCT-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hatchetman HCT-6S.mtf
+++ b/data/mekfiles/meks/3050U/Hatchetman HCT-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-1S.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-3S.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-3S1.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-3S1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-3S2.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-3S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-4K.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-4M.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-4S.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes HER-4WB.mtf
+++ b/data/mekfiles/meks/3050U/Hermes HER-4WB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes II HER-5C.mtf
+++ b/data/mekfiles/meks/3050U/Hermes II HER-5C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes II HER-5ME.mtf
+++ b/data/mekfiles/meks/3050U/Hermes II HER-5ME.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes II HER-5S.mtf
+++ b/data/mekfiles/meks/3050U/Hermes II HER-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes II HER-5SA.mtf
+++ b/data/mekfiles/meks/3050U/Hermes II HER-5SA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hermes II HER-6D.mtf
+++ b/data/mekfiles/meks/3050U/Hermes II HER-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Highlander HGN-694.mtf
+++ b/data/mekfiles/meks/3050U/Highlander HGN-694.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Highlander HGN-732.mtf
+++ b/data/mekfiles/meks/3050U/Highlander HGN-732.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Highlander HGN-734.mtf
+++ b/data/mekfiles/meks/3050U/Highlander HGN-734.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Highlander HGN-736.mtf
+++ b/data/mekfiles/meks/3050U/Highlander HGN-736.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Highlander HGN-738.mtf
+++ b/data/mekfiles/meks/3050U/Highlander HGN-738.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hoplite C.mtf
+++ b/data/mekfiles/meks/3050U/Hoplite C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hoplite HOP-4A.mtf
+++ b/data/mekfiles/meks/3050U/Hoplite HOP-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hoplite HOP-4B.mtf
+++ b/data/mekfiles/meks/3050U/Hoplite HOP-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hoplite HOP-4C.mtf
+++ b/data/mekfiles/meks/3050U/Hoplite HOP-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hoplite HOP-4D.mtf
+++ b/data/mekfiles/meks/3050U/Hoplite HOP-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hornet HNT-161.mtf
+++ b/data/mekfiles/meks/3050U/Hornet HNT-161.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hornet HNT-171.mtf
+++ b/data/mekfiles/meks/3050U/Hornet HNT-171.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5H.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5M.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5N.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5P.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5S.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5SG.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5SG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-5SS.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-5SS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-6N.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-6N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hunchback HBK-6S.mtf
+++ b/data/mekfiles/meks/3050U/Hunchback HBK-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hussar HSR-200-D.mtf
+++ b/data/mekfiles/meks/3050U/Hussar HSR-200-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hussar HSR-400-D.mtf
+++ b/data/mekfiles/meks/3050U/Hussar HSR-400-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hussar HSR-500-D.mtf
+++ b/data/mekfiles/meks/3050U/Hussar HSR-500-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hussar HSR-900-D.mtf
+++ b/data/mekfiles/meks/3050U/Hussar HSR-900-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Hussar HSR-950-D.mtf
+++ b/data/mekfiles/meks/3050U/Hussar HSR-950-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Imp C.mtf
+++ b/data/mekfiles/meks/3050U/Imp C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Imp IMP-2E.mtf
+++ b/data/mekfiles/meks/3050U/Imp IMP-2E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Imp IMP-3E.mtf
+++ b/data/mekfiles/meks/3050U/Imp IMP-3E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Imp IMP-4E.mtf
+++ b/data/mekfiles/meks/3050U/Imp IMP-4E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM6-DD.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM6-DD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM6-DDa.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM6-DDa.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM6-DGr.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM6-DGr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM6-H.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM6-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM7-D.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM7-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM7-F.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM7-F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/JagerMech JM7-G.mtf
+++ b/data/mekfiles/meks/3050U/JagerMech JM7-G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Jagermech JM6-DG.mtf
+++ b/data/mekfiles/meks/3050U/Jagermech JM6-DG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Javelin JVN-10P.mtf
+++ b/data/mekfiles/meks/3050U/Javelin JVN-10P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Javelin JVN-11A Fire Javelin.mtf
+++ b/data/mekfiles/meks/3050U/Javelin JVN-11A Fire Javelin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Javelin JVN-11B.mtf
+++ b/data/mekfiles/meks/3050U/Javelin JVN-11B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Javelin JVN-11D.mtf
+++ b/data/mekfiles/meks/3050U/Javelin JVN-11D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Javelin JVN-11F.mtf
+++ b/data/mekfiles/meks/3050U/Javelin JVN-11F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Jenner JR7-C.mtf
+++ b/data/mekfiles/meks/3050U/Jenner JR7-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Jenner JR7-C2.mtf
+++ b/data/mekfiles/meks/3050U/Jenner JR7-C2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Jenner JR7-C3.mtf
+++ b/data/mekfiles/meks/3050U/Jenner JR7-C3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Jenner JR7-K Grace.mtf
+++ b/data/mekfiles/meks/3050U/Jenner JR7-K Grace.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Jenner JR7-K.mtf
+++ b/data/mekfiles/meks/3050U/Jenner JR7-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-2.mtf
+++ b/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-C.mtf
+++ b/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-CJ.mtf
+++ b/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-CJ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-CM.mtf
+++ b/data/mekfiles/meks/3050U/Katana (Crockett) CRK-5003-CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/King Crab KGC-000.mtf
+++ b/data/mekfiles/meks/3050U/King Crab KGC-000.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/King Crab KGC-001.mtf
+++ b/data/mekfiles/meks/3050U/King Crab KGC-001.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/King Crab KGC-005.mtf
+++ b/data/mekfiles/meks/3050U/King Crab KGC-005.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/King Crab KGC-007.mtf
+++ b/data/mekfiles/meks/3050U/King Crab KGC-007.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/King Crab KGC-008.mtf
+++ b/data/mekfiles/meks/3050U/King Crab KGC-008.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/King Crab KGC-008B.mtf
+++ b/data/mekfiles/meks/3050U/King Crab KGC-008B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Kintaro KTO-19.mtf
+++ b/data/mekfiles/meks/3050U/Kintaro KTO-19.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Kintaro KTO-20.mtf
+++ b/data/mekfiles/meks/3050U/Kintaro KTO-20.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Kintaro KTO-21.mtf
+++ b/data/mekfiles/meks/3050U/Kintaro KTO-21.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Kintaro KTO-C.mtf
+++ b/data/mekfiles/meks/3050U/Kintaro KTO-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Kintaro KTO-K.mtf
+++ b/data/mekfiles/meks/3050U/Kintaro KTO-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) A.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) B.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) C.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) D.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) E.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) F.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) G.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) H.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) P.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Koshi (Mist Lynx) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Koshi (Mist Lynx) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Lancelot LNC25-01.mtf
+++ b/data/mekfiles/meks/3050U/Lancelot LNC25-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Lancelot LNC25-03.mtf
+++ b/data/mekfiles/meks/3050U/Lancelot LNC25-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Lancelot LNC25-04.mtf
+++ b/data/mekfiles/meks/3050U/Lancelot LNC25-04.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Lancelot LNC25-05.mtf
+++ b/data/mekfiles/meks/3050U/Lancelot LNC25-05.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Lancelot LNC25-06.mtf
+++ b/data/mekfiles/meks/3050U/Lancelot LNC25-06.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Lancelot LNC25-08.mtf
+++ b/data/mekfiles/meks/3050U/Lancelot LNC25-08.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) A.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) B.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) C.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) D.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) E.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) F.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) H.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Loki (Hellbringer) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Loki (Hellbringer) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) A.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) B.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) C.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) D.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) E.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) F.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) H.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) Pryde.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) Pryde.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) S.mtf
+++ b/data/mekfiles/meks/3050U/Mad Cat (Timber Wolf) S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) A.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) B.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) C.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) D.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) E.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) G.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) H.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) M.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Man O' War (Gargoyle) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Man O' War (Gargoyle) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) A.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) B.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) C.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) D.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) E.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) H.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Masakari (Warhawk) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Masakari (Warhawk) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mauler MAL-1K.mtf
+++ b/data/mekfiles/meks/3050U/Mauler MAL-1K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mauler MAL-1R.mtf
+++ b/data/mekfiles/meks/3050U/Mauler MAL-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mauler MAL-2R.mtf
+++ b/data/mekfiles/meks/3050U/Mauler MAL-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mauler MAL-3R.mtf
+++ b/data/mekfiles/meks/3050U/Mauler MAL-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mauler MAL-C.mtf
+++ b/data/mekfiles/meks/3050U/Mauler MAL-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mercury MCY-102.mtf
+++ b/data/mekfiles/meks/3050U/Mercury MCY-102.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mercury MCY-104.mtf
+++ b/data/mekfiles/meks/3050U/Mercury MCY-104.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mercury MCY-97.mtf
+++ b/data/mekfiles/meks/3050U/Mercury MCY-97.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mercury MCY-99.mtf
+++ b/data/mekfiles/meks/3050U/Mercury MCY-99.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mongoose MON-66.mtf
+++ b/data/mekfiles/meks/3050U/Mongoose MON-66.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mongoose MON-69.mtf
+++ b/data/mekfiles/meks/3050U/Mongoose MON-69.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mongoose MON-70.mtf
+++ b/data/mekfiles/meks/3050U/Mongoose MON-70.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Mongoose MON-76.mtf
+++ b/data/mekfiles/meks/3050U/Mongoose MON-76.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON1-M-DC.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON1-M-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON1-M.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON1-M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON1-MA.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON1-MA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON1-MB.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON1-MB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON1-MC.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON1-MC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON1-MD.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON1-MD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Orion ON2-M.mtf
+++ b/data/mekfiles/meks/3050U/Orion ON2-M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-10K.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-10K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-10KA.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-10KA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-12A.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-12A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-14S.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-14S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-16K.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-16K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-C.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Panther PNT-CA.mtf
+++ b/data/mekfiles/meks/3050U/Panther PNT-CA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) A.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) B.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) C.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) D.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) E.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) H.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) J.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Puma (Adder) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Puma (Adder) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Quickdraw QKD-5K.mtf
+++ b/data/mekfiles/meks/3050U/Quickdraw QKD-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Quickdraw QKD-5K2.mtf
+++ b/data/mekfiles/meks/3050U/Quickdraw QKD-5K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Quickdraw QKD-5M.mtf
+++ b/data/mekfiles/meks/3050U/Quickdraw QKD-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Quickdraw QKD-8K.mtf
+++ b/data/mekfiles/meks/3050U/Quickdraw QKD-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Quickdraw QKD-C.mtf
+++ b/data/mekfiles/meks/3050U/Quickdraw QKD-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Raven RVN-3L.mtf
+++ b/data/mekfiles/meks/3050U/Raven RVN-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Raven RVN-3M.mtf
+++ b/data/mekfiles/meks/3050U/Raven RVN-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Raven RVN-4L.mtf
+++ b/data/mekfiles/meks/3050U/Raven RVN-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Raven RVN-4LC.mtf
+++ b/data/mekfiles/meks/3050U/Raven RVN-4LC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Raven RVN-SR.mtf
+++ b/data/mekfiles/meks/3050U/Raven RVN-SR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Raven RVN-SS.mtf
+++ b/data/mekfiles/meks/3050U/Raven RVN-SS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) (Kotare).mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) (Kotare).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) A.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) B.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) C.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) D.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) E.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) F.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) G.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) H.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Ryoken (Stormcrow) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Ryoken (Stormcrow) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Sentinel STN-3L.mtf
+++ b/data/mekfiles/meks/3050U/Sentinel STN-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Sentinel STN-3M.mtf
+++ b/data/mekfiles/meks/3050U/Sentinel STN-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Sentinel STN-4D.mtf
+++ b/data/mekfiles/meks/3050U/Sentinel STN-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Sentinel STN-5WB.mtf
+++ b/data/mekfiles/meks/3050U/Sentinel STN-5WB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Sentinel STN-C.mtf
+++ b/data/mekfiles/meks/3050U/Sentinel STN-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Shogun C.mtf
+++ b/data/mekfiles/meks/3050U/Shogun C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Shogun SHG-2E.mtf
+++ b/data/mekfiles/meks/3050U/Shogun SHG-2E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Shogun SHG-2F (Trisha).mtf
+++ b/data/mekfiles/meks/3050U/Shogun SHG-2F (Trisha).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Shogun SHG-2F.mtf
+++ b/data/mekfiles/meks/3050U/Shogun SHG-2F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Spider SDR-7K.mtf
+++ b/data/mekfiles/meks/3050U/Spider SDR-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Spider SDR-7K2.mtf
+++ b/data/mekfiles/meks/3050U/Spider SDR-7K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Spider SDR-7KC.mtf
+++ b/data/mekfiles/meks/3050U/Spider SDR-7KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Spider SDR-7M.mtf
+++ b/data/mekfiles/meks/3050U/Spider SDR-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Spider SDR-8M.mtf
+++ b/data/mekfiles/meks/3050U/Spider SDR-8M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Spider SDR-C.mtf
+++ b/data/mekfiles/meks/3050U/Spider SDR-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Stalker STK-3F (Jamison).mtf
+++ b/data/mekfiles/meks/3050U/Stalker STK-3F (Jamison).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Stalker STK-5M.mtf
+++ b/data/mekfiles/meks/3050U/Stalker STK-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Stalker STK-5S.mtf
+++ b/data/mekfiles/meks/3050U/Stalker STK-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Stalker STK-6M.mtf
+++ b/data/mekfiles/meks/3050U/Stalker STK-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Stalker STK-7D.mtf
+++ b/data/mekfiles/meks/3050U/Stalker STK-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Stalker STK-8S.mtf
+++ b/data/mekfiles/meks/3050U/Stalker STK-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) A.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) B.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) C.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) D.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) E.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) F.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) G.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) H.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) HH.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) HH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) M.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thor (Summoner) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Thor (Summoner) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thorn THE-N.mtf
+++ b/data/mekfiles/meks/3050U/Thorn THE-N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thorn THE-N1.mtf
+++ b/data/mekfiles/meks/3050U/Thorn THE-N1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thorn THE-N2.mtf
+++ b/data/mekfiles/meks/3050U/Thorn THE-N2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thug THG-11E (Reich).mtf
+++ b/data/mekfiles/meks/3050U/Thug THG-11E (Reich).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thug THG-11E.mtf
+++ b/data/mekfiles/meks/3050U/Thug THG-11E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thug THG-12E.mtf
+++ b/data/mekfiles/meks/3050U/Thug THG-12E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thug THG-12K.mtf
+++ b/data/mekfiles/meks/3050U/Thug THG-12K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Thug THG-13K.mtf
+++ b/data/mekfiles/meks/3050U/Thug THG-13K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Trebuchet TBT-3C.mtf
+++ b/data/mekfiles/meks/3050U/Trebuchet TBT-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Trebuchet TBT-7M.mtf
+++ b/data/mekfiles/meks/3050U/Trebuchet TBT-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Trebuchet TBT-8B.mtf
+++ b/data/mekfiles/meks/3050U/Trebuchet TBT-8B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Trebuchet TBT-9K.mtf
+++ b/data/mekfiles/meks/3050U/Trebuchet TBT-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) A.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) B.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) C.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) D.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) E.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) F.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) H.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) S.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Uller (Kit Fox) W.mtf
+++ b/data/mekfiles/meks/3050U/Uller (Kit Fox) W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/UrbanMech UM-R63.mtf
+++ b/data/mekfiles/meks/3050U/UrbanMech UM-R63.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/UrbanMech UM-R68.mtf
+++ b/data/mekfiles/meks/3050U/UrbanMech UM-R68.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/UrbanMech UM-R70.mtf
+++ b/data/mekfiles/meks/3050U/UrbanMech UM-R70.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Urbanmech UM-R69.mtf
+++ b/data/mekfiles/meks/3050U/Urbanmech UM-R69.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-10D.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-10D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-10L.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-10L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-10S.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-10S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-11D.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-11D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-9D.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-9K.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Victor VTR-C.mtf
+++ b/data/mekfiles/meks/3050U/Victor VTR-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vindicator VND-3L.mtf
+++ b/data/mekfiles/meks/3050U/Vindicator VND-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vindicator VND-4L.mtf
+++ b/data/mekfiles/meks/3050U/Vindicator VND-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vindicator VND-5L.mtf
+++ b/data/mekfiles/meks/3050U/Vindicator VND-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vindicator VND-6L.mtf
+++ b/data/mekfiles/meks/3050U/Vindicator VND-6L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulcan VT-5M.mtf
+++ b/data/mekfiles/meks/3050U/Vulcan VT-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulcan VT-5S.mtf
+++ b/data/mekfiles/meks/3050U/Vulcan VT-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulcan VT-6C.mtf
+++ b/data/mekfiles/meks/3050U/Vulcan VT-6C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulcan VT-6M.mtf
+++ b/data/mekfiles/meks/3050U/Vulcan VT-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) A.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) B.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) C.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) D.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) E.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) F.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) H.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Vulture (Mad Dog) Prime.mtf
+++ b/data/mekfiles/meks/3050U/Vulture (Mad Dog) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Whitworth WTH-1H.mtf
+++ b/data/mekfiles/meks/3050U/Whitworth WTH-1H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Whitworth WTH-2.mtf
+++ b/data/mekfiles/meks/3050U/Whitworth WTH-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Whitworth WTH-2A.mtf
+++ b/data/mekfiles/meks/3050U/Whitworth WTH-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Whitworth WTH-3.mtf
+++ b/data/mekfiles/meks/3050U/Whitworth WTH-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Whitworth WTH-K.mtf
+++ b/data/mekfiles/meks/3050U/Whitworth WTH-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-1.mtf
+++ b/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-2.mtf
+++ b/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-B.mtf
+++ b/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-C.mtf
+++ b/data/mekfiles/meks/3050U/Wolf Trap (Tora) WFT-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolfhound IIC.mtf
+++ b/data/mekfiles/meks/3050U/Wolfhound IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolfhound WLF-1 (Allard).mtf
+++ b/data/mekfiles/meks/3050U/Wolfhound WLF-1 (Allard).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolfhound WLF-2.mtf
+++ b/data/mekfiles/meks/3050U/Wolfhound WLF-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolfhound WLF-3S.mtf
+++ b/data/mekfiles/meks/3050U/Wolfhound WLF-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wolfhound WLF-4W.mtf
+++ b/data/mekfiles/meks/3050U/Wolfhound WLF-4W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wyvern WVE-10N.mtf
+++ b/data/mekfiles/meks/3050U/Wyvern WVE-10N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wyvern WVE-5N.mtf
+++ b/data/mekfiles/meks/3050U/Wyvern WVE-5N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Wyvern WVE-9N.mtf
+++ b/data/mekfiles/meks/3050U/Wyvern WVE-9N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Zeus X ZEU-9WD.mtf
+++ b/data/mekfiles/meks/3050U/Zeus X ZEU-9WD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Zeus ZEU-10WB.mtf
+++ b/data/mekfiles/meks/3050U/Zeus ZEU-10WB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Zeus ZEU-9S-DC.mtf
+++ b/data/mekfiles/meks/3050U/Zeus ZEU-9S-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Zeus ZEU-9S.mtf
+++ b/data/mekfiles/meks/3050U/Zeus ZEU-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Zeus ZEU-9S2.mtf
+++ b/data/mekfiles/meks/3050U/Zeus ZEU-9S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3050U/Zeus ZEU-9T.mtf
+++ b/data/mekfiles/meks/3050U/Zeus ZEU-9T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Albatross ALB-3U.mtf
+++ b/data/mekfiles/meks/3055U/Albatross ALB-3U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Albatross ALB-4U.mtf
+++ b/data/mekfiles/meks/3055U/Albatross ALB-4U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Anvil ANV-3M.mtf
+++ b/data/mekfiles/meks/3055U/Anvil ANV-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Anvil ANV-3R.mtf
+++ b/data/mekfiles/meks/3055U/Anvil ANV-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Anvil ANV-5M.mtf
+++ b/data/mekfiles/meks/3055U/Anvil ANV-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Anvil ANV-5Q.mtf
+++ b/data/mekfiles/meks/3055U/Anvil ANV-5Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Anvil ANV-6M.mtf
+++ b/data/mekfiles/meks/3055U/Anvil ANV-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Anvil ANV-8M.mtf
+++ b/data/mekfiles/meks/3055U/Anvil ANV-8M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Apollo APL-1M.mtf
+++ b/data/mekfiles/meks/3055U/Apollo APL-1M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Apollo APL-1R.mtf
+++ b/data/mekfiles/meks/3055U/Apollo APL-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Apollo APL-2S.mtf
+++ b/data/mekfiles/meks/3055U/Apollo APL-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Apollo APL-3T.mtf
+++ b/data/mekfiles/meks/3055U/Apollo APL-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Aquagladius AQS-3.mtf
+++ b/data/mekfiles/meks/3055U/Aquagladius AQS-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Aquagladius AQS-4.mtf
+++ b/data/mekfiles/meks/3055U/Aquagladius AQS-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Baboon (Howler) 2.mtf
+++ b/data/mekfiles/meks/3055U/Baboon (Howler) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Baboon (Howler) 3.mtf
+++ b/data/mekfiles/meks/3055U/Baboon (Howler) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Baboon (Howler).mtf
+++ b/data/mekfiles/meks/3055U/Baboon (Howler).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Bandersnatch BNDR-01A.mtf
+++ b/data/mekfiles/meks/3055U/Bandersnatch BNDR-01A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Bandersnatch BNDR-01B.mtf
+++ b/data/mekfiles/meks/3055U/Bandersnatch BNDR-01B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Battle Hawk BH-K305.mtf
+++ b/data/mekfiles/meks/3055U/Battle Hawk BH-K305.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Battle Hawk BH-K306.mtf
+++ b/data/mekfiles/meks/3055U/Battle Hawk BH-K306.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 2.mtf
+++ b/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 3.mtf
+++ b/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 4.mtf
+++ b/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 5.mtf
+++ b/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 6.mtf
+++ b/data/mekfiles/meks/3055U/Behemoth (Stone Rhino) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Behemoth (Stone Rhino).mtf
+++ b/data/mekfiles/meks/3055U/Behemoth (Stone Rhino).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Berserker BRZ-A3.mtf
+++ b/data/mekfiles/meks/3055U/Berserker BRZ-A3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Berserker BRZ-B3.mtf
+++ b/data/mekfiles/meks/3055U/Berserker BRZ-B3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Berserker BRZ-C3.mtf
+++ b/data/mekfiles/meks/3055U/Berserker BRZ-C3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Bombard BMB-010.mtf
+++ b/data/mekfiles/meks/3055U/Bombard BMB-010.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Bombard BMB-013.mtf
+++ b/data/mekfiles/meks/3055U/Bombard BMB-013.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Bombard BMB-1X.mtf
+++ b/data/mekfiles/meks/3055U/Bombard BMB-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cerberus MR-5M.mtf
+++ b/data/mekfiles/meks/3055U/Cerberus MR-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cerberus MR-6B.mtf
+++ b/data/mekfiles/meks/3055U/Cerberus MR-6B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cerberus MR-V2.mtf
+++ b/data/mekfiles/meks/3055U/Cerberus MR-V2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cerberus MR-V3.mtf
+++ b/data/mekfiles/meks/3055U/Cerberus MR-V3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Colossus CL-P3.mtf
+++ b/data/mekfiles/meks/3055U/Colossus CL-P3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Colossus CLS-4S.mtf
+++ b/data/mekfiles/meks/3055U/Colossus CLS-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Colossus CLS-5S.mtf
+++ b/data/mekfiles/meks/3055U/Colossus CLS-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Copperhead CPR-HD-002.mtf
+++ b/data/mekfiles/meks/3055U/Copperhead CPR-HD-002.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Copperhead CPR-HD-003.mtf
+++ b/data/mekfiles/meks/3055U/Copperhead CPR-HD-003.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Copperhead CPR-HD-004.mtf
+++ b/data/mekfiles/meks/3055U/Copperhead CPR-HD-004.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cudgel CDG-1B.mtf
+++ b/data/mekfiles/meks/3055U/Cudgel CDG-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cudgel CDG-2A.mtf
+++ b/data/mekfiles/meks/3055U/Cudgel CDG-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Cudgel CDG-2B.mtf
+++ b/data/mekfiles/meks/3055U/Cudgel CDG-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daedalus DAD-3C.mtf
+++ b/data/mekfiles/meks/3055U/Daedalus DAD-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daedalus DAD-3D.mtf
+++ b/data/mekfiles/meks/3055U/Daedalus DAD-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daedalus DAD-4A.mtf
+++ b/data/mekfiles/meks/3055U/Daedalus DAD-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daedalus DAD-4B.mtf
+++ b/data/mekfiles/meks/3055U/Daedalus DAD-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daikyu DAI-01.mtf
+++ b/data/mekfiles/meks/3055U/Daikyu DAI-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daikyu DAI-02.mtf
+++ b/data/mekfiles/meks/3055U/Daikyu DAI-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daikyu DAI-03.mtf
+++ b/data/mekfiles/meks/3055U/Daikyu DAI-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daimyo DMO-1K.mtf
+++ b/data/mekfiles/meks/3055U/Daimyo DMO-1K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daimyo DMO-2K.mtf
+++ b/data/mekfiles/meks/3055U/Daimyo DMO-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daimyo DMO-4K.mtf
+++ b/data/mekfiles/meks/3055U/Daimyo DMO-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Daimyo DMO-5K.mtf
+++ b/data/mekfiles/meks/3055U/Daimyo DMO-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Dart DRT-3S.mtf
+++ b/data/mekfiles/meks/3055U/Dart DRT-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Dart DRT-4S.mtf
+++ b/data/mekfiles/meks/3055U/Dart DRT-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Dart DRT-6S.mtf
+++ b/data/mekfiles/meks/3055U/Dart DRT-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Epimetheus Prime.mtf
+++ b/data/mekfiles/meks/3055U/Epimetheus Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Falconer FLC-8R.mtf
+++ b/data/mekfiles/meks/3055U/Falconer FLC-8R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Fireball ALM-7D.mtf
+++ b/data/mekfiles/meks/3055U/Fireball ALM-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Fireball ALM-8D.mtf
+++ b/data/mekfiles/meks/3055U/Fireball ALM-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Fireball ALM-9D.mtf
+++ b/data/mekfiles/meks/3055U/Fireball ALM-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Flashfire FLS-P2.mtf
+++ b/data/mekfiles/meks/3055U/Flashfire FLS-P2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Flashfire FLS-P4.mtf
+++ b/data/mekfiles/meks/3055U/Flashfire FLS-P4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Flashfire FLS-P5.mtf
+++ b/data/mekfiles/meks/3055U/Flashfire FLS-P5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Galahad (Glass Spider) 3.mtf
+++ b/data/mekfiles/meks/3055U/Galahad (Glass Spider) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gallowglas GAL-1GLS.mtf
+++ b/data/mekfiles/meks/3055U/Gallowglas GAL-1GLS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gallowglas GAL-2GLS.mtf
+++ b/data/mekfiles/meks/3055U/Gallowglas GAL-2GLS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gallowglas GAL-3GLS.mtf
+++ b/data/mekfiles/meks/3055U/Gallowglas GAL-3GLS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gallowglas GAL-4GLS.mtf
+++ b/data/mekfiles/meks/3055U/Gallowglas GAL-4GLS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gallowglas WD.mtf
+++ b/data/mekfiles/meks/3055U/Gallowglas WD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Goshawk (Vapor Eagle) 3.mtf
+++ b/data/mekfiles/meks/3055U/Goshawk (Vapor Eagle) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Goshawk (Vapor Eagle) 4.mtf
+++ b/data/mekfiles/meks/3055U/Goshawk (Vapor Eagle) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grand Crusader GRN-D-01.mtf
+++ b/data/mekfiles/meks/3055U/Grand Crusader GRN-D-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grand Crusader GRN-D-02.mtf
+++ b/data/mekfiles/meks/3055U/Grand Crusader GRN-D-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grand Crusader II GRN-D-03.mtf
+++ b/data/mekfiles/meks/3055U/Grand Crusader II GRN-D-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grand Crusader II GRN-D-04.mtf
+++ b/data/mekfiles/meks/3055U/Grand Crusader II GRN-D-04.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grand Titan T-IT-N10M.mtf
+++ b/data/mekfiles/meks/3055U/Grand Titan T-IT-N10M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grand Titan T-IT-N11M.mtf
+++ b/data/mekfiles/meks/3055U/Grand Titan T-IT-N11M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Great Turtle GTR-1.mtf
+++ b/data/mekfiles/meks/3055U/Great Turtle GTR-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Great Turtle GTR-2.mtf
+++ b/data/mekfiles/meks/3055U/Great Turtle GTR-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grim Reaper GRM-R-PR29.mtf
+++ b/data/mekfiles/meks/3055U/Grim Reaper GRM-R-PR29.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grim Reaper GRM-R-PR30.mtf
+++ b/data/mekfiles/meks/3055U/Grim Reaper GRM-R-PR30.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Grim Reaper GRM-R-PR31.mtf
+++ b/data/mekfiles/meks/3055U/Grim Reaper GRM-R-PR31.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gunslinger GUN-1ERD.mtf
+++ b/data/mekfiles/meks/3055U/Gunslinger GUN-1ERD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Gunslinger GUN-2ERD.mtf
+++ b/data/mekfiles/meks/3055U/Gunslinger GUN-2ERD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hachiwara HCA-3T.mtf
+++ b/data/mekfiles/meks/3055U/Hachiwara HCA-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hachiwara HCA-4T.mtf
+++ b/data/mekfiles/meks/3055U/Hachiwara HCA-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hachiwara HCA-4U.mtf
+++ b/data/mekfiles/meks/3055U/Hachiwara HCA-4U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hachiwara HCA-6P.mtf
+++ b/data/mekfiles/meks/3055U/Hachiwara HCA-6P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hammer HMR-3C.mtf
+++ b/data/mekfiles/meks/3055U/Hammer HMR-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hammer HMR-3M.mtf
+++ b/data/mekfiles/meks/3055U/Hammer HMR-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hammer HMR-3P.mtf
+++ b/data/mekfiles/meks/3055U/Hammer HMR-3P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hammer HMR-3S.mtf
+++ b/data/mekfiles/meks/3055U/Hammer HMR-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hellhound (Conjurer) 2.mtf
+++ b/data/mekfiles/meks/3055U/Hellhound (Conjurer) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hellhound (Conjurer) 3.mtf
+++ b/data/mekfiles/meks/3055U/Hellhound (Conjurer) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hellhound (Conjurer) 4.mtf
+++ b/data/mekfiles/meks/3055U/Hellhound (Conjurer) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hellhound (Conjurer) 5.mtf
+++ b/data/mekfiles/meks/3055U/Hellhound (Conjurer) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hercules HRC-LS-9000.mtf
+++ b/data/mekfiles/meks/3055U/Hercules HRC-LS-9000.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hercules HRC-LS-9001.mtf
+++ b/data/mekfiles/meks/3055U/Hercules HRC-LS-9001.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hitman HM-1.mtf
+++ b/data/mekfiles/meks/3055U/Hitman HM-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hitman HM-2.mtf
+++ b/data/mekfiles/meks/3055U/Hitman HM-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hollander BZK-F3.mtf
+++ b/data/mekfiles/meks/3055U/Hollander BZK-F3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hollander BZK-G1.mtf
+++ b/data/mekfiles/meks/3055U/Hollander BZK-G1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hollander II BZK-F5.mtf
+++ b/data/mekfiles/meks/3055U/Hollander II BZK-F5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Hollander II BZK-F7.mtf
+++ b/data/mekfiles/meks/3055U/Hollander II BZK-F7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4L.mtf
+++ b/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4M.mtf
+++ b/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4N.mtf
+++ b/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4O.mtf
+++ b/data/mekfiles/meks/3055U/Huron Warrior HUR-WO-R4O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Jackal JA-KL-1532.mtf
+++ b/data/mekfiles/meks/3055U/Jackal JA-KL-1532.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Jackal JA-KL-55.mtf
+++ b/data/mekfiles/meks/3055U/Jackal JA-KL-55.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Jenner IIC 4.mtf
+++ b/data/mekfiles/meks/3055U/Jenner IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Juggernaut JG-R9T1.mtf
+++ b/data/mekfiles/meks/3055U/Juggernaut JG-R9T1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Juggernaut JG-R9T2.mtf
+++ b/data/mekfiles/meks/3055U/Juggernaut JG-R9T2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Juggernaut JG-R9T3.mtf
+++ b/data/mekfiles/meks/3055U/Juggernaut JG-R9T3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Komodo KIM-2.mtf
+++ b/data/mekfiles/meks/3055U/Komodo KIM-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Komodo KIM-2A.mtf
+++ b/data/mekfiles/meks/3055U/Komodo KIM-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Komodo KIM-2C.mtf
+++ b/data/mekfiles/meks/3055U/Komodo KIM-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Komodo KIM-3C.mtf
+++ b/data/mekfiles/meks/3055U/Komodo KIM-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Koto KT-P2.mtf
+++ b/data/mekfiles/meks/3055U/Koto KT-P2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Koto KTO-2A.mtf
+++ b/data/mekfiles/meks/3055U/Koto KTO-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Koto KTO-3A.mtf
+++ b/data/mekfiles/meks/3055U/Koto KTO-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Koto KTO-4A.mtf
+++ b/data/mekfiles/meks/3055U/Koto KTO-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Kraken (Bane) 4.mtf
+++ b/data/mekfiles/meks/3055U/Kraken (Bane) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker A.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker B.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker C.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker D.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker E.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker H.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Linebacker Prime.mtf
+++ b/data/mekfiles/meks/3055U/Linebacker Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Longshot LNG-1B.mtf
+++ b/data/mekfiles/meks/3055U/Longshot LNG-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Longshot LNG-2.mtf
+++ b/data/mekfiles/meks/3055U/Longshot LNG-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Longshot LNG-3.mtf
+++ b/data/mekfiles/meks/3055U/Longshot LNG-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Longshot LNG-3C.mtf
+++ b/data/mekfiles/meks/3055U/Longshot LNG-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Longshot LNG-4.mtf
+++ b/data/mekfiles/meks/3055U/Longshot LNG-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Mantis MTS-L.mtf
+++ b/data/mekfiles/meks/3055U/Mantis MTS-L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Mantis MTS-S.mtf
+++ b/data/mekfiles/meks/3055U/Mantis MTS-S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Mantis MTS-T.mtf
+++ b/data/mekfiles/meks/3055U/Mantis MTS-T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Mantis MTS-T2.mtf
+++ b/data/mekfiles/meks/3055U/Mantis MTS-T2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Mantis MTS-T3.mtf
+++ b/data/mekfiles/meks/3055U/Mantis MTS-T3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Mantis SA-MN.mtf
+++ b/data/mekfiles/meks/3055U/Mantis SA-MN.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Morpheus MR-P1.mtf
+++ b/data/mekfiles/meks/3055U/Morpheus MR-P1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Morpheus MRP-3S.mtf
+++ b/data/mekfiles/meks/3055U/Morpheus MRP-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Morpheus MRP-3T.mtf
+++ b/data/mekfiles/meks/3055U/Morpheus MRP-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Morpheus MRP-3W.mtf
+++ b/data/mekfiles/meks/3055U/Morpheus MRP-3W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naga A.mtf
+++ b/data/mekfiles/meks/3055U/Naga A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naga B.mtf
+++ b/data/mekfiles/meks/3055U/Naga B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naga C.mtf
+++ b/data/mekfiles/meks/3055U/Naga C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naga D.mtf
+++ b/data/mekfiles/meks/3055U/Naga D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naga Prime.mtf
+++ b/data/mekfiles/meks/3055U/Naga Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naginata NG-C3A.mtf
+++ b/data/mekfiles/meks/3055U/Naginata NG-C3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naginata NG-C3B.mtf
+++ b/data/mekfiles/meks/3055U/Naginata NG-C3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Naginata NG-C3C.mtf
+++ b/data/mekfiles/meks/3055U/Naginata NG-C3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nexus II NXS2-A.mtf
+++ b/data/mekfiles/meks/3055U/Nexus II NXS2-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nexus II NXS2-B.mtf
+++ b/data/mekfiles/meks/3055U/Nexus II NXS2-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nexus NXS1-A.mtf
+++ b/data/mekfiles/meks/3055U/Nexus NXS1-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nexus NXS1-B.mtf
+++ b/data/mekfiles/meks/3055U/Nexus NXS1-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nightsky NGS-4S.mtf
+++ b/data/mekfiles/meks/3055U/Nightsky NGS-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nightsky NGS-4T.mtf
+++ b/data/mekfiles/meks/3055U/Nightsky NGS-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nightsky NGS-5S.mtf
+++ b/data/mekfiles/meks/3055U/Nightsky NGS-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nightsky NGS-5T.mtf
+++ b/data/mekfiles/meks/3055U/Nightsky NGS-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Nightsky NGS-6S.mtf
+++ b/data/mekfiles/meks/3055U/Nightsky NGS-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Onslaught SA-OS.mtf
+++ b/data/mekfiles/meks/3055U/Onslaught SA-OS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Onslaught SA-OS2.mtf
+++ b/data/mekfiles/meks/3055U/Onslaught SA-OS2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Onslaught SA-OS3.mtf
+++ b/data/mekfiles/meks/3055U/Onslaught SA-OS3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Paladin PAL-1.mtf
+++ b/data/mekfiles/meks/3055U/Paladin PAL-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Paladin PAL-2.mtf
+++ b/data/mekfiles/meks/3055U/Paladin PAL-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Paladin PAL-3.mtf
+++ b/data/mekfiles/meks/3055U/Paladin PAL-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Penetrator PTR-4D.mtf
+++ b/data/mekfiles/meks/3055U/Penetrator PTR-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Penetrator PTR-4F.mtf
+++ b/data/mekfiles/meks/3055U/Penetrator PTR-4F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Penetrator PTR-6M.mtf
+++ b/data/mekfiles/meks/3055U/Penetrator PTR-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Penetrator PTR-6S.mtf
+++ b/data/mekfiles/meks/3055U/Penetrator PTR-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Penetrator PTR-6T.mtf
+++ b/data/mekfiles/meks/3055U/Penetrator PTR-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Peregrine (Horned Owl) 4.mtf
+++ b/data/mekfiles/meks/3055U/Peregrine (Horned Owl) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Peregrine (Horned Owl) 5.mtf
+++ b/data/mekfiles/meks/3055U/Peregrine (Horned Owl) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom A.mtf
+++ b/data/mekfiles/meks/3055U/Phantom A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom B.mtf
+++ b/data/mekfiles/meks/3055U/Phantom B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom C.mtf
+++ b/data/mekfiles/meks/3055U/Phantom C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom D.mtf
+++ b/data/mekfiles/meks/3055U/Phantom D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom E.mtf
+++ b/data/mekfiles/meks/3055U/Phantom E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom H.mtf
+++ b/data/mekfiles/meks/3055U/Phantom H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Phantom Prime.mtf
+++ b/data/mekfiles/meks/3055U/Phantom Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Porcupine PRC-1N.mtf
+++ b/data/mekfiles/meks/3055U/Porcupine PRC-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Porcupine PRC-2N.mtf
+++ b/data/mekfiles/meks/3055U/Porcupine PRC-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer A.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer B.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer C.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer D.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer E.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer H.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Pouncer Prime.mtf
+++ b/data/mekfiles/meks/3055U/Pouncer Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Prometheus.mtf
+++ b/data/mekfiles/meks/3055U/Prometheus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Prowler PWR-1X.mtf
+++ b/data/mekfiles/meks/3055U/Prowler PWR-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Prowler PWR-1X1.mtf
+++ b/data/mekfiles/meks/3055U/Prowler PWR-1X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Raijin II RJN-200-A.mtf
+++ b/data/mekfiles/meks/3055U/Raijin II RJN-200-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Raijin II RJN-200-B.mtf
+++ b/data/mekfiles/meks/3055U/Raijin II RJN-200-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Raijin II RJN-200-C.mtf
+++ b/data/mekfiles/meks/3055U/Raijin II RJN-200-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Raijin RJN 101-A.mtf
+++ b/data/mekfiles/meks/3055U/Raijin RJN 101-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Rakshasa MDG-1A.mtf
+++ b/data/mekfiles/meks/3055U/Rakshasa MDG-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Rakshasa MDG-1B.mtf
+++ b/data/mekfiles/meks/3055U/Rakshasa MDG-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Rakshasa MDG-2A.mtf
+++ b/data/mekfiles/meks/3055U/Rakshasa MDG-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Ronin SA-RN.mtf
+++ b/data/mekfiles/meks/3055U/Ronin SA-RN.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Ronin SA-RN7.mtf
+++ b/data/mekfiles/meks/3055U/Ronin SA-RN7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Salamander PPR-5S.mtf
+++ b/data/mekfiles/meks/3055U/Salamander PPR-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Salamander PPR-5T.mtf
+++ b/data/mekfiles/meks/3055U/Salamander PPR-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Salamander PPR-6S.mtf
+++ b/data/mekfiles/meks/3055U/Salamander PPR-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Salamander PPR-6T.mtf
+++ b/data/mekfiles/meks/3055U/Salamander PPR-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Salamander PPR-7S.mtf
+++ b/data/mekfiles/meks/3055U/Salamander PPR-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Sasquatch SQS-TH-001.mtf
+++ b/data/mekfiles/meks/3055U/Sasquatch SQS-TH-001.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Sasquatch SQS-TH-002.mtf
+++ b/data/mekfiles/meks/3055U/Sasquatch SQS-TH-002.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Sasquatch SQS-TH-003.mtf
+++ b/data/mekfiles/meks/3055U/Sasquatch SQS-TH-003.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Scarabus SCB-9A.mtf
+++ b/data/mekfiles/meks/3055U/Scarabus SCB-9A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Scarabus SCB-9T.mtf
+++ b/data/mekfiles/meks/3055U/Scarabus SCB-9T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Silver Fox SVR-5X.mtf
+++ b/data/mekfiles/meks/3055U/Silver Fox SVR-5X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Silver Fox SVR-5Y.mtf
+++ b/data/mekfiles/meks/3055U/Silver Fox SVR-5Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Snake SNK-1V.mtf
+++ b/data/mekfiles/meks/3055U/Snake SNK-1V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Snake SNK-2B.mtf
+++ b/data/mekfiles/meks/3055U/Snake SNK-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Spatha SP1-X.mtf
+++ b/data/mekfiles/meks/3055U/Spatha SP1-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Stealth STH-1D.mtf
+++ b/data/mekfiles/meks/3055U/Stealth STH-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Stealth STH-2D.mtf
+++ b/data/mekfiles/meks/3055U/Stealth STH-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Stealth STH-2D1.mtf
+++ b/data/mekfiles/meks/3055U/Stealth STH-2D1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Stealth STH-2D2.mtf
+++ b/data/mekfiles/meks/3055U/Stealth STH-2D2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Stealth STH-3S.mtf
+++ b/data/mekfiles/meks/3055U/Stealth STH-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tarantula ZPH-1.mtf
+++ b/data/mekfiles/meks/3055U/Tarantula ZPH-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tarantula ZPH-2A.mtf
+++ b/data/mekfiles/meks/3055U/Tarantula ZPH-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tarantula ZPH-3A.mtf
+++ b/data/mekfiles/meks/3055U/Tarantula ZPH-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tarantula ZPH-4A.mtf
+++ b/data/mekfiles/meks/3055U/Tarantula ZPH-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tempest TMP-3G.mtf
+++ b/data/mekfiles/meks/3055U/Tempest TMP-3G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tempest TMP-3M.mtf
+++ b/data/mekfiles/meks/3055U/Tempest TMP-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tempest TMP-3M2_Storm_Tempest.mtf
+++ b/data/mekfiles/meks/3055U/Tempest TMP-3M2_Storm_Tempest.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tempest TMP-3MA.mtf
+++ b/data/mekfiles/meks/3055U/Tempest TMP-3MA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Thunder THR-1L.mtf
+++ b/data/mekfiles/meks/3055U/Thunder THR-1L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Thunder THR-2L.mtf
+++ b/data/mekfiles/meks/3055U/Thunder THR-2L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Thunder THR-3L.mtf
+++ b/data/mekfiles/meks/3055U/Thunder THR-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tsunami TS-P1.mtf
+++ b/data/mekfiles/meks/3055U/Tsunami TS-P1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Tsunami TS-P1D.mtf
+++ b/data/mekfiles/meks/3055U/Tsunami TS-P1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Venom SDR-9K.mtf
+++ b/data/mekfiles/meks/3055U/Venom SDR-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Venom SDR-9KA.mtf
+++ b/data/mekfiles/meks/3055U/Venom SDR-9KA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Venom SDR-9KB.mtf
+++ b/data/mekfiles/meks/3055U/Venom SDR-9KB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Venom SDR-9KC.mtf
+++ b/data/mekfiles/meks/3055U/Venom SDR-9KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Viper (Black Python) 3.mtf
+++ b/data/mekfiles/meks/3055U/Viper (Black Python) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Viper (Black Python) 4.mtf
+++ b/data/mekfiles/meks/3055U/Viper (Black Python) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Vixen (Incubus) 4.mtf
+++ b/data/mekfiles/meks/3055U/Vixen (Incubus) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Vixen (Incubus) 5.mtf
+++ b/data/mekfiles/meks/3055U/Vixen (Incubus) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Vixen (Incubus).mtf
+++ b/data/mekfiles/meks/3055U/Vixen (Incubus).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Volkh VKH-1.mtf
+++ b/data/mekfiles/meks/3055U/Volkh VKH-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Volkh VKH-7.mtf
+++ b/data/mekfiles/meks/3055U/Volkh VKH-7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/War Dog WR-DG-02FC.mtf
+++ b/data/mekfiles/meks/3055U/War Dog WR-DG-02FC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/War Dog WR-DG-03FC.mtf
+++ b/data/mekfiles/meks/3055U/War Dog WR-DG-03FC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Watchman WTC-4DM.mtf
+++ b/data/mekfiles/meks/3055U/Watchman WTC-4DM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Watchman WTC-4M.mtf
+++ b/data/mekfiles/meks/3055U/Watchman WTC-4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Werewolf WER-LF-004.mtf
+++ b/data/mekfiles/meks/3055U/Werewolf WER-LF-004.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Werewolf WER-LF-005.mtf
+++ b/data/mekfiles/meks/3055U/Werewolf WER-LF-005.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Wildfire P1-WF.mtf
+++ b/data/mekfiles/meks/3055U/Wildfire P1-WF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Wraith TR1.mtf
+++ b/data/mekfiles/meks/3055U/Wraith TR1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Wraith TR2.mtf
+++ b/data/mekfiles/meks/3055U/Wraith TR2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3055U/Wraith TR3.mtf
+++ b/data/mekfiles/meks/3055U/Wraith TR3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OG.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OH.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OI.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OI.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Avatar AV1-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Avatar AV1-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra A.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra B.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2O.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra BTL-C-2OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra C.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra H.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Battle Cobra Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Battle Cobra Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OX.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Hawk-KU BHKU-OX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner A.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner B.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner C.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner D.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner E.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner H.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Black Lanner Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Black Lanner Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Blackjack BJ2-OX.mtf
+++ b/data/mekfiles/meks/3058Uu/Blackjack BJ2-OX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Bushwacker BSW-L1.mtf
+++ b/data/mekfiles/meks/3058Uu/Bushwacker BSW-L1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Bushwacker BSW-S2.mtf
+++ b/data/mekfiles/meks/3058Uu/Bushwacker BSW-S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Bushwacker BSW-X1.mtf
+++ b/data/mekfiles/meks/3058Uu/Bushwacker BSW-X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Bushwacker BSW-X2.mtf
+++ b/data/mekfiles/meks/3058Uu/Bushwacker BSW-X2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) A.mtf
+++ b/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) B.mtf
+++ b/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) C.mtf
+++ b/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) D.mtf
+++ b/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) H.mtf
+++ b/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Cauldron-Born (Ebon Jaguar) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cestus CTS-6X.mtf
+++ b/data/mekfiles/meks/3058Uu/Cestus CTS-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cestus CTS-6Y.mtf
+++ b/data/mekfiles/meks/3058Uu/Cestus CTS-6Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cestus CTS-6Z.mtf
+++ b/data/mekfiles/meks/3058Uu/Cestus CTS-6Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Cestus CTS-7A.mtf
+++ b/data/mekfiles/meks/3058Uu/Cestus CTS-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Chameleon CLN-7V.mtf
+++ b/data/mekfiles/meks/3058Uu/Chameleon CLN-7V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Chameleon CLN-7W.mtf
+++ b/data/mekfiles/meks/3058Uu/Chameleon CLN-7W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Chameleon CLN-7Z.mtf
+++ b/data/mekfiles/meks/3058Uu/Chameleon CLN-7Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Crossbow A.mtf
+++ b/data/mekfiles/meks/3058Uu/Crossbow A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Crossbow B.mtf
+++ b/data/mekfiles/meks/3058Uu/Crossbow B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Crossbow C.mtf
+++ b/data/mekfiles/meks/3058Uu/Crossbow C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Crossbow D.mtf
+++ b/data/mekfiles/meks/3058Uu/Crossbow D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Crossbow H.mtf
+++ b/data/mekfiles/meks/3058Uu/Crossbow H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Crossbow Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Crossbow Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Devastator DVS-1D.mtf
+++ b/data/mekfiles/meks/3058Uu/Devastator DVS-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Devastator DVS-2.mtf
+++ b/data/mekfiles/meks/3058Uu/Devastator DVS-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Devastator DVS-3.mtf
+++ b/data/mekfiles/meks/3058Uu/Devastator DVS-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Dragon Fire DGR-3F.mtf
+++ b/data/mekfiles/meks/3058Uu/Dragon Fire DGR-3F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Dragon Fire DGR-4F.mtf
+++ b/data/mekfiles/meks/3058Uu/Dragon Fire DGR-4F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Dragon Fire DGR-6FC.mtf
+++ b/data/mekfiles/meks/3058Uu/Dragon Fire DGR-6FC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-5A.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-6A.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-6A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-6D.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-6L.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-6L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-6M.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-6S.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Emperor EMP-7L.mtf
+++ b/data/mekfiles/meks/3058Uu/Emperor EMP-7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Enfield END-6J.mtf
+++ b/data/mekfiles/meks/3058Uu/Enfield END-6J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Enfield END-6Q.mtf
+++ b/data/mekfiles/meks/3058Uu/Enfield END-6Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Enfield END-6S.mtf
+++ b/data/mekfiles/meks/3058Uu/Enfield END-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Excalibur EXC-B1.mtf
+++ b/data/mekfiles/meks/3058Uu/Excalibur EXC-B1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Excalibur EXC-B2.mtf
+++ b/data/mekfiles/meks/3058Uu/Excalibur EXC-B2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Excalibur EXC-C1.mtf
+++ b/data/mekfiles/meks/3058Uu/Excalibur EXC-C1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Excalibur EXC-CS.mtf
+++ b/data/mekfiles/meks/3058Uu/Excalibur EXC-CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Excalibur EXC-D1.mtf
+++ b/data/mekfiles/meks/3058Uu/Excalibur EXC-D1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Falcon Hawk FNHK-9K.mtf
+++ b/data/mekfiles/meks/3058Uu/Falcon Hawk FNHK-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Falcon Hawk FNHK-9K1A.mtf
+++ b/data/mekfiles/meks/3058Uu/Falcon Hawk FNHK-9K1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Falcon Hawk FNHK-9K1B.mtf
+++ b/data/mekfiles/meks/3058Uu/Falcon Hawk FNHK-9K1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon A.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon B.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon C.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon D.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon E.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon H.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Fire Falcon Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Fire Falcon Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OG.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OH.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Firestarter FS9-OX.mtf
+++ b/data/mekfiles/meks/3058Uu/Firestarter FS9-OX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) A.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) B.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) C.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) D.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) E.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) F.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) H.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grendel (Mongrel) Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Grendel (Mongrel) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grizzly 2.mtf
+++ b/data/mekfiles/meks/3058Uu/Grizzly 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Grizzly.mtf
+++ b/data/mekfiles/meks/3058Uu/Grizzly.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) A.mtf
+++ b/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) B.mtf
+++ b/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) C.mtf
+++ b/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) D.mtf
+++ b/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) H.mtf
+++ b/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Hankyu (Arctic Cheetah) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hunchback IIC 2.mtf
+++ b/data/mekfiles/meks/3058Uu/Hunchback IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hunchback IIC 3.mtf
+++ b/data/mekfiles/meks/3058Uu/Hunchback IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Hunchback IIC.mtf
+++ b/data/mekfiles/meks/3058Uu/Hunchback IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher A.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher B.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher C.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher D.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher E.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher H.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kingfisher Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Kingfisher Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kodiak 2.mtf
+++ b/data/mekfiles/meks/3058Uu/Kodiak 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kodiak 3.mtf
+++ b/data/mekfiles/meks/3058Uu/Kodiak 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kodiak 4.mtf
+++ b/data/mekfiles/meks/3058Uu/Kodiak 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kodiak 5.mtf
+++ b/data/mekfiles/meks/3058Uu/Kodiak 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Kodiak.mtf
+++ b/data/mekfiles/meks/3058Uu/Kodiak.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lineholder KW1-LH2.mtf
+++ b/data/mekfiles/meks/3058Uu/Lineholder KW1-LH2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lineholder KW1-LH3.mtf
+++ b/data/mekfiles/meks/3058Uu/Lineholder KW1-LH3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lineholder KW1-LH8.mtf
+++ b/data/mekfiles/meks/3058Uu/Lineholder KW1-LH8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lineholder KW2-LHW.mtf
+++ b/data/mekfiles/meks/3058Uu/Lineholder KW2-LHW.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Longbow LGB-7Q.mtf
+++ b/data/mekfiles/meks/3058Uu/Longbow LGB-7Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Longbow LGB-7V.mtf
+++ b/data/mekfiles/meks/3058Uu/Longbow LGB-7V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lynx LNX-8Q.mtf
+++ b/data/mekfiles/meks/3058Uu/Lynx LNX-8Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lynx LNX-9C.mtf
+++ b/data/mekfiles/meks/3058Uu/Lynx LNX-9C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lynx LNX-9Q.mtf
+++ b/data/mekfiles/meks/3058Uu/Lynx LNX-9Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Lynx LNX-9R.mtf
+++ b/data/mekfiles/meks/3058Uu/Lynx LNX-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Maelstrom MTR-5K.mtf
+++ b/data/mekfiles/meks/3058Uu/Maelstrom MTR-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Maelstrom MTR-6E.mtf
+++ b/data/mekfiles/meks/3058Uu/Maelstrom MTR-6E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Maelstrom MTR-6K.mtf
+++ b/data/mekfiles/meks/3058Uu/Maelstrom MTR-6K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Merlin MLN-1A.mtf
+++ b/data/mekfiles/meks/3058Uu/Merlin MLN-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Merlin MLN-1B.mtf
+++ b/data/mekfiles/meks/3058Uu/Merlin MLN-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Merlin MLN-1C.mtf
+++ b/data/mekfiles/meks/3058Uu/Merlin MLN-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr A.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr B.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr C.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr D.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr E.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr H.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Gyr Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Gyr Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Hawk NTK-2Q.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Hawk NTK-2Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Night Hawk NTK-2S.mtf
+++ b/data/mekfiles/meks/3058Uu/Night Hawk NTK-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nightstar NSR-9FC.mtf
+++ b/data/mekfiles/meks/3058Uu/Nightstar NSR-9FC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nightstar NSR-9J.mtf
+++ b/data/mekfiles/meks/3058Uu/Nightstar NSR-9J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nightstar NSR-9SS.mtf
+++ b/data/mekfiles/meks/3058Uu/Nightstar NSR-9SS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) A.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) B.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) C.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) D.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) H.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) N.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Nobori-nin (Huntsman) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/O-Bakemono OBK-M10.mtf
+++ b/data/mekfiles/meks/3058Uu/O-Bakemono OBK-M10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/O-Bakemono OBK-M11.mtf
+++ b/data/mekfiles/meks/3058Uu/O-Bakemono OBK-M11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/O-Bakemono OBK-M12.mtf
+++ b/data/mekfiles/meks/3058Uu/O-Bakemono OBK-M12.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1A.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1B.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1C.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1D.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1E.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1F.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Owens OW-1R.mtf
+++ b/data/mekfiles/meks/3058Uu/Owens OW-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Pillager PLG-1N.mtf
+++ b/data/mekfiles/meks/3058Uu/Pillager PLG-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Pillager PLG-3Z.mtf
+++ b/data/mekfiles/meks/3058Uu/Pillager PLG-3Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Pillager PLG-4Z.mtf
+++ b/data/mekfiles/meks/3058Uu/Pillager PLG-4Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Pillager PLG-5L.mtf
+++ b/data/mekfiles/meks/3058Uu/Pillager PLG-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Pillager PLG-5Z.mtf
+++ b/data/mekfiles/meks/3058Uu/Pillager PLG-5Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Piranha 2.mtf
+++ b/data/mekfiles/meks/3058Uu/Piranha 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Piranha 3.mtf
+++ b/data/mekfiles/meks/3058Uu/Piranha 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Piranha.mtf
+++ b/data/mekfiles/meks/3058Uu/Piranha.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OG.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Raptor RTX1-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Raptor RTX1-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shadow Cat A.mtf
+++ b/data/mekfiles/meks/3058Uu/Shadow Cat A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shadow Cat B.mtf
+++ b/data/mekfiles/meks/3058Uu/Shadow Cat B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shadow Cat C.mtf
+++ b/data/mekfiles/meks/3058Uu/Shadow Cat C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shadow Cat H.mtf
+++ b/data/mekfiles/meks/3058Uu/Shadow Cat H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shadow Cat Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Shadow Cat Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shootist ST-8A.mtf
+++ b/data/mekfiles/meks/3058Uu/Shootist ST-8A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shootist ST-8C.mtf
+++ b/data/mekfiles/meks/3058Uu/Shootist ST-8C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Shootist ST-9C.mtf
+++ b/data/mekfiles/meks/3058Uu/Shootist ST-9C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spartan SPT-N1.mtf
+++ b/data/mekfiles/meks/3058Uu/Spartan SPT-N1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spartan SPT-N2.mtf
+++ b/data/mekfiles/meks/3058Uu/Spartan SPT-N2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spartan SPT-N3.mtf
+++ b/data/mekfiles/meks/3058Uu/Spartan SPT-N3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spartan SPT-NF.mtf
+++ b/data/mekfiles/meks/3058Uu/Spartan SPT-NF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spector SPR-4F.mtf
+++ b/data/mekfiles/meks/3058Uu/Spector SPR-4F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spector SPR-5F.mtf
+++ b/data/mekfiles/meks/3058Uu/Spector SPR-5F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spector SPR-5S.mtf
+++ b/data/mekfiles/meks/3058Uu/Spector SPR-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Spector SPR-ST.mtf
+++ b/data/mekfiles/meks/3058Uu/Spector SPR-ST.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Starslayer STY-2C.mtf
+++ b/data/mekfiles/meks/3058Uu/Starslayer STY-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Starslayer STY-3C.mtf
+++ b/data/mekfiles/meks/3058Uu/Starslayer STY-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Starslayer STY-3D.mtf
+++ b/data/mekfiles/meks/3058Uu/Starslayer STY-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OF.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OG.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Strider SR1-OX.mtf
+++ b/data/mekfiles/meks/3058Uu/Strider SR1-OX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Striker STC-2C.mtf
+++ b/data/mekfiles/meks/3058Uu/Striker STC-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Striker STC-2D.mtf
+++ b/data/mekfiles/meks/3058Uu/Striker STC-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Striker STC-2S.mtf
+++ b/data/mekfiles/meks/3058Uu/Striker STC-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-O Samual.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-O Samual.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-O.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OA.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OB.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OC.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OD.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OE.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OR.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Sunder SD1-OX.mtf
+++ b/data/mekfiles/meks/3058Uu/Sunder SD1-OX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Supernova 2.mtf
+++ b/data/mekfiles/meks/3058Uu/Supernova 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Supernova 3.mtf
+++ b/data/mekfiles/meks/3058Uu/Supernova 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Supernova 4.mtf
+++ b/data/mekfiles/meks/3058Uu/Supernova 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Supernova.mtf
+++ b/data/mekfiles/meks/3058Uu/Supernova.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Talon TLN-5V.mtf
+++ b/data/mekfiles/meks/3058Uu/Talon TLN-5V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Talon TLN-5W.mtf
+++ b/data/mekfiles/meks/3058Uu/Talon TLN-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Talon TLN-5Z.mtf
+++ b/data/mekfiles/meks/3058Uu/Talon TLN-5Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Thresher 2.mtf
+++ b/data/mekfiles/meks/3058Uu/Thresher 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Thresher.mtf
+++ b/data/mekfiles/meks/3058Uu/Thresher.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7KMA.mtf
+++ b/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7KMA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7S.mtf
+++ b/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7X.mtf
+++ b/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7Y.mtf
+++ b/data/mekfiles/meks/3058Uu/Thunder Hawk TDK-7Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Turkina A.mtf
+++ b/data/mekfiles/meks/3058Uu/Turkina A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Turkina B.mtf
+++ b/data/mekfiles/meks/3058Uu/Turkina B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Turkina C.mtf
+++ b/data/mekfiles/meks/3058Uu/Turkina C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Turkina D.mtf
+++ b/data/mekfiles/meks/3058Uu/Turkina D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Turkina H.mtf
+++ b/data/mekfiles/meks/3058Uu/Turkina H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3058Uu/Turkina Prime.mtf
+++ b/data/mekfiles/meks/3058Uu/Turkina Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1A.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1B.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1C.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1D.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1E.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Fox AF1F.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Fox AF1F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Wolf 2.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Wolf 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Wolf A.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Wolf A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Wolf J.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Wolf J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Wolf Prime.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Wolf Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Arctic Wolf.mtf
+++ b/data/mekfiles/meks/3060u/Arctic Wolf.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Barghest BGS-1T.mtf
+++ b/data/mekfiles/meks/3060u/Barghest BGS-1T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Barghest BGS-2T.mtf
+++ b/data/mekfiles/meks/3060u/Barghest BGS-2T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Barghest BGS-3T.mtf
+++ b/data/mekfiles/meks/3060u/Barghest BGS-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Barghest BGS-7S.mtf
+++ b/data/mekfiles/meks/3060u/Barghest BGS-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Beowulf BEO-12.mtf
+++ b/data/mekfiles/meks/3060u/Beowulf BEO-12.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Beowulf BEO-14.mtf
+++ b/data/mekfiles/meks/3060u/Beowulf BEO-14.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Bishamon BSN-3K.mtf
+++ b/data/mekfiles/meks/3060u/Bishamon BSN-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Bishamon BSN-4K.mtf
+++ b/data/mekfiles/meks/3060u/Bishamon BSN-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Bishamon BSN-5KC.mtf
+++ b/data/mekfiles/meks/3060u/Bishamon BSN-5KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Black Watch BKW-7R.mtf
+++ b/data/mekfiles/meks/3060u/Black Watch BKW-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Black Watch BKW-9R.mtf
+++ b/data/mekfiles/meks/3060u/Black Watch BKW-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Blitzkrieg BTZ-3F.mtf
+++ b/data/mekfiles/meks/3060u/Blitzkrieg BTZ-3F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Blitzkrieg BTZ-4F.mtf
+++ b/data/mekfiles/meks/3060u/Blitzkrieg BTZ-4F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Buccaneer BCN-3R.mtf
+++ b/data/mekfiles/meks/3060u/Buccaneer BCN-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Buccaneer BCN-5W.mtf
+++ b/data/mekfiles/meks/3060u/Buccaneer BCN-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Buccaneer BCN-6W.mtf
+++ b/data/mekfiles/meks/3060u/Buccaneer BCN-6W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Canis 2.mtf
+++ b/data/mekfiles/meks/3060u/Canis 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Canis.mtf
+++ b/data/mekfiles/meks/3060u/Canis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Clint IIC 2.mtf
+++ b/data/mekfiles/meks/3060u/Clint IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Clint IIC.mtf
+++ b/data/mekfiles/meks/3060u/Clint IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cobra CBR-02.mtf
+++ b/data/mekfiles/meks/3060u/Cobra CBR-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cobra CBR-03.mtf
+++ b/data/mekfiles/meks/3060u/Cobra CBR-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Commando IIC.mtf
+++ b/data/mekfiles/meks/3060u/Commando IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Corvis 2.mtf
+++ b/data/mekfiles/meks/3060u/Corvis 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Corvis.mtf
+++ b/data/mekfiles/meks/3060u/Corvis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cossack C-1FC.mtf
+++ b/data/mekfiles/meks/3060u/Cossack C-1FC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cossack C-SK1.mtf
+++ b/data/mekfiles/meks/3060u/Cossack C-SK1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cougar A.mtf
+++ b/data/mekfiles/meks/3060u/Cougar A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cougar B.mtf
+++ b/data/mekfiles/meks/3060u/Cougar B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cougar C.mtf
+++ b/data/mekfiles/meks/3060u/Cougar C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cougar D.mtf
+++ b/data/mekfiles/meks/3060u/Cougar D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Cougar Prime.mtf
+++ b/data/mekfiles/meks/3060u/Cougar Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Duan Gung D9-G10.mtf
+++ b/data/mekfiles/meks/3060u/Duan Gung D9-G10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Duan Gung D9-G9.mtf
+++ b/data/mekfiles/meks/3060u/Duan Gung D9-G9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Eagle EGL-1M.mtf
+++ b/data/mekfiles/meks/3060u/Eagle EGL-1M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Eagle EGL-2M.mtf
+++ b/data/mekfiles/meks/3060u/Eagle EGL-2M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Eagle EGL-3M.mtf
+++ b/data/mekfiles/meks/3060u/Eagle EGL-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Enforcer III ENF-6M.mtf
+++ b/data/mekfiles/meks/3060u/Enforcer III ENF-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Enforcer III ENF-6NAIS.mtf
+++ b/data/mekfiles/meks/3060u/Enforcer III ENF-6NAIS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Fire Scorpion 2.mtf
+++ b/data/mekfiles/meks/3060u/Fire Scorpion 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Fire Scorpion 3.mtf
+++ b/data/mekfiles/meks/3060u/Fire Scorpion 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Fire Scorpion.mtf
+++ b/data/mekfiles/meks/3060u/Fire Scorpion.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Garm GRM-01A.mtf
+++ b/data/mekfiles/meks/3060u/Garm GRM-01A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Garm GRM-01A2.mtf
+++ b/data/mekfiles/meks/3060u/Garm GRM-01A2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Garm GRM-01B.mtf
+++ b/data/mekfiles/meks/3060u/Garm GRM-01B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Garm GRM-01C.mtf
+++ b/data/mekfiles/meks/3060u/Garm GRM-01C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Great Wyrm 2.mtf
+++ b/data/mekfiles/meks/3060u/Great Wyrm 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Great Wyrm.mtf
+++ b/data/mekfiles/meks/3060u/Great Wyrm.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Guillotine IIC 2.mtf
+++ b/data/mekfiles/meks/3060u/Guillotine IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Guillotine IIC.mtf
+++ b/data/mekfiles/meks/3060u/Guillotine IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ha Otoko 2.mtf
+++ b/data/mekfiles/meks/3060u/Ha Otoko 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ha Otoko HKO-1C.mtf
+++ b/data/mekfiles/meks/3060u/Ha Otoko HKO-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ha Otoko.mtf
+++ b/data/mekfiles/meks/3060u/Ha Otoko.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Hauptmann HA1-O.mtf
+++ b/data/mekfiles/meks/3060u/Hauptmann HA1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Hauptmann HA1-OA.mtf
+++ b/data/mekfiles/meks/3060u/Hauptmann HA1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Hauptmann HA1-OB.mtf
+++ b/data/mekfiles/meks/3060u/Hauptmann HA1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Hauptmann HA1-OC.mtf
+++ b/data/mekfiles/meks/3060u/Hauptmann HA1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Hauptmann HA1-OD.mtf
+++ b/data/mekfiles/meks/3060u/Hauptmann HA1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Hauptmann HA1-OE.mtf
+++ b/data/mekfiles/meks/3060u/Hauptmann HA1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Helios HEL-3D.mtf
+++ b/data/mekfiles/meks/3060u/Helios HEL-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Helios HEL-4A.mtf
+++ b/data/mekfiles/meks/3060u/Helios HEL-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Helios HEL-6X.mtf
+++ b/data/mekfiles/meks/3060u/Helios HEL-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Helios HEL-C.mtf
+++ b/data/mekfiles/meks/3060u/Helios HEL-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Highlander IIC 2.mtf
+++ b/data/mekfiles/meks/3060u/Highlander IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Highlander IIC.mtf
+++ b/data/mekfiles/meks/3060u/Highlander IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Icestorm 2.mtf
+++ b/data/mekfiles/meks/3060u/Icestorm 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Icestorm.mtf
+++ b/data/mekfiles/meks/3060u/Icestorm.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Initiate INI-02.mtf
+++ b/data/mekfiles/meks/3060u/Initiate INI-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Initiate INI-04.mtf
+++ b/data/mekfiles/meks/3060u/Initiate INI-04.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/JagerMech III JM6-D3.mtf
+++ b/data/mekfiles/meks/3060u/JagerMech III JM6-D3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/JagerMech III JM6-D4.mtf
+++ b/data/mekfiles/meks/3060u/JagerMech III JM6-D4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Jinggau JN-G7L.mtf
+++ b/data/mekfiles/meks/3060u/Jinggau JN-G7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Jinggau JN-G8A.mtf
+++ b/data/mekfiles/meks/3060u/Jinggau JN-G8A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Jinggau JN-G9CC.mtf
+++ b/data/mekfiles/meks/3060u/Jinggau JN-G9CC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Kabuto KBO-7A.mtf
+++ b/data/mekfiles/meks/3060u/Kabuto KBO-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Kabuto KBO-7B.mtf
+++ b/data/mekfiles/meks/3060u/Kabuto KBO-7B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Mandrill.mtf
+++ b/data/mekfiles/meks/3060u/Mandrill.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Marshal MHL-2L.mtf
+++ b/data/mekfiles/meks/3060u/Marshal MHL-2L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Marshal MHL-6MC.mtf
+++ b/data/mekfiles/meks/3060u/Marshal MHL-6MC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Marshal MHL-X1.mtf
+++ b/data/mekfiles/meks/3060u/Marshal MHL-X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Matador 2.mtf
+++ b/data/mekfiles/meks/3060u/Matador 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Matador.mtf
+++ b/data/mekfiles/meks/3060u/Matador.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-O.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-OA.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-OB.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-OC.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-OD.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-OE.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Men Shen MS1-OF.mtf
+++ b/data/mekfiles/meks/3060u/Men Shen MS1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat A.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat B.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat C.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat D.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat E.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat F.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat G.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Nova Cat Prime.mtf
+++ b/data/mekfiles/meks/3060u/Nova Cat Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Orion IIC.mtf
+++ b/data/mekfiles/meks/3060u/Orion IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Pack Hunter 2.mtf
+++ b/data/mekfiles/meks/3060u/Pack Hunter 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Pack Hunter 3.mtf
+++ b/data/mekfiles/meks/3060u/Pack Hunter 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Pack Hunter 4.mtf
+++ b/data/mekfiles/meks/3060u/Pack Hunter 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Pack Hunter.mtf
+++ b/data/mekfiles/meks/3060u/Pack Hunter.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Predator 2.mtf
+++ b/data/mekfiles/meks/3060u/Predator 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Predator.mtf
+++ b/data/mekfiles/meks/3060u/Predator.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Sentry SNT-04.mtf
+++ b/data/mekfiles/meks/3060u/Sentry SNT-04.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Sentry SNT-W5.mtf
+++ b/data/mekfiles/meks/3060u/Sentry SNT-W5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Shugenja SJA-7D.mtf
+++ b/data/mekfiles/meks/3060u/Shugenja SJA-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Shugenja SJA-8H.mtf
+++ b/data/mekfiles/meks/3060u/Shugenja SJA-8H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Sirocco SRC-3C.mtf
+++ b/data/mekfiles/meks/3060u/Sirocco SRC-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Sirocco SRC-5C.mtf
+++ b/data/mekfiles/meks/3060u/Sirocco SRC-5C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Sirocco SRC-6C.mtf
+++ b/data/mekfiles/meks/3060u/Sirocco SRC-6C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Snow Fox 2.mtf
+++ b/data/mekfiles/meks/3060u/Snow Fox 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Snow Fox 3.mtf
+++ b/data/mekfiles/meks/3060u/Snow Fox 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Snow Fox.mtf
+++ b/data/mekfiles/meks/3060u/Snow Fox.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stalking Spider 2.mtf
+++ b/data/mekfiles/meks/3060u/Stalking Spider 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stalking Spider 3.mtf
+++ b/data/mekfiles/meks/3060u/Stalking Spider 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stalking Spider.mtf
+++ b/data/mekfiles/meks/3060u/Stalking Spider.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Star Adder (Blood Asp) A.mtf
+++ b/data/mekfiles/meks/3060u/Star Adder (Blood Asp) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Star Adder (Blood Asp) B.mtf
+++ b/data/mekfiles/meks/3060u/Star Adder (Blood Asp) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Star Adder (Blood Asp) C.mtf
+++ b/data/mekfiles/meks/3060u/Star Adder (Blood Asp) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Star Adder (Blood Asp) D.mtf
+++ b/data/mekfiles/meks/3060u/Star Adder (Blood Asp) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Star Adder (Blood Asp) Prime.mtf
+++ b/data/mekfiles/meks/3060u/Star Adder (Blood Asp) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk A.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk B.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk C.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk D.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk E.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk F.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk G.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Stooping Hawk Prime.mtf
+++ b/data/mekfiles/meks/3060u/Stooping Hawk Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Tai-sho TSH-7S.mtf
+++ b/data/mekfiles/meks/3060u/Tai-sho TSH-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Tai-sho TSH-8S.mtf
+++ b/data/mekfiles/meks/3060u/Tai-sho TSH-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Thunder Stallion 2.mtf
+++ b/data/mekfiles/meks/3060u/Thunder Stallion 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Thunder Stallion 3.mtf
+++ b/data/mekfiles/meks/3060u/Thunder Stallion 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Thunder Stallion.mtf
+++ b/data/mekfiles/meks/3060u/Thunder Stallion.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ti Ts'ang TSG-9C.mtf
+++ b/data/mekfiles/meks/3060u/Ti Ts'ang TSG-9C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ti Ts'ang TSG-9H.mtf
+++ b/data/mekfiles/meks/3060u/Ti Ts'ang TSG-9H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ti Ts'ang TSG-9J.mtf
+++ b/data/mekfiles/meks/3060u/Ti Ts'ang TSG-9J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Toyama TYM-1A.mtf
+++ b/data/mekfiles/meks/3060u/Toyama TYM-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Toyama TYM-1B.mtf
+++ b/data/mekfiles/meks/3060u/Toyama TYM-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Toyama TYM-1C.mtf
+++ b/data/mekfiles/meks/3060u/Toyama TYM-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/UrbanMech IIC 2.mtf
+++ b/data/mekfiles/meks/3060u/UrbanMech IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/UrbanMech IIC.mtf
+++ b/data/mekfiles/meks/3060u/UrbanMech IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ursus 2.mtf
+++ b/data/mekfiles/meks/3060u/Ursus 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Ursus.mtf
+++ b/data/mekfiles/meks/3060u/Ursus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Viking VKG-2F.mtf
+++ b/data/mekfiles/meks/3060u/Viking VKG-2F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Viking VKG-2G.mtf
+++ b/data/mekfiles/meks/3060u/Viking VKG-2G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Viking VKG-3A.mtf
+++ b/data/mekfiles/meks/3060u/Viking VKG-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Viking VKG-3W.mtf
+++ b/data/mekfiles/meks/3060u/Viking VKG-3W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Wyvern IIC 2.mtf
+++ b/data/mekfiles/meks/3060u/Wyvern IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Wyvern IIC.mtf
+++ b/data/mekfiles/meks/3060u/Wyvern IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yeoman YMN-10-OR.mtf
+++ b/data/mekfiles/meks/3060u/Yeoman YMN-10-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yeoman YMN-6Y.mtf
+++ b/data/mekfiles/meks/3060u/Yeoman YMN-6Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yu Huang Y-H10G.mtf
+++ b/data/mekfiles/meks/3060u/Yu Huang Y-H10G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yu Huang Y-H11G.mtf
+++ b/data/mekfiles/meks/3060u/Yu Huang Y-H11G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yu Huang Y-H9G.mtf
+++ b/data/mekfiles/meks/3060u/Yu Huang Y-H9G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yu Huang Y-H9GB.mtf
+++ b/data/mekfiles/meks/3060u/Yu Huang Y-H9GB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3060u/Yu Huang Y-H9GC.mtf
+++ b/data/mekfiles/meks/3060u/Yu Huang Y-H9GC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Arcas 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Arcas 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman 4.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Bowman.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Burrock 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Burrock 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Crimson Langur D.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Crimson Langur D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Crimson Langur E.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Crimson Langur E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Hellfire 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Hellfire 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Lobo 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Lobo 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Lobo 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Lobo 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Mad Cat Mk II 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Mad Cat Mk II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Mad Cat Mk II 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Mad Cat Mk II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Pinion 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Pinion 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Rabid Coyote 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Rabid Coyote 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Savage Coyote J.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Savage Coyote J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Savage Coyote W.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Savage Coyote W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Scylla 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Scylla 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Scylla 3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Scylla 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Solitaire 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Solitaire 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/Clan Meks/Spirit 2.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/Clan Meks/Spirit 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Akuma AKU-2X.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Akuma AKU-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Akuma AKU-2XK.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Akuma AKU-2XK.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Anubis ABS-4C.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Anubis ABS-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Argus AGS-5D.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Argus AGS-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Argus AGS-6F.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Argus AGS-6F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Bloodhound B3-HND.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Bloodhound B3-HND.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Blue Flame BLF-40.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Blue Flame BLF-40.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Brigand LDT-X3.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Brigand LDT-X3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Brigand LDT-X4.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Brigand LDT-X4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Chimera CMA-2k.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Chimera CMA-2k.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Cronus CNS-TD9.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Cronus CNS-TD9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Fafnir FNR-5WB.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Fafnir FNR-5WB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Fafnir FNR-6U.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Fafnir FNR-6U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Gurkha GUR-6G.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Gurkha GUR-6G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Gurkha GUR-8G.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Gurkha GUR-8G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Hellspawn HSN-10G.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Hellspawn HSN-10G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Hellspawn HSN-10SR.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Hellspawn HSN-10SR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Lao Hu LHU-3L.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Lao Hu LHU-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Lao Hu LHU-4E.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Lao Hu LHU-4E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Legacy LGC-03.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Legacy LGC-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Legacy LGC-04-WVR.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Legacy LGC-04-WVR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Legacy LGC-05.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Legacy LGC-05.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Lightray LGH-7W.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Lightray LGH-7W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Ninja-To NJT-4.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Ninja-To NJT-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/No-Dachi NDA-3S.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/No-Dachi NDA-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Osiris OSR-5D.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Osiris OSR-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Perseus P1P.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Perseus P1P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Perseus P1W.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Perseus P1W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Razorback RZK-10S.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Razorback RZK-10S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Razorback RZK-10T.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Razorback RZK-10T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Red Shift RDS-3A.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Red Shift RDS-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Sagittaire SGT-10X.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Sagittaire SGT-10X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Sagittaire SGT-9D.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Sagittaire SGT-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Sha Yu SYU-6B.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Sha Yu SYU-6B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Stiletto STO-4C.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Stiletto STO-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OD.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OE.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OF.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OG.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OH.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OI.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Templar TLR1-OI.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Tessen TSN-C3M.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Tessen TSN-C3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Thanatos THS-4T.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Thanatos THS-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Thanatos THS-6S.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Thanatos THS-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Uziel UZL-8S.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Uziel UZL-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Vanquisher VQR-5V.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Vanquisher VQR-5V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Vanquisher VQR-7U.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Vanquisher VQR-7U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Vanquisher VQR-7V.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Vanquisher VQR-7V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Verfolger VR6-C.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Verfolger VR6-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/Verfolger VR6-T.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/Verfolger VR6-T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/White Flame WHF-3C.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/White Flame WHF-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067 Unabridged/IS Meks/White Flame WHF-4C.mtf
+++ b/data/mekfiles/meks/3067 Unabridged/IS Meks/White Flame WHF-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Akuma AKU-1X.mtf
+++ b/data/mekfiles/meks/3067/Akuma AKU-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Akuma AKU-1XJ.mtf
+++ b/data/mekfiles/meks/3067/Akuma AKU-1XJ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Anubis ABS-3L.mtf
+++ b/data/mekfiles/meks/3067/Anubis ABS-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Anubis ABS-3R.mtf
+++ b/data/mekfiles/meks/3067/Anubis ABS-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Anubis ABS-3T.mtf
+++ b/data/mekfiles/meks/3067/Anubis ABS-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Arcas 2.mtf
+++ b/data/mekfiles/meks/3067/Arcas 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Arcas.mtf
+++ b/data/mekfiles/meks/3067/Arcas.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Argus AGS-2D.mtf
+++ b/data/mekfiles/meks/3067/Argus AGS-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Argus AGS-4D.mtf
+++ b/data/mekfiles/meks/3067/Argus AGS-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Axman AXM-3S.mtf
+++ b/data/mekfiles/meks/3067/Axman AXM-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Blood Kite 2.mtf
+++ b/data/mekfiles/meks/3067/Blood Kite 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Blood Kite.mtf
+++ b/data/mekfiles/meks/3067/Blood Kite.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Bloodhound B1-HND.mtf
+++ b/data/mekfiles/meks/3067/Bloodhound B1-HND.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Bloodhound B2-HND.mtf
+++ b/data/mekfiles/meks/3067/Bloodhound B2-HND.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Blue Flame BLF-21.mtf
+++ b/data/mekfiles/meks/3067/Blue Flame BLF-21.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Brigand LDT-1.mtf
+++ b/data/mekfiles/meks/3067/Brigand LDT-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Brigand LDT-X1.mtf
+++ b/data/mekfiles/meks/3067/Brigand LDT-X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Brigand LDT-X2.mtf
+++ b/data/mekfiles/meks/3067/Brigand LDT-X2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Burrock.mtf
+++ b/data/mekfiles/meks/3067/Burrock.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Chimera CMA-1S.mtf
+++ b/data/mekfiles/meks/3067/Chimera CMA-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Chimera CMA-C.mtf
+++ b/data/mekfiles/meks/3067/Chimera CMA-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Crimson Langur A.mtf
+++ b/data/mekfiles/meks/3067/Crimson Langur A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Crimson Langur B.mtf
+++ b/data/mekfiles/meks/3067/Crimson Langur B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Crimson Langur C.mtf
+++ b/data/mekfiles/meks/3067/Crimson Langur C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Crimson Langur Prime.mtf
+++ b/data/mekfiles/meks/3067/Crimson Langur Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Cronus CNS-3M.mtf
+++ b/data/mekfiles/meks/3067/Cronus CNS-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Cronus CNS-5M.mtf
+++ b/data/mekfiles/meks/3067/Cronus CNS-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Fafnir FNR-5.mtf
+++ b/data/mekfiles/meks/3067/Fafnir FNR-5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Fafnir FNR-5B.mtf
+++ b/data/mekfiles/meks/3067/Fafnir FNR-5B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Gurkha GUR-2G.mtf
+++ b/data/mekfiles/meks/3067/Gurkha GUR-2G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Gurkha GUR-4G.mtf
+++ b/data/mekfiles/meks/3067/Gurkha GUR-4G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellfire 2.mtf
+++ b/data/mekfiles/meks/3067/Hellfire 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellfire.mtf
+++ b/data/mekfiles/meks/3067/Hellfire.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellion A.mtf
+++ b/data/mekfiles/meks/3067/Hellion A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellion B.mtf
+++ b/data/mekfiles/meks/3067/Hellion B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellion C.mtf
+++ b/data/mekfiles/meks/3067/Hellion C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellion Prime.mtf
+++ b/data/mekfiles/meks/3067/Hellion Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellspawn HSN-7D.mtf
+++ b/data/mekfiles/meks/3067/Hellspawn HSN-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellspawn HSN-8E.mtf
+++ b/data/mekfiles/meks/3067/Hellspawn HSN-8E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Hellspawn HSN-9F.mtf
+++ b/data/mekfiles/meks/3067/Hellspawn HSN-9F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lao Hu LHU-2B.mtf
+++ b/data/mekfiles/meks/3067/Lao Hu LHU-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lao Hu LHU-3B.mtf
+++ b/data/mekfiles/meks/3067/Lao Hu LHU-3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lao Hu LHU-3C.mtf
+++ b/data/mekfiles/meks/3067/Lao Hu LHU-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Legacy LGC-01.mtf
+++ b/data/mekfiles/meks/3067/Legacy LGC-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Legacy LGC-02.mtf
+++ b/data/mekfiles/meks/3067/Legacy LGC-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lightray LGH-4W.mtf
+++ b/data/mekfiles/meks/3067/Lightray LGH-4W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lightray LGH-4Y.mtf
+++ b/data/mekfiles/meks/3067/Lightray LGH-4Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lightray LGH-5W.mtf
+++ b/data/mekfiles/meks/3067/Lightray LGH-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Lobo.mtf
+++ b/data/mekfiles/meks/3067/Lobo.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Mad Cat Mk II.mtf
+++ b/data/mekfiles/meks/3067/Mad Cat Mk II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Ninja-To NJT-2.mtf
+++ b/data/mekfiles/meks/3067/Ninja-To NJT-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Ninja-To NJT-3.mtf
+++ b/data/mekfiles/meks/3067/Ninja-To NJT-3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/No-Dachi NDA-1K.mtf
+++ b/data/mekfiles/meks/3067/No-Dachi NDA-1K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/No-Dachi NDA-2K.mtf
+++ b/data/mekfiles/meks/3067/No-Dachi NDA-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/No-Dachi NDA-2KO.mtf
+++ b/data/mekfiles/meks/3067/No-Dachi NDA-2KO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Osiris OSR-3D.mtf
+++ b/data/mekfiles/meks/3067/Osiris OSR-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Osiris OSR-4D.mtf
+++ b/data/mekfiles/meks/3067/Osiris OSR-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Perseus P1 A.mtf
+++ b/data/mekfiles/meks/3067/Perseus P1 A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Perseus P1 B.mtf
+++ b/data/mekfiles/meks/3067/Perseus P1 B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Perseus P1 C.mtf
+++ b/data/mekfiles/meks/3067/Perseus P1 C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Perseus P1 D.mtf
+++ b/data/mekfiles/meks/3067/Perseus P1 D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Perseus P1 Prime.mtf
+++ b/data/mekfiles/meks/3067/Perseus P1 Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Pinion 2.mtf
+++ b/data/mekfiles/meks/3067/Pinion 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Pinion.mtf
+++ b/data/mekfiles/meks/3067/Pinion.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Rabid Coyote.mtf
+++ b/data/mekfiles/meks/3067/Rabid Coyote.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Razorback RZK-9S.mtf
+++ b/data/mekfiles/meks/3067/Razorback RZK-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Razorback RZK-9T.mtf
+++ b/data/mekfiles/meks/3067/Razorback RZK-9T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Red Shift RDS-2A.mtf
+++ b/data/mekfiles/meks/3067/Red Shift RDS-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Red Shift RDS-2B.mtf
+++ b/data/mekfiles/meks/3067/Red Shift RDS-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Sagittaire SGT-8R.mtf
+++ b/data/mekfiles/meks/3067/Sagittaire SGT-8R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Savage Coyote A.mtf
+++ b/data/mekfiles/meks/3067/Savage Coyote A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Savage Coyote B.mtf
+++ b/data/mekfiles/meks/3067/Savage Coyote B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Savage Coyote C.mtf
+++ b/data/mekfiles/meks/3067/Savage Coyote C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Savage Coyote Prime.mtf
+++ b/data/mekfiles/meks/3067/Savage Coyote Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Scylla.mtf
+++ b/data/mekfiles/meks/3067/Scylla.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Sha Yu SYU-2B.mtf
+++ b/data/mekfiles/meks/3067/Sha Yu SYU-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Sha Yu SYU-4B.mtf
+++ b/data/mekfiles/meks/3067/Sha Yu SYU-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Solitaire.mtf
+++ b/data/mekfiles/meks/3067/Solitaire.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Spirit.mtf
+++ b/data/mekfiles/meks/3067/Spirit.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Stiletto STO-4A.mtf
+++ b/data/mekfiles/meks/3067/Stiletto STO-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Stiletto STO-4B.mtf
+++ b/data/mekfiles/meks/3067/Stiletto STO-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Templar TLR1-O (Grayson).mtf
+++ b/data/mekfiles/meks/3067/Templar TLR1-O (Grayson).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Templar TLR1-O (Tancred).mtf
+++ b/data/mekfiles/meks/3067/Templar TLR1-O (Tancred).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Templar TLR1-O.mtf
+++ b/data/mekfiles/meks/3067/Templar TLR1-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Templar TLR1-OA.mtf
+++ b/data/mekfiles/meks/3067/Templar TLR1-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Templar TLR1-OB.mtf
+++ b/data/mekfiles/meks/3067/Templar TLR1-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Templar TLR1-OC.mtf
+++ b/data/mekfiles/meks/3067/Templar TLR1-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Tessen TSN-1C.mtf
+++ b/data/mekfiles/meks/3067/Tessen TSN-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Tessen TSN-C3.mtf
+++ b/data/mekfiles/meks/3067/Tessen TSN-C3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Thanatos THS-4S.mtf
+++ b/data/mekfiles/meks/3067/Thanatos THS-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Uziel UZL-2S.mtf
+++ b/data/mekfiles/meks/3067/Uziel UZL-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Uziel UZL-3S.mtf
+++ b/data/mekfiles/meks/3067/Uziel UZL-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Vanquisher VQR-2A.mtf
+++ b/data/mekfiles/meks/3067/Vanquisher VQR-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Vanquisher VQR-2B.mtf
+++ b/data/mekfiles/meks/3067/Vanquisher VQR-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/Verfolger VR5-R.mtf
+++ b/data/mekfiles/meks/3067/Verfolger VR5-R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3067/White Flame WHF-3B.mtf
+++ b/data/mekfiles/meks/3067/White Flame WHF-3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Archangel C-ANG-O Invictus.mtf
+++ b/data/mekfiles/meks/3075/Archangel C-ANG-O Invictus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Archangel C-ANG-OA Dominus.mtf
+++ b/data/mekfiles/meks/3075/Archangel C-ANG-OA Dominus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Archangel C-ANG-OB Infernus.mtf
+++ b/data/mekfiles/meks/3075/Archangel C-ANG-OB Infernus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Archangel C-ANG-OC Comminus.mtf
+++ b/data/mekfiles/meks/3075/Archangel C-ANG-OC Comminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Archangel C-ANG-OD Luminos.mtf
+++ b/data/mekfiles/meks/3075/Archangel C-ANG-OD Luminos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Archangel C-ANG-OE Eminus.mtf
+++ b/data/mekfiles/meks/3075/Archangel C-ANG-OE Eminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Atlas II AS7-D-H.mtf
+++ b/data/mekfiles/meks/3075/Atlas II AS7-D-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Atlas II AS7-D-H2.mtf
+++ b/data/mekfiles/meks/3075/Atlas II AS7-D-H2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Balius A.mtf
+++ b/data/mekfiles/meks/3075/Balius A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Balius B.mtf
+++ b/data/mekfiles/meks/3075/Balius B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Balius C.mtf
+++ b/data/mekfiles/meks/3075/Balius C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Balius D.mtf
+++ b/data/mekfiles/meks/3075/Balius D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Balius Prime.mtf
+++ b/data/mekfiles/meks/3075/Balius Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/BattleAxe BKX-7K.mtf
+++ b/data/mekfiles/meks/3075/BattleAxe BKX-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/BattleAxe BKX-7NC.mtf
+++ b/data/mekfiles/meks/3075/BattleAxe BKX-7NC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/BattleAxe BKX-8D.mtf
+++ b/data/mekfiles/meks/3075/BattleAxe BKX-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/BattleMaster BLR-1Gb.mtf
+++ b/data/mekfiles/meks/3075/BattleMaster BLR-1Gb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/BattleMaster BLR-1Gbc.mtf
+++ b/data/mekfiles/meks/3075/BattleMaster BLR-1Gbc.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/BattleMaster BLR-1Gc.mtf
+++ b/data/mekfiles/meks/3075/BattleMaster BLR-1Gc.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Bear Cub 2.mtf
+++ b/data/mekfiles/meks/3075/Bear Cub 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Bear Cub 3.mtf
+++ b/data/mekfiles/meks/3075/Bear Cub 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Bear Cub.mtf
+++ b/data/mekfiles/meks/3075/Bear Cub.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crab CRB-27b.mtf
+++ b/data/mekfiles/meks/3075/Crab CRB-27b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crimson Hawk 2.mtf
+++ b/data/mekfiles/meks/3075/Crimson Hawk 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crimson Hawk 3.mtf
+++ b/data/mekfiles/meks/3075/Crimson Hawk 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crimson Hawk.mtf
+++ b/data/mekfiles/meks/3075/Crimson Hawk.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crossbow CRS-6B.mtf
+++ b/data/mekfiles/meks/3075/Crossbow CRS-6B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crossbow CRS-6C.mtf
+++ b/data/mekfiles/meks/3075/Crossbow CRS-6C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crossbow CRS-9A.mtf
+++ b/data/mekfiles/meks/3075/Crossbow CRS-9A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Crusader CRD-2R.mtf
+++ b/data/mekfiles/meks/3075/Crusader CRD-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Cygnus 2.mtf
+++ b/data/mekfiles/meks/3075/Cygnus 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Cygnus 3.mtf
+++ b/data/mekfiles/meks/3075/Cygnus 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Cygnus.mtf
+++ b/data/mekfiles/meks/3075/Cygnus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Defiance DFN-3C.mtf
+++ b/data/mekfiles/meks/3075/Defiance DFN-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Defiance DFN-3S.mtf
+++ b/data/mekfiles/meks/3075/Defiance DFN-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Defiance DFN-3T.mtf
+++ b/data/mekfiles/meks/3075/Defiance DFN-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/DemolitionMech WI-DM.mtf
+++ b/data/mekfiles/meks/3075/DemolitionMech WI-DM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/DemolitionMech WI-DM2.mtf
+++ b/data/mekfiles/meks/3075/DemolitionMech WI-DM2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Deva C-DVA-O Invictus.mtf
+++ b/data/mekfiles/meks/3075/Deva C-DVA-O Invictus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Deva C-DVA-OA Dominus.mtf
+++ b/data/mekfiles/meks/3075/Deva C-DVA-OA Dominus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Deva C-DVA-OB Infernus.mtf
+++ b/data/mekfiles/meks/3075/Deva C-DVA-OB Infernus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Deva C-DVA-OC Comminus.mtf
+++ b/data/mekfiles/meks/3075/Deva C-DVA-OC Comminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Deva C-DVA-OD Luminos.mtf
+++ b/data/mekfiles/meks/3075/Deva C-DVA-OD Luminos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Deva C-DVA-OE Eminus.mtf
+++ b/data/mekfiles/meks/3075/Deva C-DVA-OE Eminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Excalibur EXC-B2b.mtf
+++ b/data/mekfiles/meks/3075/Excalibur EXC-B2b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Eyleuka EYL-35A.mtf
+++ b/data/mekfiles/meks/3075/Eyleuka EYL-35A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Eyleuka EYL-45A.mtf
+++ b/data/mekfiles/meks/3075/Eyleuka EYL-45A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Eyleuka EYL-45B.mtf
+++ b/data/mekfiles/meks/3075/Eyleuka EYL-45B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Eyleuka EYL-4A.mtf
+++ b/data/mekfiles/meks/3075/Eyleuka EYL-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Firebee FRB-2E.mtf
+++ b/data/mekfiles/meks/3075/Firebee FRB-2E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Firebee FRB-3E.mtf
+++ b/data/mekfiles/meks/3075/Firebee FRB-3E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Galahad GLH-1D.mtf
+++ b/data/mekfiles/meks/3075/Galahad GLH-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Galahad GLH-2D.mtf
+++ b/data/mekfiles/meks/3075/Galahad GLH-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Galahad GLH-3D.mtf
+++ b/data/mekfiles/meks/3075/Galahad GLH-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Gladiator GLD-1R (Keller).mtf
+++ b/data/mekfiles/meks/3075/Gladiator GLD-1R (Keller).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Gladiator GLD-2R.mtf
+++ b/data/mekfiles/meks/3075/Gladiator GLD-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Gladiator GLD-3R.mtf
+++ b/data/mekfiles/meks/3075/Gladiator GLD-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Gladiator GLD-4R.mtf
+++ b/data/mekfiles/meks/3075/Gladiator GLD-4R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Gladiator GLD-5R.mtf
+++ b/data/mekfiles/meks/3075/Gladiator GLD-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-O Invictus.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-O Invictus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-O Tamiel.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-O Tamiel.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-OA Dominus.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-OA Dominus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-OB Infernus.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-OB Infernus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-OC Comminus.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-OC Comminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-OD Luminos.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-OD Luminos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Grigori C-GRG-OE Eminus.mtf
+++ b/data/mekfiles/meks/3075/Grigori C-GRG-OE Eminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hammerhands HMH-3D.mtf
+++ b/data/mekfiles/meks/3075/Hammerhands HMH-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hammerhands HMH-4D.mtf
+++ b/data/mekfiles/meks/3075/Hammerhands HMH-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hammerhands HMH-5D.mtf
+++ b/data/mekfiles/meks/3075/Hammerhands HMH-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hammerhands HMH-6D.mtf
+++ b/data/mekfiles/meks/3075/Hammerhands HMH-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Helepolis HEP-2H.mtf
+++ b/data/mekfiles/meks/3075/Helepolis HEP-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Helepolis HEP-2X.mtf
+++ b/data/mekfiles/meks/3075/Helepolis HEP-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Helepolis HEP-3H.mtf
+++ b/data/mekfiles/meks/3075/Helepolis HEP-3H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Helepolis HEP-4H.mtf
+++ b/data/mekfiles/meks/3075/Helepolis HEP-4H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Highlander HGN-732b.mtf
+++ b/data/mekfiles/meks/3075/Highlander HGN-732b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hussar HSR-200-Db.mtf
+++ b/data/mekfiles/meks/3075/Hussar HSR-200-Db.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hyena HYN-4A SalvageMech .mtf
+++ b/data/mekfiles/meks/3075/Hyena HYN-4A SalvageMech .mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hyena HYN-4B SalvageMech.mtf
+++ b/data/mekfiles/meks/3075/Hyena HYN-4B SalvageMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Hyena HYN-KTO.mtf
+++ b/data/mekfiles/meks/3075/Hyena HYN-KTO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Icarus II ICR-1S.mtf
+++ b/data/mekfiles/meks/3075/Icarus II ICR-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Icarus II ICR-2S.mtf
+++ b/data/mekfiles/meks/3075/Icarus II ICR-2S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jabberwocky ConstructionMech JAW-66D.mtf
+++ b/data/mekfiles/meks/3075/Jabberwocky ConstructionMech JAW-66D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jabberwocky DemolitionMech JAW-66C.mtf
+++ b/data/mekfiles/meks/3075/Jabberwocky DemolitionMech JAW-66C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jabberwocky EngineerMech JAW-65A.mtf
+++ b/data/mekfiles/meks/3075/Jabberwocky EngineerMech JAW-65A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jabberwocky EngineerMech JAW-66B.mtf
+++ b/data/mekfiles/meks/3075/Jabberwocky EngineerMech JAW-66B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jackrabbit JKR-8T.mtf
+++ b/data/mekfiles/meks/3075/Jackrabbit JKR-8T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jackrabbit JKR-9R.mtf
+++ b/data/mekfiles/meks/3075/Jackrabbit JKR-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jackrabbit JKR-9W.mtf
+++ b/data/mekfiles/meks/3075/Jackrabbit JKR-9W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jupiter 2.mtf
+++ b/data/mekfiles/meks/3075/Jupiter 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jupiter 3.mtf
+++ b/data/mekfiles/meks/3075/Jupiter 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Jupiter.mtf
+++ b/data/mekfiles/meks/3075/Jupiter.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/King Crab KGC-000b.mtf
+++ b/data/mekfiles/meks/3075/King Crab KGC-000b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Kintaro KTO-19b.mtf
+++ b/data/mekfiles/meks/3075/Kintaro KTO-19b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Kiso K-3N-KR4 ConstructionMech.mtf
+++ b/data/mekfiles/meks/3075/Kiso K-3N-KR4 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Kiso K-3N-KR5 ConstructionMech.mtf
+++ b/data/mekfiles/meks/3075/Kiso K-3N-KR5 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-3I.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-3I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-3L.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-4I.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-4I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-4L.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-5I.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-5I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-5MC.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-5MC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Koschei KSC-5X.mtf
+++ b/data/mekfiles/meks/3075/Koschei KSC-5X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Kyudo KY2-D-02.mtf
+++ b/data/mekfiles/meks/3075/Kyudo KY2-D-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Kyudo KY2-D-03.mtf
+++ b/data/mekfiles/meks/3075/Kyudo KY2-D-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Legionnaire LGN-1X.mtf
+++ b/data/mekfiles/meks/3075/Legionnaire LGN-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Legionnaire LGN-2D.mtf
+++ b/data/mekfiles/meks/3075/Legionnaire LGN-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Legionnaire LGN-2XA.mtf
+++ b/data/mekfiles/meks/3075/Legionnaire LGN-2XA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Legionnaire LGN-2XU.mtf
+++ b/data/mekfiles/meks/3075/Legionnaire LGN-2XU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Lumberjack LM1A.mtf
+++ b/data/mekfiles/meks/3075/Lumberjack LM1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Lumberjack LM4C.mtf
+++ b/data/mekfiles/meks/3075/Lumberjack LM4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Lumberjack LM4P.mtf
+++ b/data/mekfiles/meks/3075/Lumberjack LM4P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mackie MSK-6S.mtf
+++ b/data/mekfiles/meks/3075/Mackie MSK-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mackie MSK-7A.mtf
+++ b/data/mekfiles/meks/3075/Mackie MSK-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mackie MSK-8B.mtf
+++ b/data/mekfiles/meks/3075/Mackie MSK-8B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mackie MSK-9H.mtf
+++ b/data/mekfiles/meks/3075/Mackie MSK-9H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Malak C-MK-O Invictus.mtf
+++ b/data/mekfiles/meks/3075/Malak C-MK-O Invictus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Malak C-MK-OA Dominus.mtf
+++ b/data/mekfiles/meks/3075/Malak C-MK-OA Dominus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Malak C-MK-OB Infernus.mtf
+++ b/data/mekfiles/meks/3075/Malak C-MK-OB Infernus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Malak C-MK-OC Comminus.mtf
+++ b/data/mekfiles/meks/3075/Malak C-MK-OC Comminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Malak C-MK-OD Luminos.mtf
+++ b/data/mekfiles/meks/3075/Malak C-MK-OD Luminos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Malak C-MK-OE Eminus.mtf
+++ b/data/mekfiles/meks/3075/Malak C-MK-OE Eminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Marauder MAD-1R.mtf
+++ b/data/mekfiles/meks/3075/Marauder MAD-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Marauder MAD-2R.mtf
+++ b/data/mekfiles/meks/3075/Marauder MAD-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mongoose II MON-266.mtf
+++ b/data/mekfiles/meks/3075/Mongoose II MON-266.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mongoose II MON-267.mtf
+++ b/data/mekfiles/meks/3075/Mongoose II MON-267.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mongoose II MON-268.mtf
+++ b/data/mekfiles/meks/3075/Mongoose II MON-268.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Mongoose MON-66b.mtf
+++ b/data/mekfiles/meks/3075/Mongoose MON-66b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ocelot 2.mtf
+++ b/data/mekfiles/meks/3075/Ocelot 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ocelot 3.mtf
+++ b/data/mekfiles/meks/3075/Ocelot 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ocelot.mtf
+++ b/data/mekfiles/meks/3075/Ocelot.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ostroc OSR-2Cb.mtf
+++ b/data/mekfiles/meks/3075/Ostroc OSR-2Cb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ostscout OTT-7Jb.mtf
+++ b/data/mekfiles/meks/3075/Ostscout OTT-7Jb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Pariah A.mtf
+++ b/data/mekfiles/meks/3075/Pariah A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Pariah B.mtf
+++ b/data/mekfiles/meks/3075/Pariah B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Pariah C.mtf
+++ b/data/mekfiles/meks/3075/Pariah C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Pariah D.mtf
+++ b/data/mekfiles/meks/3075/Pariah D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Pariah Prime.mtf
+++ b/data/mekfiles/meks/3075/Pariah Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Patriot PKM-2C.mtf
+++ b/data/mekfiles/meks/3075/Patriot PKM-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Patriot PKM-2D.mtf
+++ b/data/mekfiles/meks/3075/Patriot PKM-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Patriot PKM-2E.mtf
+++ b/data/mekfiles/meks/3075/Patriot PKM-2E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Patron LoaderMech.mtf
+++ b/data/mekfiles/meks/3075/Patron LoaderMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Patron PTN-1 LoaderMech.mtf
+++ b/data/mekfiles/meks/3075/Patron PTN-1 LoaderMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Phoenix Hawk PXH-1b.mtf
+++ b/data/mekfiles/meks/3075/Phoenix Hawk PXH-1b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Phoenix Hawk PXH-1c.mtf
+++ b/data/mekfiles/meks/3075/Phoenix Hawk PXH-1c.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Phoenix PX-3R.mtf
+++ b/data/mekfiles/meks/3075/Phoenix PX-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Phoenix PX-4R.mtf
+++ b/data/mekfiles/meks/3075/Phoenix PX-4R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Preta C-PRT-O Invictus.mtf
+++ b/data/mekfiles/meks/3075/Preta C-PRT-O Invictus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Preta C-PRT-OA Dominus.mtf
+++ b/data/mekfiles/meks/3075/Preta C-PRT-OA Dominus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Preta C-PRT-OB Infernus.mtf
+++ b/data/mekfiles/meks/3075/Preta C-PRT-OB Infernus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Preta C-PRT-OC Comminus.mtf
+++ b/data/mekfiles/meks/3075/Preta C-PRT-OC Comminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Preta C-PRT-OD Luminos.mtf
+++ b/data/mekfiles/meks/3075/Preta C-PRT-OD Luminos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Preta C-PRT-OE Eminus.mtf
+++ b/data/mekfiles/meks/3075/Preta C-PRT-OE Eminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Quasit QUA-51M MilitiaMech.mtf
+++ b/data/mekfiles/meks/3075/Quasit QUA-51M MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Quasit QUA-51P MilitiaMech.mtf
+++ b/data/mekfiles/meks/3075/Quasit QUA-51P MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Quasit QUA-51T MilitiaMech.mtf
+++ b/data/mekfiles/meks/3075/Quasit QUA-51T MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Rifleman II RFL-3N-2.mtf
+++ b/data/mekfiles/meks/3075/Rifleman II RFL-3N-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ryoken II 2.mtf
+++ b/data/mekfiles/meks/3075/Ryoken II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ryoken II 3.mtf
+++ b/data/mekfiles/meks/3075/Ryoken II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ryoken II.mtf
+++ b/data/mekfiles/meks/3075/Ryoken II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Seraph C-SRP-O Invictus.mtf
+++ b/data/mekfiles/meks/3075/Seraph C-SRP-O Invictus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Seraph C-SRP-OA Dominus.mtf
+++ b/data/mekfiles/meks/3075/Seraph C-SRP-OA Dominus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Seraph C-SRP-OB Infernus.mtf
+++ b/data/mekfiles/meks/3075/Seraph C-SRP-OB Infernus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Seraph C-SRP-OC Comminus.mtf
+++ b/data/mekfiles/meks/3075/Seraph C-SRP-OC Comminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Seraph C-SRP-OD Luminos.mtf
+++ b/data/mekfiles/meks/3075/Seraph C-SRP-OD Luminos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Seraph C-SRP-OE Eminus.mtf
+++ b/data/mekfiles/meks/3075/Seraph C-SRP-OE Eminus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Sun Cobra.mtf
+++ b/data/mekfiles/meks/3075/Sun Cobra.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Thug THG-11Eb.mtf
+++ b/data/mekfiles/meks/3075/Thug THG-11Eb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Titan II TI-2P.mtf
+++ b/data/mekfiles/meks/3075/Titan II TI-2P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Titan II TI-2PA.mtf
+++ b/data/mekfiles/meks/3075/Titan II TI-2PA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Titan TI-1A.mtf
+++ b/data/mekfiles/meks/3075/Titan TI-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Toro TR-A-6.mtf
+++ b/data/mekfiles/meks/3075/Toro TR-A-6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Valiant V4-LNT-J3.mtf
+++ b/data/mekfiles/meks/3075/Valiant V4-LNT-J3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Valiant V4-LNT-K7.mtf
+++ b/data/mekfiles/meks/3075/Valiant V4-LNT-K7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Valiant VLN-3T.mtf
+++ b/data/mekfiles/meks/3075/Valiant VLN-3T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Von Rohrs (Hebi) VON 4RH-5.mtf
+++ b/data/mekfiles/meks/3075/Von Rohrs (Hebi) VON 4RH-5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Von Rohrs (Hebi) VON 4RH-6.mtf
+++ b/data/mekfiles/meks/3075/Von Rohrs (Hebi) VON 4RH-6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Warhammer WHM-6Rb.mtf
+++ b/data/mekfiles/meks/3075/Warhammer WHM-6Rb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Warlord BLR-2D.mtf
+++ b/data/mekfiles/meks/3075/Warlord BLR-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Warlord BLR-2G.mtf
+++ b/data/mekfiles/meks/3075/Warlord BLR-2G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wight WGT-1LAWSC.mtf
+++ b/data/mekfiles/meks/3075/Wight WGT-1LAWSC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wight WGT-1LAWSC3.mtf
+++ b/data/mekfiles/meks/3075/Wight WGT-1LAWSC3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wight WGT-2LAW.mtf
+++ b/data/mekfiles/meks/3075/Wight WGT-2LAW.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wight WGT-2LAWC3.mtf
+++ b/data/mekfiles/meks/3075/Wight WGT-2LAWC3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wight WGT-2SC.mtf
+++ b/data/mekfiles/meks/3075/Wight WGT-2SC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wight WGT-3SC.mtf
+++ b/data/mekfiles/meks/3075/Wight WGT-3SC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wolverine II WVR-7H.mtf
+++ b/data/mekfiles/meks/3075/Wolverine II WVR-7H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Wyvern WVE-5Nb.mtf
+++ b/data/mekfiles/meks/3075/Wyvern WVE-5Nb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Xanthos XNT-3O.mtf
+++ b/data/mekfiles/meks/3075/Xanthos XNT-3O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Xanthos XNT-4O.mtf
+++ b/data/mekfiles/meks/3075/Xanthos XNT-4O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Xanthos XNT-5O.mtf
+++ b/data/mekfiles/meks/3075/Xanthos XNT-5O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ymir BWP-2B.mtf
+++ b/data/mekfiles/meks/3075/Ymir BWP-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ymir BWP-2E.mtf
+++ b/data/mekfiles/meks/3075/Ymir BWP-2E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3075/Ymir BWP-3A.mtf
+++ b/data/mekfiles/meks/3075/Ymir BWP-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arbalest 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arbalest 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arbalest 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arbalest 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arbalest.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arbalest.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II Prime.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Arctic Wolf II Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS7-Dr.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS7-Dr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS7-K2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS7-K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS7-K3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS7-K3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS8-D.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Atlas AS8-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Blade BLD-XL.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Blade BLD-XL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Blade BLD-XS.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Blade BLD-XS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Blade BLD-XX.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Blade BLD-XX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Blood Reaper 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Blood Reaper 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Blood Reaper.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Blood Reaper.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Brahma BRM-5A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Brahma BRM-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Brahma BRM-5B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Brahma BRM-5B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Bruin 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Bruin 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Bruin.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Bruin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Cuirass CDR-1X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Cuirass CDR-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow 4.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Dark Crow.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Dasher II 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Dasher II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Dasher II.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Dasher II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Deimos 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Deimos 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Deimos A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Deimos A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Deimos B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Deimos B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Deimos C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Deimos C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Deimos Prime.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Deimos Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Deimos S.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Deimos S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Diomede D-M3D-3 ConstructionMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Diomede D-M3D-3 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Diomede D-M3D-4 DemolitionMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Diomede D-M3D-4 DemolitionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ebony MEB-10.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ebony MEB-10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ebony MEB-11.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ebony MEB-11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ebony MEB-9.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ebony MEB-9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Eidolon C-EID-001.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Eidolon C-EID-001.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Eisenfaust EFT-4J.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Eisenfaust EFT-4J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Eisenfaust EFT-7X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Eisenfaust EFT-7X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Eisenfaust EFT-8X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Eisenfaust EFT-8X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Fennec FEC-1CM.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Fennec FEC-1CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Fennec FEC-3C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Fennec FEC-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Flamberge 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Flamberge 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Flamberge 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Flamberge 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Flamberge A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Flamberge A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Flamberge B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Flamberge B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Flamberge C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Flamberge C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Flamberge Prime.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Flamberge Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Fwltur FWL-3R SalvageMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Fwltur FWL-3R SalvageMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Fwltur FWL-3V SalvageMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Fwltur FWL-3V SalvageMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Gallant GLT-7-0.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Gallant GLT-7-0.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Gallant GLT-8-0.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Gallant GLT-8-0.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ghost GST-10.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ghost GST-10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ghost GST-11.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ghost GST-11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Goshawk II 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Goshawk II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Goshawk II 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Goshawk II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Goshawk II.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Goshawk II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Hatchetman HCT-6M.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Hatchetman HCT-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Hatchetman HCT-7S.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Hatchetman HCT-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Hellstar 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Hellstar 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Hellstar 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Hellstar 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Hellstar.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Hellstar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Karhu A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Karhu A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Karhu B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Karhu B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Karhu C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Karhu C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Karhu D.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Karhu D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Karhu Prime.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Karhu Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Kuma 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Kuma 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Kuma 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Kuma 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Kuma.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Kuma.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Mangonel MNL-3L.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Mangonel MNL-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Mangonel MNL-3W.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Mangonel MNL-3W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Mjolnir MLR-B2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Mjolnir MLR-B2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Mjolnir MLR-BX.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Mjolnir MLR-BX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Morrigan 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Morrigan 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Morrigan 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Morrigan 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Morrigan.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Morrigan.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Night Wolf.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Night Wolf.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Nyx NX-80.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Nyx NX-80.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Nyx NX-80C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Nyx NX-80C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Nyx NX-90.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Nyx NX-90.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Omen.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Omen.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Onager.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Onager.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Orochi OR-2I.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Orochi OR-2I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Osprey OSP-15.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Osprey OSP-15.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Osprey OSP-25.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Osprey OSP-25.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Osprey OSP-26.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Osprey OSP-26.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ostwar OWR-2M.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ostwar OWR-2M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ostwar OWR-2Mb.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ostwar OWR-2Mb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ostwar OWR-3M.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ostwar OWR-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Pack Hunter II 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Pack Hunter II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Pack Hunter II 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Pack Hunter II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Pack Hunter II.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Pack Hunter II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-10K2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-10K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-12K.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-12K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-12K2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-12K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-13K.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Panther PNT-13K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Parash 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Parash 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Parash.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Parash.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Peacekeeper PKP-1A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Peacekeeper PKP-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Peacekeeper PKP-1B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Peacekeeper PKP-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Penthesilea PEN-2H.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Penthesilea PEN-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Penthesilea PEN-2MAF.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Penthesilea PEN-2MAF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Prefect PRF-1R.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Prefect PRF-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Prefect PRF-2R.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Prefect PRF-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-2X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-2X1.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-2X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-3X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-5X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Raptor II RPT-5X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-1A.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-1B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-3X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Rook NH-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Shadow Cat II 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Shadow Cat II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Shadow Cat II.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Shadow Cat II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Shen Yi SHY-3B.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Shen Yi SHY-3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Shockwave SKW-2F.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Shockwave SKW-2F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Shockwave SKW-4G.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Shockwave SKW-4G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Sokuryou SKU-181 SurveyMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Sokuryou SKU-181 SurveyMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Sokuryou SKU-197 SurveyMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Sokuryou SKU-197 SurveyMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Sokuryou SKU-198 SurveyMech.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Sokuryou SKU-198 SurveyMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Sphinx 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Sphinx 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Sphinx.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Sphinx.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Spider SDR-8K.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Spider SDR-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Spider SDR-8R.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Spider SDR-8R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Spider SDR-8X.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Spider SDR-8X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Targe TRG-1N.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Targe TRG-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Targe TRG-2N.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Targe TRG-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Thunder Fox TFT-A9.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Thunder Fox TFT-A9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Thunder Fox TFT-C3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Thunder Fox TFT-C3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Thunder Fox TFT-L8.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Thunder Fox TFT-L8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Trebaruna TR-XB.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Trebaruna TR-XB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Trebaruna TR-XJ.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Trebaruna TR-XJ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Trebaruna TR-XL.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Trebaruna TR-XL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf 2.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf 3.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf 4.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Tundra Wolf.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Ursus II.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Ursus II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Warhammer WHD-10CT.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Warhammer WHD-10CT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Wolfhound WLF-3M.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Wolfhound WLF-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Wolfhound WLF-5.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Wolfhound WLF-5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Cutting Edge/Yao Lien YOL-4C.mtf
+++ b/data/mekfiles/meks/3085u/Cutting Edge/Yao Lien YOL-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Akuma AKU-2XC.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Akuma AKU-2XC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Albatross ALB-3Ur.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Albatross ALB-3Ur.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Arctic Fox AF1U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Arctic Fox AF1U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Argus AGS-8DX.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Argus AGS-8DX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Avatar AV1-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Avatar AV1-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Axman AXM-3Sr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Axman AXM-3Sr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Balius U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Balius U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Bandersnatch BNDR-01Ar.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Bandersnatch BNDR-01Ar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Banshee BNC-3Mr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Banshee BNC-3Mr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Beowulf C.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Beowulf C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Black Hawk (Nova) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Black Hawk (Nova) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Black Hawk-KU BHKU-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Black Hawk-KU BHKU-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Blackjack BJ2-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Blackjack BJ2-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Bushwacker BSW-S2r.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Bushwacker BSW-S2r.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Catapult CPLT-C5A.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Catapult CPLT-C5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Cauldron-Born (Ebon Jaguar) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Cauldron-Born (Ebon Jaguar) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Centurion CN9-Ar.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Centurion CN9-Ar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Charger CGR-3Kr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Charger CGR-3Kr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Commando COM-2Dr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Commando COM-2Dr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Crossbow U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Crossbow U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Cyclops CP-11-B.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Cyclops CP-11-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Cyclops CP-11-C2.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Cyclops CP-11-C2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Cyclops CP-11-C3.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Cyclops CP-11-C3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Daikyu DAI-01r.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Daikyu DAI-01r.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Daishi (Dire Wolf) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Daishi (Dire Wolf) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Dart DRT-6T.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Dart DRT-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Dervish DV-6Mr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Dervish DV-6Mr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Deva C-DVA-OU Exanimus.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Deva C-DVA-OU Exanimus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Dragon DRG-5Nr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Dragon DRG-5Nr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Dragonfly (Viper) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Dragonfly (Viper) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Enfield END-6Sr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Enfield END-6Sr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Enforcer III ENF-6Ma.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Enforcer III ENF-6Ma.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Enforcer III ENF-7C3BS.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Enforcer III ENF-7C3BS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Fafnir FNR-5X.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Fafnir FNR-5X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Falconer FLC-9R.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Falconer FLC-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Fenris (Ice Ferret) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Fenris (Ice Ferret) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Fireball ALM-10D.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Fireball ALM-10D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Firestarter FS9-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Firestarter FS9-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Gallowglas GAL-2GLSA.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Gallowglas GAL-2GLSA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Grand Dragon DRG-7KC.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Grand Dragon DRG-7KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Grigori C-GRG-OU Exanimus.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Grigori C-GRG-OU Exanimus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Gunslinger GUN-2ERDr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Gunslinger GUN-2ERDr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Ha Otoko 3.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Ha Otoko 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Hammerhands HMH-6E.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Hammerhands HMH-6E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Hatamoto-Chi HTM-28Tr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Hatamoto-Chi HTM-28Tr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Hermes II HER-5Sr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Hermes II HER-5Sr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Highlander IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Highlander IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Hitman HM-1r.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Hitman HM-1r.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Hunchback IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Hunchback IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/JagerMech JM7-C3BS.mtf
+++ b/data/mekfiles/meks/3085u/ONN/JagerMech JM7-C3BS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Jenner JR7-C4.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Jenner JR7-C4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/King Crab KGC-005r.mtf
+++ b/data/mekfiles/meks/3085u/ONN/King Crab KGC-005r.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Longbow LGB-8V.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Longbow LGB-8V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Mad Cat (Timber Wolf) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Mad Cat (Timber Wolf) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Men Shen MS1-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Men Shen MS1-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Mongoose MON-86.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Mongoose MON-86.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Naginata NG-C3Ar.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Naginata NG-C3Ar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Nightsky NGS-6T.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Nightsky NGS-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/No-Dachi NDA-2KC.mtf
+++ b/data/mekfiles/meks/3085u/ONN/No-Dachi NDA-2KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Piranha 4.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Piranha 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Preta C-PRT-OU Exanimus.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Preta C-PRT-OU Exanimus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Quickdraw QKD-5Mr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Quickdraw QKD-5Mr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Rakshasa MDG-1Ar.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Rakshasa MDG-1Ar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Raptor RTX1-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Raptor RTX1-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Raven RVN-4Lr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Raven RVN-4Lr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Snake SNK-2Br.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Snake SNK-2Br.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Spider SDR-7Kr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Spider SDR-7Kr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Stalker STK-7C3BS.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Stalker STK-7C3BS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Starslayer STY-3Dr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Starslayer STY-3Dr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Talon TLN-6W.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Talon TLN-6W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Templar TLR1-OU.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Templar TLR1-OU.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Tessen TSN-1Cr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Tessen TSN-1Cr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Thor (Summoner) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Thor (Summoner) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Turkina U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Turkina U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Uller (Kit Fox) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Uller (Kit Fox) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/UrbanMech UM-AIV.mtf
+++ b/data/mekfiles/meks/3085u/ONN/UrbanMech UM-AIV.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/UrbanMech UM-R80.mtf
+++ b/data/mekfiles/meks/3085u/ONN/UrbanMech UM-R80.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Victor VTR-9Ka.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Victor VTR-9Ka.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Victor VTR-Cr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Victor VTR-Cr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Vindicator VND-3Lr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Vindicator VND-3Lr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Vulcan VT-5Sr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Vulcan VT-5Sr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Vulture (Mad Dog) U.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Vulture (Mad Dog) U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/ONN/Warlord BLR-2Dr.mtf
+++ b/data/mekfiles/meks/3085u/ONN/Warlord BLR-2Dr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-6S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-6W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-6W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-7L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-7S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-8M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-8M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-9K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-9M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Archer ARC-9W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Archer ARC-9W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-10S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-10S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-10S2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-10S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-2C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-3M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-3S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-4L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-4S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-5M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-6X.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-CM.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-K3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-K3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-K4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-K4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-M3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster BLR-M3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/BattleMaster C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/BattleMaster C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-4L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-5K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-6M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-7L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-7W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-7W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-8L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-8L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-8S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Crusader CRD-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-2H.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-3L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-3S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-4S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-5D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-5W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-6H.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-6H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-6M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Goliath GOL-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-1DS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-1DS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-3M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-4N.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-4N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-4R.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-4R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-5K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-5K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-5L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-5M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-6CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-6CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-6S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin GRF-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 8.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Griffin IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust IIC 8.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust IIC 9.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-1V2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-1V2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5V.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5W2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-5W2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Locust LCT-6M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Locust LCT-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-12C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-12C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-12R.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-12R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-13C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-13C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-13NAIS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-13NAIS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-14C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Longbow LGB-14C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II Bounty Hunter.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II Bounty Hunter.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-4H.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-4H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-4K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-4S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-5W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-6D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-6M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder II MAD-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5R.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-6L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-6L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-7D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9M2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9W2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Marauder MAD-9W2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-4C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-4K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-4L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-5C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-5C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-5W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostroc OSR-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-10CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-10CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-11J.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-11J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-7K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-9CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-9CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-9S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostscout OTT-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-5D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-6D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-7M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-8D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-8M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-8M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-9M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-9R.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Ostsol OTL-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 8.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-3M Masters.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-3M Masters.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-3PL.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-3PL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-4L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-4W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-4W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-5L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-6D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-7CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-7CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-7K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-7S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-8CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Phoenix Hawk PXH-8CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman C 2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 8.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-3Cr.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-3Cr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-6D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-6X.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-7M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-7X.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-7X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-8D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-8X.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-8X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-9T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Rifleman RFL-9T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-10M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-10M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-12C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-12C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-12K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-12K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-12S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Scorpion SCP-12S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 8.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-11CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-11CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-12C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-12C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-3K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-5D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-7CS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-7CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-7M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-8L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-8L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-9D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Shadow Hawk SHD-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Stinger STG-3P.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Stinger STG-3P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Stinger STG-5R.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Stinger STG-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Stinger STG-5T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Stinger STG-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Stinger STG-6L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Stinger STG-6L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Stinger STG-6S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Stinger STG-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Stinger STG-7S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Stinger STG-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-10M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-10M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-10SE.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-10SE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-11SE.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-11SE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-17S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-17S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-60-RLA.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-60-RLA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-7SE.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-7SE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9NAIS.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9NAIS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9Nr.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9Nr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Thunderbolt TDR-9T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD1.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QD4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QS5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QS5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QT2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QT2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QW5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Valkyrie VLK-QW5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 3.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 4.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 5.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 6.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 7.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 8.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 9.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-10T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-10T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-11T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-11T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-4L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-5L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-8D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-8K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-8M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-8M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-9D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-9S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Warhammer WHM-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-3A.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-3L.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-3L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-3S.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-7MAF.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-7MAF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-8T.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wasp WSP-8T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-8C.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-8C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-8D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-8K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9D.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9K.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9M.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9W.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9W2.mtf
+++ b/data/mekfiles/meks/3085u/Phoenix/Wolverine WVR-9W2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Eyrie.mtf
+++ b/data/mekfiles/meks/3145/Clans/Eyrie.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gravedigger GDR-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon 2.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon 3.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon 4.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Gyrfalcon.mtf
+++ b/data/mekfiles/meks/3145/Clans/Gyrfalcon.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Kodiak II 2.mtf
+++ b/data/mekfiles/meks/3145/Clans/Kodiak II 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Kodiak II.mtf
+++ b/data/mekfiles/meks/3145/Clans/Kodiak II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Loki Mk II (Hel) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Shrike 2.mtf
+++ b/data/mekfiles/meks/3145/Clans/Shrike 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Shrike 3.mtf
+++ b/data/mekfiles/meks/3145/Clans/Shrike 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Shrike.mtf
+++ b/data/mekfiles/meks/3145/Clans/Shrike.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Thor Mk II (Grand Summoner) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Tomahawk II C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Tomahawk II C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III Prime.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture (Mad Dog) Mk III Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Vulture Mk III (Mad Dog Mk III) A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Vulture Mk III (Mad Dog Mk III) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Warwolf (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Warwolf A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Warwolf B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Warwolf C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Warwolf H.mtf
+++ b/data/mekfiles/meks/3145/Clans/Warwolf H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen (Prime).mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen A.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen B.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen C.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen D.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen E.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Clans/Wulfen H.mtf
+++ b/data/mekfiles/meks/3145/Clans/Wulfen H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Antlion LK-3D.mtf
+++ b/data/mekfiles/meks/3145/Davion/Antlion LK-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Atlas III AS7-D2.mtf
+++ b/data/mekfiles/meks/3145/Davion/Atlas III AS7-D2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Atlas III AS7-D3.mtf
+++ b/data/mekfiles/meks/3145/Davion/Atlas III AS7-D3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-2Y.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-2Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3A.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3B.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-4D.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-5H.mtf
+++ b/data/mekfiles/meks/3145/Davion/Black Knight BLK-NT-5H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-O.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OA.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OB.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OC.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OD.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Centurion CN11-OE.mtf
+++ b/data/mekfiles/meks/3145/Davion/Centurion CN11-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Gunsmith CH11-NG.mtf
+++ b/data/mekfiles/meks/3145/Davion/Gunsmith CH11-NG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Hollander III BZK-D1.mtf
+++ b/data/mekfiles/meks/3145/Davion/Hollander III BZK-D1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Hollander III BZK-D2.mtf
+++ b/data/mekfiles/meks/3145/Davion/Hollander III BZK-D2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Hollander III BZK-D3.mtf
+++ b/data/mekfiles/meks/3145/Davion/Hollander III BZK-D3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Prey Seeker PY-SR10.mtf
+++ b/data/mekfiles/meks/3145/Davion/Prey Seeker PY-SR10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4 Hobbled Scarecrow.mtf
+++ b/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4 Hobbled Scarecrow.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4.mtf
+++ b/data/mekfiles/meks/3145/Davion/Scarecrow UCU-F4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-O.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OA.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OB.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OC.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Templar III TLR2-OD.mtf
+++ b/data/mekfiles/meks/3145/Davion/Templar III TLR2-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Davion/Vulpes VLP-1D.mtf
+++ b/data/mekfiles/meks/3145/Davion/Vulpes VLP-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1O.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OA.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OB.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OC.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1ON.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1ON.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OR.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Avalanche AVL-1OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11K.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11R.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Dragon II DRG-11R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Exhumer EXR-2X.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Exhumer EXR-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Exhumer EXR-3P.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Exhumer EXR-3P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Hatamoto-Godai HTM-30Z.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hatamoto-Godai HTM-30Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Hatamoto-Suna HTM-30S.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hatamoto-Suna HTM-30S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1F.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1P.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Hitotsume Kozo HKZ-1P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K2.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Phoenix Hawk L PXH-11K2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4K.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4T.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4X.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Rokurokubi RK-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Shiro SH-1V.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Shiro SH-1V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Shiro SH-2P.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Shiro SH-2P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-O.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OA.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OB.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OR.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Tenshi TN-10-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Wendigo (Prime).mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Wendigo A.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Wendigo B.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Wendigo C.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Wendigo-VP (Prime).mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo-VP (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Kurita/Wendigo-VP A.mtf
+++ b/data/mekfiles/meks/3145/Kurita/Wendigo-VP A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Anubis ABS-5Y.mtf
+++ b/data/mekfiles/meks/3145/Liao/Anubis ABS-5Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Anubis ABS-5Z.mtf
+++ b/data/mekfiles/meks/3145/Liao/Anubis ABS-5Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Calliope CAL-1MAF.mtf
+++ b/data/mekfiles/meks/3145/Liao/Calliope CAL-1MAF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7.mtf
+++ b/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7L.mtf
+++ b/data/mekfiles/meks/3145/Liao/Catapult II CPLT-L7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Gun GN-2O.mtf
+++ b/data/mekfiles/meks/3145/Liao/Gun GN-2O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Gun GN-2OA.mtf
+++ b/data/mekfiles/meks/3145/Liao/Gun GN-2OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Gun GN-2OC.mtf
+++ b/data/mekfiles/meks/3145/Liao/Gun GN-2OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Lu Wei Bing LN-4B.mtf
+++ b/data/mekfiles/meks/3145/Liao/Lu Wei Bing LN-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Mortis MS-1A.mtf
+++ b/data/mekfiles/meks/3145/Liao/Mortis MS-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Mortis MS-1P.mtf
+++ b/data/mekfiles/meks/3145/Liao/Mortis MS-1P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Raven II RVN-5X.mtf
+++ b/data/mekfiles/meks/3145/Liao/Raven II RVN-5X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N1.mtf
+++ b/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N2.mtf
+++ b/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N3.mtf
+++ b/data/mekfiles/meks/3145/Liao/Tian-Zong TNZ-N3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Vandal LI-O.mtf
+++ b/data/mekfiles/meks/3145/Liao/Vandal LI-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Vandal LI-OA.mtf
+++ b/data/mekfiles/meks/3145/Liao/Vandal LI-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Vandal LI-OB.mtf
+++ b/data/mekfiles/meks/3145/Liao/Vandal LI-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3E.mtf
+++ b/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3Y.mtf
+++ b/data/mekfiles/meks/3145/Liao/Yinghuochong YHC-3Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Anzu ZU-G60.mtf
+++ b/data/mekfiles/meks/3145/Marik/Anzu ZU-G60.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Anzu ZU-J70.mtf
+++ b/data/mekfiles/meks/3145/Marik/Anzu ZU-J70.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Carronade CRN-7M.mtf
+++ b/data/mekfiles/meks/3145/Marik/Carronade CRN-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Gambit GBT-1G.mtf
+++ b/data/mekfiles/meks/3145/Marik/Gambit GBT-1G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Gambit GBT-1L.mtf
+++ b/data/mekfiles/meks/3145/Marik/Gambit GBT-1L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Havoc HVC-P6.mtf
+++ b/data/mekfiles/meks/3145/Marik/Havoc HVC-P6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Juliano JLN-5A.mtf
+++ b/data/mekfiles/meks/3145/Marik/Juliano JLN-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Neanderthal NTL-AG.mtf
+++ b/data/mekfiles/meks/3145/Marik/Neanderthal NTL-AG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Neanderthal NTL-UG.mtf
+++ b/data/mekfiles/meks/3145/Marik/Neanderthal NTL-UG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Quasimodo QSM-3D.mtf
+++ b/data/mekfiles/meks/3145/Marik/Quasimodo QSM-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Sarath SRTH-1O.mtf
+++ b/data/mekfiles/meks/3145/Marik/Sarath SRTH-1O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OA.mtf
+++ b/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OB.mtf
+++ b/data/mekfiles/meks/3145/Marik/Sarath SRTH-1OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Stalker II STK-9A.mtf
+++ b/data/mekfiles/meks/3145/Marik/Stalker II STK-9A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Violator VT-U1.mtf
+++ b/data/mekfiles/meks/3145/Marik/Violator VT-U1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Marik/Violator VT-U3.mtf
+++ b/data/mekfiles/meks/3145/Marik/Violator VT-U3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 3.mtf
+++ b/data/mekfiles/meks/3145/Merc/Black Hawk (Standard) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Black Hawk (Standard).mtf
+++ b/data/mekfiles/meks/3145/Merc/Black Hawk (Standard).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Cadaver CVR-A1.mtf
+++ b/data/mekfiles/meks/3145/Merc/Cadaver CVR-A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Cadaver CVR-T1.mtf
+++ b/data/mekfiles/meks/3145/Merc/Cadaver CVR-T1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/HawkWolf HWK-4F.mtf
+++ b/data/mekfiles/meks/3145/Merc/HawkWolf HWK-4F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Hound HD-2F.mtf
+++ b/data/mekfiles/meks/3145/Merc/Hound HD-2F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk 3.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-03.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-04.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk JHK-04.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Jade Hawk.mtf
+++ b/data/mekfiles/meks/3145/Merc/Jade Hawk.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Koshi (Standard) 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Koshi (Standard) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Koshi (Standard) 3.mtf
+++ b/data/mekfiles/meks/3145/Merc/Koshi (Standard) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Koshi (Standard).mtf
+++ b/data/mekfiles/meks/3145/Merc/Koshi (Standard).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV (Prime).mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV (Prime).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV A.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV B.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV C.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR 2.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR.mtf
+++ b/data/mekfiles/meks/3145/Merc/Mad Cat Mk IV PR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Stalking Spider II.mtf
+++ b/data/mekfiles/meks/3145/Merc/Stalking Spider II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Tiburon.mtf
+++ b/data/mekfiles/meks/3145/Merc/Tiburon.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV A.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV B.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV C.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV D.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Merc/Vulture Mk IV Prime.mtf
+++ b/data/mekfiles/meks/3145/Merc/Vulture Mk IV Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Archer ARC-9KC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Archer ARC-9KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Atlas AS7-K4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Atlas AS7-K4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Avatar AV1-OJ.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Avatar AV1-OJ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Balius E.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Balius E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Banshee BNC-9S2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Banshee BNC-9S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Berserker BRZ-D4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Berserker BRZ-D4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Black Hawk (Nova) X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Black Hawk (Nova) X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Black Hawk-KU BHKU-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Black Hawk-KU BHKU-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ-2r.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ-2r.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ2-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Blackjack BJ2-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Blade BLD-7R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Blade BLD-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Commando COM-8S.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Commando COM-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Cougar X 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cougar X 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Cougar X 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cougar X 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Cougar X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cougar X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Crimson Hawk 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Crimson Hawk 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2BC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2BC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cuirass CDR-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Cygnus 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Cygnus 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Dasher II 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Dasher II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Dasher II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Dasher II 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Deimos D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Deimos D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Deimos E.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Deimos E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Diomede D-M3D-M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Diomede D-M3D-M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-12.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-12.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-13.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ebony MEB-13.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Emperor EMP-8L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Emperor EMP-8L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Fennec FEC-5CM.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Fennec FEC-5CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Flamberge D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Flamberge D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Gallant GLT-10-0.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Gallant GLT-10-0.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Ghost GST-50.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ghost GST-50.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Ghost GST-90.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ghost GST-90.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Grand Dragon DRG-10K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Grand Dragon DRG-10K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Grand Titan T-IT-N13M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Grand Titan T-IT-N13M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Griffin GRF-6S2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Griffin GRF-6S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OF.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OM.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OT.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hauptmann HA1-OT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Hellion G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Hellion G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Javelin JVN-11P.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Javelin JVN-11P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Jupiter 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Jupiter 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Karhu G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Karhu G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Koschei KSC-6L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Koschei KSC-6L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Kuma 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Kuma 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Legionnaire LGN-2K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Legionnaire LGN-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Locust LCT-5M3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Loki (Hellbringer) G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Loki (Hellbringer) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Longbow LGB-14C2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Longbow LGB-14C2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat III 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 6.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mad Cat Mk II 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Maelstrom MTR-7K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Maelstrom MTR-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Man O' War (Gargoyle) X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Man O' War (Gargoyle) X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Mangonel MNL-4S.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Mangonel MNL-4S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Marauder II MAD-4L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Marauder II MAD-4L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Marauder MAD-9D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Marauder MAD-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Marshal MHL-3MC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Marshal MHL-3MC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Men Shen MS1-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Men Shen MS1-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Morrigan 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Morrigan 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Morrigan 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Morrigan 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Awesome AWS-11V.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Awesome AWS-11V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/BattleMaster BLR-6M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/BattleMaster BLR-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/BattleMaster C 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/BattleMaster C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Bombard BMB-016.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Bombard BMB-016.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Brahma BRM-6T.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Brahma BRM-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Caesar CES-5D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Caesar CES-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Cerberus MR-7K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Cerberus MR-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Devastator DVS-10.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Devastator DVS-10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Enforcer III ENF-6R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Enforcer III ENF-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Goshawk II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Goshawk II 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Hatamoto-Kaze HTM-27V2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Hatamoto-Kaze HTM-27V2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Hatchetman HCT-7D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Hatchetman HCT-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Helios HEL-7L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Helios HEL-7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Hercules HRC-LS-9003.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Hercules HRC-LS-9003.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Hercules HRC-LS-9004.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Hercules HRC-LS-9004.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Hollander BZK-G2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Hollander BZK-G2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Hunchback HBK-6P.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Hunchback HBK-6P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Huron Warrior HUR-WO-R5L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Huron Warrior HUR-WO-R5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Icarus II ICR-2R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Icarus II ICR-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Lineholder KW2-LH10.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Lineholder KW2-LH10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Omega SHP-5R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Omega SHP-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Orion C.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Orion C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Orochi OR-3K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Orochi OR-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Pendragon PDG-3R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Pendragon PDG-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Penetrator PTR-7D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Penetrator PTR-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Shogun C 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Shogun C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Shogun SHG-3E.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Shogun SHG-3E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Striker STC-2L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Striker STC-2L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Tempest C.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Tempest C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Tempest TMP-4M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Tempest TMP-4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Venom SDR-9KE.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Venom SDR-9KE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Vixen (Incubus) 6.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Vixen (Incubus) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Watchman WTC-4DM2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Watchman WTC-4DM2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/NTNU/Yu Huang Y-H12GC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/NTNU/Yu Huang Y-H12GC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Nobori-nin (Huntsman) F.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nobori-nin (Huntsman) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Nova Cat H.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nova Cat H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Nova Cat I.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nova Cat I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Nyx NX-100.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nyx NX-100.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Nyx NX-110.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Nyx NX-110.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Ocelot 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ocelot 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Omen 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Omen 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Onager 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Onager 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Owens OW-1G.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Owens OW-1G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Pack Hunter II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Pack Hunter II 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Panther PNT-12KC.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Panther PNT-12KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Peacekeeper PKP-2K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Peacekeeper PKP-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Prefect PRF-3R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Prefect PRF-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Quickdraw QKD-9M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Quickdraw QKD-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Raptor II RPT-2X2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Raptor II RPT-2X2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Sagittaire SGT-14D.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sagittaire SGT-14D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Salamander PPR-7T.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Salamander PPR-7T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Cat F.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Cat F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Cat II 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shadow Hawk IIC 9.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shadow Hawk IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shen Yi SHY-5B.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shen Yi SHY-5B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-6H.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-6H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-8X.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Shockwave SKW-8X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Sphinx 3.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sphinx 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Sphinx 4.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sphinx 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Spider SDR-10K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Spider SDR-10K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Spider SDR-8Xr.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Spider SDR-8Xr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OH.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OM.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Strider SR1-OM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Sun Cobra 2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sun Cobra 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OF.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OG.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Sunder SD1-OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Tarantula ZPH-5A.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Tarantula ZPH-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Targe TRG-3M.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Targe TRG-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Templar TLR1-OR.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Templar TLR1-OR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Thunder Fox TFT-F11.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Thunder Fox TFT-F11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Thunderbolt TDR-10S.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Thunderbolt TDR-10S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Ti Ts'ang TSG-10L.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Ti Ts'ang TSG-10L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Aj.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Aj.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Ar.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Titan TI-1Ar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Trebaruna TR-XH.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Trebaruna TR-XH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Trebuchet TBT-9R.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Trebuchet TBT-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Tundra Wolf 5.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Tundra Wolf 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Uller (Kit Fox) I.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Uller (Kit Fox) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Valkyrie VLK-QD8.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Valkyrie VLK-QD8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 10.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 11.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 12.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer IIC 12.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Warhammer WHM-8D2.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Warhammer WHM-8D2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3K.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3P.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Wasp WSP-3P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-6O.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-6O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-7O.mtf
+++ b/data/mekfiles/meks/3145/NTNU RS/Xanthos XNT-7O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Aphrodite.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Aphrodite.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hades.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hades.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hephaestus.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hephaestus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hera.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Hera.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Zeus.mtf
+++ b/data/mekfiles/meks/3145/Republic/Ares ARS-V1 Zeus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-O.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OA.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OB.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OD.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OE.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-03-OE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-04-R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-04-R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Celerity CLR-05-X.mtf
+++ b/data/mekfiles/meks/3145/Republic/Celerity CLR-05-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-O.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OA.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OB.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Doloire DLR-OD.mtf
+++ b/data/mekfiles/meks/3145/Republic/Doloire DLR-OD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-BD.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-BD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-C.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA Wolpertinger.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA Wolpertinger.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA.mtf
+++ b/data/mekfiles/meks/3145/Republic/Jackalope JLP-KA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Kheper KHP-7R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Kheper KHP-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-2R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-3C.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-3R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Lament LMT-4RC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Lament LMT-4RC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XP.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XP.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XT.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-XV.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-XV.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Malice MAL-YZ.mtf
+++ b/data/mekfiles/meks/3145/Republic/Malice MAL-YZ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K1.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K3.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K4.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K7.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-K7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Night Stalker NSR-KC.mtf
+++ b/data/mekfiles/meks/3145/Republic/Night Stalker NSR-KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Poseidon PSD-V2.mtf
+++ b/data/mekfiles/meks/3145/Republic/Poseidon PSD-V2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R2.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R3.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R4.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Revenant UBM-2R7.mtf
+++ b/data/mekfiles/meks/3145/Republic/Revenant UBM-2R7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Republic/Uraeus UAE-7R.mtf
+++ b/data/mekfiles/meks/3145/Republic/Uraeus UAE-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M3.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M4.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Firestarter FS9-M4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1O.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OA.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OB.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OC.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gauntlet GTL-1OC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Gotterdammerung GTD-20S.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Gotterdammerung GTD-20S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Jaguar 2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Jaguar 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Jaguar.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Jaguar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/King Crab KGC-009.mtf
+++ b/data/mekfiles/meks/3145/Steiner/King Crab KGC-009.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Mongrel MGL-T2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Scourge SCG-WD1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Scourge SCG-WD1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Scourge SCG-WF1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Scourge SCG-WF1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R1.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R3.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R4.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Storm Raider STM-R4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Ursa URA-2A.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Ursa URA-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Ursa URA-2C.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Ursa URA-2C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Viking IIC.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Viking IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X2.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X3.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X4.mtf
+++ b/data/mekfiles/meks/3145/Steiner/Zeus X ZEU-X4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Gotterdammerung GTD-20C.mtf
+++ b/data/mekfiles/meks/3150/Gotterdammerung GTD-20C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Gotterdammerung GTD-30S.mtf
+++ b/data/mekfiles/meks/3150/Gotterdammerung GTD-30S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Juliano JLN-5B.mtf
+++ b/data/mekfiles/meks/3150/Juliano JLN-5B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Juliano JLN-5C.mtf
+++ b/data/mekfiles/meks/3150/Juliano JLN-5C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/King Crab KGC-009C.mtf
+++ b/data/mekfiles/meks/3150/King Crab KGC-009C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Kodiak II 3.mtf
+++ b/data/mekfiles/meks/3150/Kodiak II 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Prey Seeker PY-SR20.mtf
+++ b/data/mekfiles/meks/3150/Prey Seeker PY-SR20.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Prey Seeker PY-SR30.mtf
+++ b/data/mekfiles/meks/3150/Prey Seeker PY-SR30.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Raider JL-3A.mtf
+++ b/data/mekfiles/meks/3150/Raider JL-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Raider JL-3B.mtf
+++ b/data/mekfiles/meks/3150/Raider JL-3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Raider Mk II JL-3C.mtf
+++ b/data/mekfiles/meks/3150/Raider Mk II JL-3C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/3150/Shrike Black Rose.mtf
+++ b/data/mekfiles/meks/3150/Shrike Black Rose.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Arano Restoration/Atlas II AS7-D-HT.mtf
+++ b/data/mekfiles/meks/Arano Restoration/Atlas II AS7-D-HT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Battlecorps/Banshee BNC-9S.mtf
+++ b/data/mekfiles/meks/Battlecorps/Banshee BNC-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Battlecorps/Orion ON1-K (Kerensky).mtf
+++ b/data/mekfiles/meks/Battlecorps/Orion ON1-K (Kerensky).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Battlecorps/Ti Tsang TSG-9 China Doll.mtf
+++ b/data/mekfiles/meks/Battlecorps/Ti Tsang TSG-9 China Doll.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Agrotera AGT-1A.mtf
+++ b/data/mekfiles/meks/Dark Age/Agrotera AGT-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Atlas AS7-K2 (Jedra).mtf
+++ b/data/mekfiles/meks/Dark Age/Atlas AS7-K2 (Jedra).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Inquisitor II ITW-205.mtf
+++ b/data/mekfiles/meks/Dark Age/Inquisitor II ITW-205.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Legionnaire LGN-2D Raul.mtf
+++ b/data/mekfiles/meks/Dark Age/Legionnaire LGN-2D Raul.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Mad Cat III (Eve).mtf
+++ b/data/mekfiles/meks/Dark Age/Mad Cat III (Eve).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Mad Cat III 2 (MWDA).mtf
+++ b/data/mekfiles/meks/Dark Age/Mad Cat III 2 (MWDA).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Mad Cat III Dark Age RS.mtf
+++ b/data/mekfiles/meks/Dark Age/Mad Cat III Dark Age RS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Pack Hunter II (Isis).mtf
+++ b/data/mekfiles/meks/Dark Age/Pack Hunter II (Isis).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Ryoken II Tassa.mtf
+++ b/data/mekfiles/meks/Dark Age/Ryoken II Tassa.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dark Age/Yu Huang Carson.mtf
+++ b/data/mekfiles/meks/Dark Age/Yu Huang Carson.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dominions Divided (April)/Ares ARS-V1E Apollo.mtf
+++ b/data/mekfiles/meks/Dominions Divided (April)/Ares ARS-V1E Apollo.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Bounty Hunter/Javelin JVN-11D Farrell.mtf
+++ b/data/mekfiles/meks/Dossiers/Bounty Hunter/Javelin JVN-11D Farrell.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Bounty Hunter/Mad Cat (Timber Wolf) (Bounty Hunter 2).mtf
+++ b/data/mekfiles/meks/Dossiers/Bounty Hunter/Mad Cat (Timber Wolf) (Bounty Hunter 2).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Bounty Hunter/Phoenix Hawk PXH-4L Sante.mtf
+++ b/data/mekfiles/meks/Dossiers/Bounty Hunter/Phoenix Hawk PXH-4L Sante.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Bounty Hunter/Shadow Hawk SHD-5D (Sandy).mtf
+++ b/data/mekfiles/meks/Dossiers/Bounty Hunter/Shadow Hawk SHD-5D (Sandy).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Jason Zaklan/Ti Ts'ang  Jason.mtf
+++ b/data/mekfiles/meks/Dossiers/Jason Zaklan/Ti Ts'ang  Jason.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Karhu Syngman.mtf
+++ b/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Karhu Syngman.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Osprey OSP-26 Lawrence.mtf
+++ b/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Osprey OSP-26 Lawrence.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Prefect PRF-1R Veronica.mtf
+++ b/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Prefect PRF-1R Veronica.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Thunderbolt TDR-10M Ilyena.mtf
+++ b/data/mekfiles/meks/Dossiers/Lamenkov's Liability/Thunderbolt TDR-10M Ilyena.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Salazar Tsakalotos/Thunderbolt TDR-10M Salazar.mtf
+++ b/data/mekfiles/meks/Dossiers/Salazar Tsakalotos/Thunderbolt TDR-10M Salazar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Youling Zhanshi/Duan Gung (Vaughn).mtf
+++ b/data/mekfiles/meks/Dossiers/Youling Zhanshi/Duan Gung (Vaughn).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Youling Zhanshi/Men Shen (Li).mtf
+++ b/data/mekfiles/meks/Dossiers/Youling Zhanshi/Men Shen (Li).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Youling Zhanshi/Sha Yu (Bulldog).mtf
+++ b/data/mekfiles/meks/Dossiers/Youling Zhanshi/Sha Yu (Bulldog).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Dossiers/Youling Zhanshi/Snake (Arthur).mtf
+++ b/data/mekfiles/meks/Dossiers/Youling Zhanshi/Snake (Arthur).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/BattleMaster BLR-1GHE HellSlinger.mtf
+++ b/data/mekfiles/meks/ER 2750/BattleMaster BLR-1GHE HellSlinger.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/BattleMaster BLR-1Gd.mtf
+++ b/data/mekfiles/meks/ER 2750/BattleMaster BLR-1Gd.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Crab CRB-27sl.mtf
+++ b/data/mekfiles/meks/ER 2750/Crab CRB-27sl.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Dervish DV-6Md.mtf
+++ b/data/mekfiles/meks/ER 2750/Dervish DV-6Md.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Hammerhands HMH-3D Kessem.mtf
+++ b/data/mekfiles/meks/ER 2750/Hammerhands HMH-3D Kessem.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Lancelot LNC25-01sl.mtf
+++ b/data/mekfiles/meks/ER 2750/Lancelot LNC25-01sl.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Mackie MSK-9HKR Kill Roys Little Buddy.mtf
+++ b/data/mekfiles/meks/ER 2750/Mackie MSK-9HKR Kill Roys Little Buddy.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Phoenix Hawk PXH-1Kk.mtf
+++ b/data/mekfiles/meks/ER 2750/Phoenix Hawk PXH-1Kk.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Stalker STK-3Fk.mtf
+++ b/data/mekfiles/meks/ER 2750/Stalker STK-3Fk.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Thunderbolt TDR-5Sd.mtf
+++ b/data/mekfiles/meks/ER 2750/Thunderbolt TDR-5Sd.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Victor VTR-9B (Shoji).mtf
+++ b/data/mekfiles/meks/ER 2750/Victor VTR-9B (Shoji).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Warhammer WHM-6Rk.mtf
+++ b/data/mekfiles/meks/ER 2750/Warhammer WHM-6Rk.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ER 2750/Wyvern WVE-5Nsl.mtf
+++ b/data/mekfiles/meks/ER 2750/Wyvern WVE-5Nsl.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Era Digests/Age of War/Hector HOR-1B.mtf
+++ b/data/mekfiles/meks/Era Digests/Age of War/Hector HOR-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Era Digests/Age of War/Hector HOR-1C.mtf
+++ b/data/mekfiles/meks/Era Digests/Age of War/Hector HOR-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Era Digests/Dark Age/Cave Lion.mtf
+++ b/data/mekfiles/meks/Era Digests/Dark Age/Cave Lion.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Era Digests/Dark Age/Raider JL-1.mtf
+++ b/data/mekfiles/meks/Era Digests/Dark Age/Raider JL-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Era Digests/Dark Age/Raider Mk II JL-2.mtf
+++ b/data/mekfiles/meks/Era Digests/Dark Age/Raider Mk II JL-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Atlas AS7-D (Ian).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Atlas AS7-D (Ian).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Awesome AWS-8V _Pretty Baby_.mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Awesome AWS-8V _Pretty Baby_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Blackjack BJ-1 _Arrow_.mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Blackjack BJ-1 _Arrow_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Javelin JVN-10F (Shinto).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Javelin JVN-10F (Shinto).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Longbow LGB-0W (Vijay).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Longbow LGB-0W (Vijay).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Marauder MAD-3D (Sanchez).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Marauder MAD-3D (Sanchez).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Rifleman RFL-4D (Cyrus).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Rifleman RFL-4D (Cyrus).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Shadow Hawk SHD-2H (Berkowitz).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Shadow Hawk SHD-2H (Berkowitz).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Thug THG-11E (Flanagan).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Thug THG-11E (Flanagan).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Davion/Valkyrie VLK-QD (Karano).mtf
+++ b/data/mekfiles/meks/Force Manuals/Davion/Valkyrie VLK-QD (Karano).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Atlas AS7-S (Hanssen).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Atlas AS7-S (Hanssen).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Catapult CPLT-K2 (Kasigi).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Catapult CPLT-K2 (Kasigi).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Griffin GRF-1DS (Almstedt).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Griffin GRF-1DS (Almstedt).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Guillotine GLT-3N (Estridsen).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Guillotine GLT-3N (Estridsen).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Hatamoto-Chi HTM-27T (Lowenbrau).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Hatamoto-Chi HTM-27T (Lowenbrau).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Jenner JR7-D (Webster).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Jenner JR7-D (Webster).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Ostsol OTL-4D (Ragnar).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Ostsol OTL-4D (Ragnar).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Ostsol OTL-5M (Maki).mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Ostsol OTL-5M (Maki).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Panther PNT-10ALAG.mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Panther PNT-10ALAG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Panther PNT-9ALAG.mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Panther PNT-9ALAG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Kurita/Panther PNT-CM.mtf
+++ b/data/mekfiles/meks/Force Manuals/Kurita/Panther PNT-CM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Archer ARC-4M (Ismail).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Archer ARC-4M (Ismail).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Banshee BNC-3E (El Gaupo).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Banshee BNC-3E (El Gaupo).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Crockett CRK-5003-0 (Saddleford).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Crockett CRK-5003-0 (Saddleford).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Crusader CRD-3R (Bear).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Crusader CRD-3R (Bear).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Dervish DV-6M (Turner).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Dervish DV-6M (Turner).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Orion ON1-K (Muller).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Orion ON1-K (Muller).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Manuals/Mercs/Scorpion SCP-1N (Wendall 2).mtf
+++ b/data/mekfiles/meks/Force Manuals/Mercs/Scorpion SCP-1N (Wendall 2).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/Davion/Gunsmith CH11-NG-A.mtf
+++ b/data/mekfiles/meks/Force Packs/Davion/Gunsmith CH11-NG-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/Third Star League/Havoc HVC-P7.mtf
+++ b/data/mekfiles/meks/Force Packs/Third Star League/Havoc HVC-P7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/Third Star League/Kintaro KTO-22.mtf
+++ b/data/mekfiles/meks/Force Packs/Third Star League/Kintaro KTO-22.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/UrbanLAM/UrbanMech LAM S-UM-1XLA.mtf
+++ b/data/mekfiles/meks/Force Packs/UrbanLAM/UrbanMech LAM S-UM-1XLA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/UrbanLAM/UrbanMech LAM UM-A07.mtf
+++ b/data/mekfiles/meks/Force Packs/UrbanLAM/UrbanMech LAM UM-A07.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/UrbanMech/UrbanMech UM-R27.mtf
+++ b/data/mekfiles/meks/Force Packs/UrbanMech/UrbanMech UM-R27.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Force Packs/Wolfs Dragoons/Archer C 2.mtf
+++ b/data/mekfiles/meks/Force Packs/Wolfs Dragoons/Archer C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Cestus CTS-6Y-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Cestus CTS-6Y-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Coyotl A.mtf
+++ b/data/mekfiles/meks/Golden Century/Coyotl A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Coyotl B.mtf
+++ b/data/mekfiles/meks/Golden Century/Coyotl B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Coyotl C.mtf
+++ b/data/mekfiles/meks/Golden Century/Coyotl C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Coyotl D.mtf
+++ b/data/mekfiles/meks/Golden Century/Coyotl D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Coyotl Prime.mtf
+++ b/data/mekfiles/meks/Golden Century/Coyotl Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Devastator DVS-2-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Devastator DVS-2-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Drift Shag.mtf
+++ b/data/mekfiles/meks/Golden Century/Drift Shag.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Emperor EMP-6A-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Emperor EMP-6A-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Enfield END-6J-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Enfield END-6J-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Excalibur EXC-B2b-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Excalibur EXC-B2b-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Exterminator EC EXT-4Db.mtf
+++ b/data/mekfiles/meks/Golden Century/Exterminator EC EXT-4Db.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Fox CS-1.mtf
+++ b/data/mekfiles/meks/Golden Century/Fox CS-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Fox.mtf
+++ b/data/mekfiles/meks/Golden Century/Fox.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lancelot C 2.mtf
+++ b/data/mekfiles/meks/Golden Century/Lancelot C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lancelot C.mtf
+++ b/data/mekfiles/meks/Golden Century/Lancelot C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lupus A.mtf
+++ b/data/mekfiles/meks/Golden Century/Lupus A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lupus B.mtf
+++ b/data/mekfiles/meks/Golden Century/Lupus B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lupus C.mtf
+++ b/data/mekfiles/meks/Golden Century/Lupus C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lupus D.mtf
+++ b/data/mekfiles/meks/Golden Century/Lupus D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lupus Prime.mtf
+++ b/data/mekfiles/meks/Golden Century/Lupus Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Lynx C.mtf
+++ b/data/mekfiles/meks/Golden Century/Lynx C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Masauwu.mtf
+++ b/data/mekfiles/meks/Golden Century/Masauwu.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Minsk 2.mtf
+++ b/data/mekfiles/meks/Golden Century/Minsk 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Minsk MNK-101.mtf
+++ b/data/mekfiles/meks/Golden Century/Minsk MNK-101.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Minsk.mtf
+++ b/data/mekfiles/meks/Golden Century/Minsk.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Mongoose C 2.mtf
+++ b/data/mekfiles/meks/Golden Century/Mongoose C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Mongoose C.mtf
+++ b/data/mekfiles/meks/Golden Century/Mongoose C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Naja KTO-19b-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Naja KTO-19b-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Naja.mtf
+++ b/data/mekfiles/meks/Golden Century/Naja.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Night Hawk NTK-2Q-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Night Hawk NTK-2Q-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Omni-Corvis A.mtf
+++ b/data/mekfiles/meks/Golden Century/Omni-Corvis A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Omni-Corvis B.mtf
+++ b/data/mekfiles/meks/Golden Century/Omni-Corvis B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Omni-Corvis Prime.mtf
+++ b/data/mekfiles/meks/Golden Century/Omni-Corvis Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Phoenix Hawk PXH-1-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Phoenix Hawk PXH-1-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Pulverizer PUL-3R.mtf
+++ b/data/mekfiles/meks/Golden Century/Pulverizer PUL-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Pulverizer.mtf
+++ b/data/mekfiles/meks/Golden Century/Pulverizer.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Redback.mtf
+++ b/data/mekfiles/meks/Golden Century/Redback.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Spartan C.mtf
+++ b/data/mekfiles/meks/Golden Century/Spartan C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Starslayer STY-2C-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Starslayer STY-2C-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Storm Giant 2.mtf
+++ b/data/mekfiles/meks/Golden Century/Storm Giant 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Storm Giant.mtf
+++ b/data/mekfiles/meks/Golden Century/Storm Giant.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Sun Bear A.mtf
+++ b/data/mekfiles/meks/Golden Century/Sun Bear A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Sun Bear B.mtf
+++ b/data/mekfiles/meks/Golden Century/Sun Bear B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Sun Bear Prime.mtf
+++ b/data/mekfiles/meks/Golden Century/Sun Bear Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Talon TLN-5W-EC.mtf
+++ b/data/mekfiles/meks/Golden Century/Talon TLN-5W-EC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Vision Quest 2.mtf
+++ b/data/mekfiles/meks/Golden Century/Vision Quest 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Vision Quest VQ-1NC.mtf
+++ b/data/mekfiles/meks/Golden Century/Vision Quest VQ-1NC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Vision Quest.mtf
+++ b/data/mekfiles/meks/Golden Century/Vision Quest.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Wakazashi.mtf
+++ b/data/mekfiles/meks/Golden Century/Wakazashi.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Woodsman A.mtf
+++ b/data/mekfiles/meks/Golden Century/Woodsman A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Woodsman B.mtf
+++ b/data/mekfiles/meks/Golden Century/Woodsman B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Woodsman C.mtf
+++ b/data/mekfiles/meks/Golden Century/Woodsman C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Woodsman D.mtf
+++ b/data/mekfiles/meks/Golden Century/Woodsman D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Golden Century/Woodsman Prime.mtf
+++ b/data/mekfiles/meks/Golden Century/Woodsman Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/Atlas AS7-H.mtf
+++ b/data/mekfiles/meks/Gothic/Atlas AS7-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/Firestarter FS9-HB.mtf
+++ b/data/mekfiles/meks/Gothic/Firestarter FS9-HB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/King Crab KGC-0KP.mtf
+++ b/data/mekfiles/meks/Gothic/King Crab KGC-0KP.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/Marauder MAD-3H.mtf
+++ b/data/mekfiles/meks/Gothic/Marauder MAD-3H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/Phoenix Hawk PXH-1T.mtf
+++ b/data/mekfiles/meks/Gothic/Phoenix Hawk PXH-1T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/Rifleman RFL-3B.mtf
+++ b/data/mekfiles/meks/Gothic/Rifleman RFL-3B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/Scorpion SCP-1B.mtf
+++ b/data/mekfiles/meks/Gothic/Scorpion SCP-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Gothic/UrbanMech UM-R60B.mtf
+++ b/data/mekfiles/meks/Gothic/UrbanMech UM-R60B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/HBMPS/Rock Hound AM-PRM-RH7 'Rock Possum' ProspectorMech.mtf
+++ b/data/mekfiles/meks/HBMPS/Rock Hound AM-PRM-RH7 'Rock Possum' ProspectorMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/HBMPS/Rock Hound AM-PRM-RH7 ProspectorMech.mtf
+++ b/data/mekfiles/meks/HBMPS/Rock Hound AM-PRM-RH7 ProspectorMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/HBMPS/Rock Hound AM-PRM-RH7A 'Rock Otter' ProspectorMech.mtf
+++ b/data/mekfiles/meks/HBMPS/Rock Hound AM-PRM-RH7A 'Rock Otter' ProspectorMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/HBMPS/Space Hound AM-PRM-SH1 ProspectorMech.mtf
+++ b/data/mekfiles/meks/HBMPS/Space Hound AM-PRM-SH1 ProspectorMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-01.mtf
+++ b/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-02.mtf
+++ b/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-03.mtf
+++ b/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-03.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-04.mtf
+++ b/data/mekfiles/meks/Historicals/Hist LOT II/Dragoon AEM-04.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist Reunification War/Alfar AL-A1.mtf
+++ b/data/mekfiles/meks/Historicals/Hist Reunification War/Alfar AL-A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist Reunification War/Alfar AL-D1 Dokkalfar.mtf
+++ b/data/mekfiles/meks/Historicals/Hist Reunification War/Alfar AL-D1 Dokkalfar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist Reunification War/Talos TLS-1B.mtf
+++ b/data/mekfiles/meks/Historicals/Hist Reunification War/Talos TLS-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist Second SW/Thunderbolt TDR-5L.mtf
+++ b/data/mekfiles/meks/Historicals/Hist Second SW/Thunderbolt TDR-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist Second SW/Thunderbolt TDR-5LS.mtf
+++ b/data/mekfiles/meks/Historicals/Hist Second SW/Thunderbolt TDR-5LS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Historicals/Hist WOTRA/Bakeneko BKN-1K.mtf
+++ b/data/mekfiles/meks/Historicals/Hist WOTRA/Bakeneko BKN-1K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ISP/Mad Cat (Timber Wolf) (Bounty Hunter).mtf
+++ b/data/mekfiles/meks/ISP/Mad Cat (Timber Wolf) (Bounty Hunter).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ISP2/Rampage RMP-2G.mtf
+++ b/data/mekfiles/meks/ISP2/Rampage RMP-2G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ISP2/Rampage RMP-4G.mtf
+++ b/data/mekfiles/meks/ISP2/Rampage RMP-4G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ISP2/Rampage RMP-5G.mtf
+++ b/data/mekfiles/meks/ISP2/Rampage RMP-5G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ISP3/Arana MilitiaMech ARA-S-1.mtf
+++ b/data/mekfiles/meks/ISP3/Arana MilitiaMech ARA-S-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ISP3/Reptar EPT-C-1 MilitiaMech.mtf
+++ b/data/mekfiles/meks/ISP3/Reptar EPT-C-1 MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Iron Wind Metals/Thor II (Grand Summoner) E.mtf
+++ b/data/mekfiles/meks/Iron Wind Metals/Thor II (Grand Summoner) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Iron Wind Metals/Thunderbolt IIC 2.mtf
+++ b/data/mekfiles/meks/Iron Wind Metals/Thunderbolt IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Final Reckoning/'Gestalt' D2X-G.mtf
+++ b/data/mekfiles/meks/Jihad Final Reckoning/'Gestalt' D2X-G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Final Reckoning/OMEGA SHP-4X.mtf
+++ b/data/mekfiles/meks/Jihad Final Reckoning/OMEGA SHP-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Final Reckoning/Revenant UBM-1A.mtf
+++ b/data/mekfiles/meks/Jihad Final Reckoning/Revenant UBM-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Archangel C-ANG-OS Caelestis.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Archangel C-ANG-OS Caelestis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Deva C-DVA-OS Caelestis.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Deva C-DVA-OS Caelestis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Grigori C-GRG-OS Caelestis.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Grigori C-GRG-OS Caelestis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Malak C-MK-OS Caelestis.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Malak C-MK-OS Caelestis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Mercury II MCY-100.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Mercury II MCY-100.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Preta C-PRT-OS Caelestis.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Preta C-PRT-OS Caelestis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Pulverizer PUL-2V.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Pulverizer PUL-2V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Seraph C-SRP-O Caelestis.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Seraph C-SRP-O Caelestis.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Stag II ST-24G.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Stag II ST-24G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Jihad Secrets/Stag ST-14G.mtf
+++ b/data/mekfiles/meks/Jihad Secrets/Stag ST-14G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Phoenix Hawk LAM Mk I PHX-HK1.mtf
+++ b/data/mekfiles/meks/LAMS/Phoenix Hawk LAM Mk I PHX-HK1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Phoenix Hawk LAM Mk I PHX-HK1R.mtf
+++ b/data/mekfiles/meks/LAMS/Phoenix Hawk LAM Mk I PHX-HK1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Phoenix Hawk LAM PHX-HK1RB.mtf
+++ b/data/mekfiles/meks/LAMS/Phoenix Hawk LAM PHX-HK1RB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Phoenix Hawk LAM PHX-HK2.mtf
+++ b/data/mekfiles/meks/LAMS/Phoenix Hawk LAM PHX-HK2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Phoenix Hawk LAM PHX-HK2M.mtf
+++ b/data/mekfiles/meks/LAMS/Phoenix Hawk LAM PHX-HK2M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Pwwka S-PW-1LAM.mtf
+++ b/data/mekfiles/meks/LAMS/Pwwka S-PW-1LAM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Screamer LAM SCR-1X-LAM.mtf
+++ b/data/mekfiles/meks/LAMS/Screamer LAM SCR-1X-LAM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Shadow Hawk LAM SHD-X1.mtf
+++ b/data/mekfiles/meks/LAMS/Shadow Hawk LAM SHD-X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Shadow Hawk LAM SHD-X2.mtf
+++ b/data/mekfiles/meks/LAMS/Shadow Hawk LAM SHD-X2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Stinger LAM Mk I STG-A1.mtf
+++ b/data/mekfiles/meks/LAMS/Stinger LAM Mk I STG-A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Stinger LAM STG-A10.mtf
+++ b/data/mekfiles/meks/LAMS/Stinger LAM STG-A10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Stinger LAM STG-A5.mtf
+++ b/data/mekfiles/meks/LAMS/Stinger LAM STG-A5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Waneta S-WN-1LAM.mtf
+++ b/data/mekfiles/meks/LAMS/Waneta S-WN-1LAM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Waneta S-WN-2LAM.mtf
+++ b/data/mekfiles/meks/LAMS/Waneta S-WN-2LAM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Wasp LAM Mk I WSP-100.mtf
+++ b/data/mekfiles/meks/LAMS/Wasp LAM Mk I WSP-100.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Wasp LAM Mk I WSP-100A.mtf
+++ b/data/mekfiles/meks/LAMS/Wasp LAM Mk I WSP-100A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Wasp LAM Mk I WSP-100b.mtf
+++ b/data/mekfiles/meks/LAMS/Wasp LAM Mk I WSP-100b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Wasp LAM WSP-105.mtf
+++ b/data/mekfiles/meks/LAMS/Wasp LAM WSP-105.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Wasp LAM WSP-105M.mtf
+++ b/data/mekfiles/meks/LAMS/Wasp LAM WSP-105M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Wasp LAM WSP-110.mtf
+++ b/data/mekfiles/meks/LAMS/Wasp LAM WSP-110.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/LAMS/Yurei S-YR-1LAM.mtf
+++ b/data/mekfiles/meks/LAMS/Yurei S-YR-1LAM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Annihilator ANH-1G.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Annihilator ANH-1G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Annihilator ANH-1X.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Annihilator ANH-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Annihilator Bryan Gausszilla.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Annihilator Bryan Gausszilla.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Annihilator C2.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Annihilator C2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech (Rocket).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech (Rocket).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Champion CHP-1Nb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Champion CHP-1Nb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Champion CHP-1Nb2.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Champion CHP-1Nb2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Crockett CRK-5003-1b.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Crockett CRK-5003-1b.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 (Flamer).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 (Flamer).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 (Rocket).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 (Rocket).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 ForestryMech.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 ForestryMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Daedalus GTX2 (Militarized).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Daedalus GTX2 (Militarized).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Daedalus GTX2A Stevedore.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Daedalus GTX2A Stevedore.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Daedalus GTX2B Navvy.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Daedalus GTX2B Navvy.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Exterminator EXT-4Db.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Exterminator EXT-4Db.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb Saho.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb Saho.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb-PP.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb-PP.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb-PP2.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb-PP2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Falcon FLC-4Nb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Firefly FFL-3A.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Firefly FFL-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Firefly FFL-3PP.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Firefly FFL-3PP.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Firefly FFL-3PP2.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Firefly FFL-3PP2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Firefly FFL-3PP3.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Firefly FFL-3PP3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Firefly FFL-3SLE.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Firefly FFL-3SLE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Griffin GRF-2N.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Griffin GRF-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Griffin GRF-2N2.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Griffin GRF-2N2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Harvester Ant KIC-3 Agromech (MG).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Harvester Ant KIC-3 Agromech (MG).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Harvester Ant KIC-3M-B AgroMech (LRM).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Harvester Ant KIC-3M-B AgroMech (LRM).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Hermes HER-1Sb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Hermes HER-1Sb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Highlander HGN-732 Colleen.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Highlander HGN-732 Colleen.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Hoplite HOP-4Bb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Hoplite HOP-4Bb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Hoplite HOP-4Cb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Hoplite HOP-4Cb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Imp IMP-1A.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Imp IMP-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Imp IMP-1B.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Imp IMP-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Imp IMP-1C.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Imp IMP-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Marco MR-8C.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Marco MR-8C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Marco MR-8D.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Marco MR-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Marco MR-8E.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Marco MR-8E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Powerman SC XI LoaderMech.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Powerman SC XI LoaderMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Sentinel STN-3Lb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Sentinel STN-3Lb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Shogun SHG-2H.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Shogun SHG-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Sling SL-1G.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Sling SL-1G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Sling SL-1H.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Sling SL-1H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Stalker STK-3Fb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Stalker STK-3Fb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Thorn THE-Nb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Thorn THE-Nb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Thunderbolt TDR-5Sb.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Thunderbolt TDR-5Sb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Operation Klondike/Thunderbolt TDR-5Sb2.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Thunderbolt TDR-5Sb2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Apollo APL-4M.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Apollo APL-4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Axman AXM-6T.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Axman AXM-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Barghest BGS-4T.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Barghest BGS-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Beowulf IIC.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Beowulf IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Deep Lord RCL-Z1M MilitiaMech.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Deep Lord RCL-Z1M MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Dola DOL-1A1.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Dola DOL-1A1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Dola DOL-1A2 Yoh Ti Ts'angs.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Dola DOL-1A2 Yoh Ti Ts'angs.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Grasshopper GHR-7P.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Grasshopper GHR-7P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Hatamoto-Kaeru HTM-35K.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Hatamoto-Kaeru HTM-35K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Hunchback HBK-7R.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Hunchback HBK-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Incubus II.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Incubus II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Legionnaire LGN-2F.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Legionnaire LGN-2F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Mad Cat III 2.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Mad Cat III 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Mad Cat III X.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Mad Cat III X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Mad Cat III.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Mad Cat III.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Mad Cat Mk II Enhanced.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Mad Cat Mk II Enhanced.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Orion ON3-M.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Orion ON3-M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Pandarus LFA-1A.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Pandarus LFA-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Patron PTN-2M MilitiaMech.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Patron PTN-2M MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Pendragon PDG-1R.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Pendragon PDG-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Quickdraw QKD-8P.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Quickdraw QKD-8P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Sarissa MN2-A SecurityMech.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Sarissa MN2-A SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Spindrift Aquatic SecurityMech SDT-1A.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Spindrift Aquatic SecurityMech SDT-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Stiletto STO-6S.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Stiletto STO-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Stinger IIC 2.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Stinger IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Stinger IIC.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Stinger IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Thunder THR-C4.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Thunder THR-C4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Thunderbolt IIC.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Thunderbolt IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Ti Ts'ang DDC TSG9-DDC.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Ti Ts'ang DDC TSG9-DDC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Trebuchet TBT-K7R.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Trebuchet TBT-K7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Ursus 3.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Ursus 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Wolf Trap (Tora) WFT-2B.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Wolf Trap (Tora) WFT-2B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ProtoTypes/Wolfhound WLF-2H.mtf
+++ b/data/mekfiles/meks/ProtoTypes/Wolfhound WLF-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Arion.mtf
+++ b/data/mekfiles/meks/QuadVees/Arion.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Boreas A.mtf
+++ b/data/mekfiles/meks/QuadVees/Boreas A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Boreas B.mtf
+++ b/data/mekfiles/meks/QuadVees/Boreas B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Boreas C.mtf
+++ b/data/mekfiles/meks/QuadVees/Boreas C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Boreas D.mtf
+++ b/data/mekfiles/meks/QuadVees/Boreas D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Boreas Prime.mtf
+++ b/data/mekfiles/meks/QuadVees/Boreas Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Cyllaros.mtf
+++ b/data/mekfiles/meks/QuadVees/Cyllaros.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Harpagos.mtf
+++ b/data/mekfiles/meks/QuadVees/Harpagos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Notos A.mtf
+++ b/data/mekfiles/meks/QuadVees/Notos A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Notos B.mtf
+++ b/data/mekfiles/meks/QuadVees/Notos B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Notos C.mtf
+++ b/data/mekfiles/meks/QuadVees/Notos C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Notos D.mtf
+++ b/data/mekfiles/meks/QuadVees/Notos D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/QuadVees/Notos Prime.mtf
+++ b/data/mekfiles/meks/QuadVees/Notos Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Jihad/Deimos H.mtf
+++ b/data/mekfiles/meks/RS Jihad/Deimos H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Jihad/Shadow Hawk SHD-11CS2.mtf
+++ b/data/mekfiles/meks/RS Jihad/Shadow Hawk SHD-11CS2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Succession Wars/Javelin JVN-10A.mtf
+++ b/data/mekfiles/meks/RS Succession Wars/Javelin JVN-10A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Succession Wars/Thunderbolt TDR-5D.mtf
+++ b/data/mekfiles/meks/RS Succession Wars/Thunderbolt TDR-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Succession Wars/Zeus ZEU-6A.mtf
+++ b/data/mekfiles/meks/RS Succession Wars/Zeus ZEU-6A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Assassin Alice.mtf
+++ b/data/mekfiles/meks/RS Unique/Assassin Alice.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Bandersnatch Horus.mtf
+++ b/data/mekfiles/meks/RS Unique/Bandersnatch Horus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Daikyu Tabitha.mtf
+++ b/data/mekfiles/meks/RS Unique/Daikyu Tabitha.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Emperor Nerran.mtf
+++ b/data/mekfiles/meks/RS Unique/Emperor Nerran.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Excalibur Cernunnos.mtf
+++ b/data/mekfiles/meks/RS Unique/Excalibur Cernunnos.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Grand Dragon DRG-1G Douglas.mtf
+++ b/data/mekfiles/meks/RS Unique/Grand Dragon DRG-1G Douglas.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Great Wyrm Aemelia.mtf
+++ b/data/mekfiles/meks/RS Unique/Great Wyrm Aemelia.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Gunslinger Jared.mtf
+++ b/data/mekfiles/meks/RS Unique/Gunslinger Jared.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Hercules Julius.mtf
+++ b/data/mekfiles/meks/RS Unique/Hercules Julius.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Jenner Samuli.mtf
+++ b/data/mekfiles/meks/RS Unique/Jenner Samuli.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Merlin Porter.mtf
+++ b/data/mekfiles/meks/RS Unique/Merlin Porter.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Snake Alexi.mtf
+++ b/data/mekfiles/meks/RS Unique/Snake Alexi.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Stealth Anna.mtf
+++ b/data/mekfiles/meks/RS Unique/Stealth Anna.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Thanatos THS-4S (Felix).mtf
+++ b/data/mekfiles/meks/RS Unique/Thanatos THS-4S (Felix).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/RS Unique/Wolf Trap Daitama.mtf
+++ b/data/mekfiles/meks/RS Unique/Wolf Trap Daitama.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Commando COM-9S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Commando COM-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Dominator 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Dominator 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Dominator.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Dominator.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Goliath C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Goliath C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Grasshopper GHR-8K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Grasshopper GHR-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-1RG.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-1RG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-3N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-3N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-3RG.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-3RG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-6R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Griffin GRF-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Loki (Hellbringer) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Loki (Hellbringer) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Loki (Hellbringer) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Loki (Hellbringer) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Pack Hunter 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 1/Pack Hunter 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer (Wolf).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer (Wolf).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-2Rb.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-2Rb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-4M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-4M2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-4M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-5R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-5S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-5W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-7C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-7C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-9R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer ARC-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Archer C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Centurion CN10-D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Centurion CN10-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Crucible 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Crucible 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Crucible 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Crucible 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Crucible.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Crucible.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Hermit Crab HMC-13.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Hermit Crab HMC-13.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Hermit Crab HMC-14.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Hermit Crab HMC-14.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Hermit Crab HMC-15.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Hermit Crab HMC-15.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Highlander HGN-740.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Highlander HGN-740.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Mongoose MON-96.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Mongoose MON-96.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) DD.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) DD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) V.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 10/Vulture (Mad Dog) V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Butcherbird (Ion Sparrow) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) P.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Man O' War (Gargoyle) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl) 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Peregrine (Horned Owl).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk C 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-2K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-2K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-4M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-4M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Phoenix Hawk PXH-9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) V.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 11/Uller (Kit Fox) V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Axman AXM-5N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Axman AXM-5N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Black Knight BL-18-KNT.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Black Knight BL-18-KNT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Carrion Crow Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Hatchetman HCT-8S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Hatchetman HCT-8S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Nobori-nin (Huntsman) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-2D2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-2D2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-2Hb.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-2Hb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-4H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-4H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-5M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-5R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-5S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-6D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-7H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Shadow Hawk SHD-7H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Viper (Black Python) .mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Viper (Black Python) .mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Viper (Black Python) 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Viper (Black Python) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Viper (Black Python) 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/Viper (Black Python) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/White Raven 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/White Raven 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 12/White Raven.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 12/White Raven.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Daishi (Dire Wolf) E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Daishi (Dire Wolf) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Daishi (Dire Wolf) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Daishi (Dire Wolf) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Daishi (Dire Wolf) X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Daishi (Dire Wolf) X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Firestorm.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Firestorm.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Galahad (Glass Spider) 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Galahad (Glass Spider) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Galahad (Glass Spider) 4.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Galahad (Glass Spider) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Galahad (Glass Spider).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Galahad (Glass Spider).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Hunchback IIC 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Hunchback IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Piranha 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Piranha 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger C 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-3Gb.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-3Gb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-4G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-4G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-5G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-5G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-5M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-6G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-6G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-6M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-6M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-6R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Stinger STG-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Supernova 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 13/Supernova 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Black Hawk (Nova) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Exterminator EXT-7X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Exterminator EXT-7X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Griffin IIC 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Griffin IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Griffin IIC 9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Griffin IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Griffin IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Griffin IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Lightning LHN-C5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Lightning LHN-C5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-5M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-8E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-8E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-8E3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-8E3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-8F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Ostsol OTL-8F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Sentinel STN-6S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Sentinel STN-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Thug THG-13U.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 14/Thug THG-13U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Black Lanner X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Fire Falcon T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC 10.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC 10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC 9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Phoenix Hawk IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Rawhide RWD-R1.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Rawhide RWD-R1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt C 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-11S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-11S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-12R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-12R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-8M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-8M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-9S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-9SE.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-9SE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-9W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 15/Thunderbolt TDR-9W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Cauldron-Born (Ebon Jaguar) X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC 10.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC 10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-1Vb.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-1Vb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-3D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-3D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-3M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-3S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-3S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-5S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-7S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-7V.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-7V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-7V2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Locust LCT-7V2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Stormwolf Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 16/Turkina X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Amarok 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Amarok 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Amarok 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Amarok 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Amarok.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Amarok.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Banshee BNC-12S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Banshee BNC-12S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crossbow W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-3R (Crael).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-3R (Crael).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-4BR.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-4BR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-4D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-4D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-4K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-5M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-5S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-6D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-6D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-6T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-7D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-7M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-7M2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-7M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-8R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-8R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-9BR.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-9BR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-9R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Crusader CRD-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane) 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Kraken (Bane).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Panther PNT-14R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Panther PNT-14R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Wolfhound WLF-6S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 17/Wolfhound WLF-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Enforcer ENF-5R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Enforcer ENF-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Eris ERS-2H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Eris ERS-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Eris ERS-2N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Eris ERS-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Eris ERS-3R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Eris ERS-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner JR7-N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Jenner JR7-N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Kingfisher X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Victor VTR-12D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Victor VTR-12D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-10D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-10D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-10R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-10R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-10V2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-10V2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-11M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-11M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7M2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-7M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-9R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 18/Wolverine WVR-9R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Cougar T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Iron Cheetah Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Mercury MCY-105.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Mercury MCY-105.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Orion C 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Orion C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Rime Otter Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-1BR.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-1BR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-1O.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-1O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-1TB.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-1TB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-2N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Scorpion SCP-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Spider SDR-9M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 19/Spider SDR-9M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Behemoth (Stone Rhino) 7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Behemoth (Stone Rhino) 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Behemoth (Stone Rhino) 8.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Behemoth (Stone Rhino) 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Behemoth BHN-6H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Behemoth BHN-6H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Bushwacker BSW-X4.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Bushwacker BSW-X4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Grendel (Mongrel) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Ostscout OTT-12R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Ostscout OTT-12R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Ostscout OTT-8J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Ostscout OTT-8J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Sojourner Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/UrbanMech UM-R96.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/UrbanMech UM-R96.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Zeus ZEU-11S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 2/Zeus ZEU-11S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion P.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Hellion T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-0H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-0H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-0W2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-0W2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-10C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-10C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-10K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-10K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-14Q.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-14Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-14V.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-14V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-8C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Longbow LGB-8C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Masakari (Warhawk) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Mastodon Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC 10.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC 10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC 11.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC 11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 20/Shadow Hawk IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Cyclops C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Cyclops C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hankyu (Arctic Cheetah) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hunchback C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Hunchback C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Kodiak 6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Kodiak 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Kontio.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Kontio.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-2D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-3M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-6R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-9C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Ostroc OSR-9C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 21/Regent Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Battle Cobra X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Doom Courser Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-3M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-3M2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-3M2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-7C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-7C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-7K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-7R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Goliath GOL-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Jade Phoenix Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 22/Night Gyr X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Fujin RJN-301-F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Fujin RJN-301-F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Grand Crusader GRN-D-01-X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Grand Crusader GRN-D-01-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Grand Crusader GRN-D-02-B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Grand Crusader GRN-D-02-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Guillotine GLT-7M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Guillotine GLT-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Katana (Crockett) CRK-5006-1.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Katana (Crockett) CRK-5006-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Lancelot LNC25-09.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Lancelot LNC25-09.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Nexus NXS1-C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Nexus NXS1-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Nova Cat M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Nova Cat M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Nova Cat T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Nova Cat T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 101-B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 101-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 101-C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 101-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 101-X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 101-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 301-B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Raijin RJN 301-B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Rifleman IIC 10.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Rifleman IIC 10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Rifleman IIC 9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Rifleman IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Crusader A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Crusader A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Crusader B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Crusader B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Crusader Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Crusader Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Python.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 23/Star Python.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/(Ryoken III) Skinwalker Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Alpha Wolf Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Annihilator ANH-5W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Annihilator ANH-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-K-DC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-K-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-S3-DC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-S3-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-S3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-S3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-S4.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS7-S4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS8-K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS8-K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS8-KE.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS8-KE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS8-S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas AS8-S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas C 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas C 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas C 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas II AS7-DK-H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Atlas II AS7-DK-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Flashman FLS-10E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Flashman FLS-10E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Grand Dragon DRG-12K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Grand Dragon DRG-12K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Stalker STK-9F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 24/Stalker STK-9F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon CLN-8V.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon CLN-8V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon CLN-9V.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon CLN-9V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon TRC-4B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon TRC-4B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon TRC-4C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Chameleon TRC-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer X.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Pouncer X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Vindicator VND-7L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Vindicator VND-7L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Wraith TR5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 25/Wraith TR5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Caesar CES-5R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Caesar CES-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Flea FLE-21.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Flea FLE-21.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Hermes II HER-7A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Hermes II HER-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin MLN-1D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin MLN-1D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin MLN-1E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin MLN-1E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin MLN-1P.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Merlin MLN-1P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Naga II W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Quickdraw QKD-9G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Quickdraw QKD-9G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Starslayer STY-4C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 26/Starslayer STY-4C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Gunslinger GUN-3ERD.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Gunslinger GUN-3ERD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Nightsky NGS-7S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Nightsky NGS-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Penetrator PTR-8D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Penetrator PTR-8D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 27/Phantom T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Cicada CDA-4A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Cicada CDA-4A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Devastator DVS-11.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Devastator DVS-11.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Firestarter FS9-N 'Mirage II'.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Firestarter FS9-N 'Mirage II'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Spector SPR-6F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 28/Spector SPR-6F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Assassin ASN-109.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Assassin ASN-109.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Charger C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Charger C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Dervish DV-11DK.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Dervish DV-11DK.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Firefly FFL-5A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Firefly FFL-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Sagittaire SGT-14R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 29/Sagittaire SGT-14R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-3M-DC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-3M-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-6C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-6C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-6G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-6G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-6R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster BLR-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster C 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/BattleMaster C 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Hierofalcon Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Puma (Adder) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Shadow Cat III Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) AA.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) AA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) Q.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) Q.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 3/Thor (Summoner) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Grizzly 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Grizzly 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hellcat (Hellhound II).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hellcat (Hellhound II).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hellhound (Conjurer) 6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hellhound (Conjurer) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hellhound II-P (Hellcat-P).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hellhound II-P (Hellcat-P).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Highlander IIC 4.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Highlander IIC 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hoplite HOP-5C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Hoplite HOP-5C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Vulcan VT-7T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Vulcan VT-7T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Whitworth WTH-2H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 30/Whitworth WTH-2H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Clint CLNT-3 4T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Clint CLNT-3 4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Javelin JVN-12N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Javelin JVN-12N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Pillager_PLG-6Z.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Pillager_PLG-6Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Shogun_C_3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 31/Shogun_C_3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/JagerMech_JM7-DD.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/JagerMech_JM7-DD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Star Adder (Blood Asp)_T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-1.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-8.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 32/Viper_VP-9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Blood Reaper 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Blood Reaper 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Gyrfalcon 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Gyrfalcon 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Hatamoto-Chi HTM-30T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Hatamoto-Chi HTM-30T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Loki Mk II (Hel) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Mauler MAL-4R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Mauler MAL-4R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Naga T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Naga T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Spartan SPT-N4.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Spartan SPT-N4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Thunder Hawk TDK-7Z.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 33/Thunder Hawk TDK-7Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Awesome AWS-11H.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Awesome AWS-11H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Blackjack BJ-5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Blackjack BJ-5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Fenris (Ice Ferret) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Thresher Mk II.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Thresher Mk II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Trebuchet TBT-9N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Trebuchet TBT-9N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Warhammer IIC 13.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Warhammer IIC 13.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Warhammer IIC 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Warhammer IIC 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Warhammer IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Warhammer IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-1S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-3M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-3M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-3W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-3W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-4W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-4W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-5A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 4/Wasp WSP-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Catapult CPLT-K6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Catapult CPLT-K6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Crab CRB-54.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Crab CRB-54.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hammerhead.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hammerhead.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hellhound (Conjurer) 7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hellhound (Conjurer) 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hellhound (Conjurer) 8.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hellhound (Conjurer) 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hellhound (Conjurer).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Hellhound (Conjurer).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/King Crab KGC-011.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/King Crab KGC-011.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) W.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Mad Cat (Timber Wolf) W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-10D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-10D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-5A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-5A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-5B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-5B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-5C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-5C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-6A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-6A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-6C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-6C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-8K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 5/Marauder II MAD-8K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cataphract CTF-5L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cataphract CTF-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cataphract CTF-5LL.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cataphract CTF-5LL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cricket RWN-01.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cricket RWN-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cricket RWN-02.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Cricket RWN-02.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Linebacker T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Bounty Hunter 3015.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Bounty Hunter 3015.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Bounty Hunter 3044.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Bounty Hunter 3044.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Bounty Hunter 3138.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Bounty Hunter 3138.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC 10.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC 10.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC 8.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC 9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-11D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-11D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-2T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-2T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-5D-DC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-5D-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-5D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-5S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder MAD-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Red Hunter.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Marauder Red Hunter.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Nightstar NSR-10D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Nightstar NSR-10D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Raven RVN-5L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 6/Raven RVN-5L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Koshi (Mist Lynx) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) P.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Ryoken (Stormcrow) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 8.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 8.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 9.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Vixen (Incubus) 9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow B.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow Prime.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/War Crow Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer C 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer C 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer C 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer C 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-10K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-10K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7A.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7M-DC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7M-DC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7S.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-8R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-8R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-9K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 7/Warhammer WHM-9K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Baboon (Howler) 4.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Baboon (Howler) 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Baboon (Howler) 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Baboon (Howler) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Baboon (Howler) 6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Baboon (Howler) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) P.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dasher (Fire Moth) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Devil.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Devil.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) K.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) R.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Dragonfly (Viper) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman C 3.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman C 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-5D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-5D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-5M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-7G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-7G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-7N.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-7N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-7N2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 8/Rifleman RFL-7N2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) F.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) G.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) L.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) L.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Gladiator (Executioner) T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 2.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 5.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 7.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle) 7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle).mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Goshawk (Vapor Eagle).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NO.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOA.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOB.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOC.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOR.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Inferno INF-NOR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat D.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat E.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat I.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat I.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat J.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat M.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat T.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Shadow Cat T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie C.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie VLK-QD.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie VLK-QD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie VLK-QD6.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie VLK-QD6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie VLK-QDD.mtf
+++ b/data/mekfiles/meks/Rec Guides ilClan/Vol 9/Valkyrie VLK-QDD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shattered Fortress/Templar III TLR2-J Arthur.mtf
+++ b/data/mekfiles/meks/Shattered Fortress/Templar III TLR2-J Arthur.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Gothic/Phoenix Hawk 'Hammer Hawk' PXH-1S.mtf
+++ b/data/mekfiles/meks/Shrapnel/Gothic/Phoenix Hawk 'Hammer Hawk' PXH-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Gothic/Phoenix Hawk PXH-1GU 'Special'.mtf
+++ b/data/mekfiles/meks/Shrapnel/Gothic/Phoenix Hawk PXH-1GU 'Special'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Gothic/Phoenix Hawk PXH-1VC.mtf
+++ b/data/mekfiles/meks/Shrapnel/Gothic/Phoenix Hawk PXH-1VC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 10/Hel HL-1.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 10/Hel HL-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 10/Hel HL-2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 10/Hel HL-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 10/Tiburon 2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 10/Tiburon 2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 10/Toro TR-B-12.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 10/Toro TR-B-12.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 10/Toro TR-B-9.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 10/Toro TR-B-9.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OG.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OG.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OH.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OI.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OI.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OJ.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 11/Battle Cobra BTL-C-2OJ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G7Lr.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G7Lr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G8Ar.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G8Ar.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G8B.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G8B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G9CCr.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 12/Jinggau JN-G9CCr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-4Ur.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-4Ur.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-5U.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-5U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-5W.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-5W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-6U.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 13/Albatross ALB-6U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 13/Albatross C 'Sooty Albatross'.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 13/Albatross C 'Sooty Albatross'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 14/Shadow Hawk SHD-3H.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 14/Shadow Hawk SHD-3H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 14/Shadow Hawk SHD-3H2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 14/Shadow Hawk SHD-3H2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Gladiator GLD-7R.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Gladiator GLD-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Gladiator GLD-7R_SF.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Gladiator GLD-7R_SF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Gladiator GLD-9SF.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Gladiator GLD-9SF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1KX.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1KX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1PT5.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1PT5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1PT6.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1PT6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1X-AFFC.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1X-AFFC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1Y.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-1Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-2D.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-3K.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 15/Mauler MAL-3K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7A.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7J.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7T 'Blazing Inferno II'.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7T 'Blazing Inferno II'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7W.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7X.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Y.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Y2 'Blazing Inferno'.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Y2 'Blazing Inferno'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Z.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Z2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Commando COM-7Z2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-BD-L 'Harvey'.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-BD-L 'Harvey'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-IC.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-IC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-KB.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-KB.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-NH.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 16/Jackalope JLP-NH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR4-X.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR4-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR4.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR6.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR7.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 18/Thunder Hawk TDK-7XEM.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 18/Thunder Hawk TDK-7XEM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 18/Thunder Hawk TDK-7ZEM.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 18/Thunder Hawk TDK-7ZEM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 2/Centurion CN10-J.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 2/Centurion CN10-J.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 2/Centurion CN10-W.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 2/Centurion CN10-W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 20/Orion (Kerensky).mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 20/Orion (Kerensky).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 20/Orion ON1-Kb.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 20/Orion ON1-Kb.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 21/Blackjack BJ-2A.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 21/Blackjack BJ-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 21/Blackjack BJ-2t.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 21/Blackjack BJ-2t.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 21/Blackjack C.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 21/Blackjack C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-6S2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-6S2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-6T.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-6T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-7D.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-7D2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Thanatos TNS-7D2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Tian-Zong TNZ-N4.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Tian-Zong TNZ-N4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Tian-Zong TNZ-N5.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Tian-Zong TNZ-N5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 22/Tian-Zong TNZ-N6.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 22/Tian-Zong TNZ-N6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 23/Hermes II HER-2R.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 23/Hermes II HER-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 23/Hermes III HER-4K.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 23/Hermes III HER-4K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 23/Hermes III HER-6K.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 23/Hermes III HER-6K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 23/Hermes III HER-7K.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 23/Hermes III HER-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 3/Thunder Stallion 4.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 3/Thunder Stallion 4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 4/SuburbanMech UM-R100.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 4/SuburbanMech UM-R100.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 4/SuburbanMech UM-R90.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 4/SuburbanMech UM-R90.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 5/Crusader CRD-10S.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 5/Crusader CRD-10S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 5/Crusader CRD-9S.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 5/Crusader CRD-9S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 6/Victor C.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 6/Victor C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 7/Hatchetman HCT-5DT.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 7/Hatchetman HCT-5DT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) A.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) B.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) C.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) Prime.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 8/Gladiator-B (Executioner-B) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 9/Longshot LNG-2 Reskov.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 9/Longshot LNG-2 Reskov.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake II RSN-1.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake II RSN-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake II RSN-2.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake II RSN-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake JR7-31.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake JR7-31.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake JR7-31P.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake JR7-31P.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake JR7-31R Gideon.mtf
+++ b/data/mekfiles/meks/Shrapnel/Vol 9/Rattlesnake JR7-31R Gideon.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-4 6N.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-4 6N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-5F.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-5F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-7K.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-7K.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-9D.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Dragon Fire DGR-9D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Grotesque (Mongrel) Prime.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Grotesque (Mongrel) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Sidewinder Prime.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Sidewinder Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Shrapnel/vol 19/Starhawk Prime.mtf
+++ b/data/mekfiles/meks/Shrapnel/vol 19/Starhawk Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Hellion Keshik/Awesome C.mtf
+++ b/data/mekfiles/meks/Spotlight On/Hellion Keshik/Awesome C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Holts Hilltoppers/Nightstar NSR-9J (Holt).mtf
+++ b/data/mekfiles/meks/Spotlight On/Holts Hilltoppers/Nightstar NSR-9J (Holt).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Jade Warriors/Titan TI-1Ak _Highshooter_.mtf
+++ b/data/mekfiles/meks/Spotlight On/Jade Warriors/Titan TI-1Ak _Highshooter_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Unending Faith/Avatar AV1-OBLO.mtf
+++ b/data/mekfiles/meks/Spotlight On/Unending Faith/Avatar AV1-OBLO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Unending Faith/Doloire DLR-OBLO.mtf
+++ b/data/mekfiles/meks/Spotlight On/Unending Faith/Doloire DLR-OBLO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Unending Faith/Mad Cat (Timber Wolf) BLO.mtf
+++ b/data/mekfiles/meks/Spotlight On/Unending Faith/Mad Cat (Timber Wolf) BLO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Unending Faith/Templar TLR1-OBLO.mtf
+++ b/data/mekfiles/meks/Spotlight On/Unending Faith/Templar TLR1-OBLO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Unending Faith/Uller (Kit Fox) BLO.mtf
+++ b/data/mekfiles/meks/Spotlight On/Unending Faith/Uller (Kit Fox) BLO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Spotlight On/Unending Faith/Vulture Mk III (Mad Dog Mk III) BLO.mtf
+++ b/data/mekfiles/meks/Spotlight On/Unending Faith/Vulture Mk III (Mad Dog Mk III) BLO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Black Knight BL-6-KNT Ian.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Black Knight BL-6-KNT Ian.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Cataphract CTF-2X George.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Cataphract CTF-2X George.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Enforcer ENF-4R Daniel.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Enforcer ENF-4R Daniel.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Grand Dragon DRG-5K Emory.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Grand Dragon DRG-5K Emory.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Hatamoto-Chi HTM-27T Daniel.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Hatamoto-Chi HTM-27T Daniel.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Hatchetman HCT-3F Austin.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Hatchetman HCT-3F Austin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterbook Sword and Dragon/Hunchback HBK-4G Shakir.mtf
+++ b/data/mekfiles/meks/Starterbook Sword and Dragon/Hunchback HBK-4G Shakir.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Black Knight BL-10-KNT Ross.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Black Knight BL-10-KNT Ross.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Cataphract CTF-3X Sara.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Cataphract CTF-3X Sara.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Enforcer ENF-5D Daniel.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Enforcer ENF-5D Daniel.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Grand Dragon DRG-7K Mark.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Grand Dragon DRG-7K Mark.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Hatamoto-Chi HTM-27T Daniel II.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Hatamoto-Chi HTM-27T Daniel II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Hatchetman HCT-5S Austin.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Hatchetman HCT-5S Austin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Hunchback HBK-4G Hohiro.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Hunchback HBK-4G Hohiro.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Starterpack Sword and Dragon/Jenner JR7-K Grace II.mtf
+++ b/data/mekfiles/meks/Starterpack Sword and Dragon/Jenner JR7-K Grace II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Burrower DTM-1 MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Burrower DTM-1 MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Burrower DTM-1M MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Burrower DTM-1M MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Buster BC XXI-M HaulerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Buster BC XXI-M HaulerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Carbine CON-9M Karenna.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Carbine CON-9M Karenna.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Carbine CON-9M-J ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Carbine CON-9M-J ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Carbine CON-9M-JB ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Carbine CON-9M-JB ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H2 MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H2 MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H2H MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H2H MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H3 MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H3 MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Crosscut ED-X4M-A LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Crosscut ED-X4M-A LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Crosscut ED-X4M-E LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Crosscut ED-X4M-E LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Crosscut ED-X4M-L LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Crosscut ED-X4M-L LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Deep Lord RCL-Z1M-B MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Deep Lord RCL-Z1M-B MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Demeter WLD-1 AgroMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Demeter WLD-1 AgroMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Demeter WLD-1-M AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Demeter WLD-1-M AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/DemolitionMech WI-DMM MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/DemolitionMech WI-DMM MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Dig Lord RCL-4M MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Dig Lord RCL-4M MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Dig Lord RCL-4M-B MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Dig Lord RCL-4M-B MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Exo HMX-1 Haulermech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Exo HMX-1 Haulermech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Exo HMX-2 Haulermech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Exo HMX-2 Haulermech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Exo HMX-3 Haulermech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Exo HMX-3 Haulermech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Exo HMX-3M Haulermech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Exo HMX-3M Haulermech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Firebee WI-WAM MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Firebee WI-WAM MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Ground Pounder DVM-2 MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Ground Pounder DVM-2 MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Ground Pounder DVM-2M MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Ground Pounder DVM-2M MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Guard GS-107X SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Guard GS-107X SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Guard GS-54 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Guard GS-54 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Gulon C SolahmaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Gulon C SolahmaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Gulon GLN-1A MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Gulon GLN-1A MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Gulon GLN-1B SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Gulon GLN-1B SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199 AgroMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199 AgroMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M-A AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M-A AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M-B AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M-B AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M-M AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Harvester HVR-199M-M AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Heavy Forester HFL-1 LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Heavy Forester HFL-1 LoggerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Heavy Forester HFL-1M LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Heavy Forester HFL-1M LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Heavy Lifter HCL-1M CargoMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Heavy Lifter HCL-1M CargoMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Heavy Lifter HCL-1MM MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Heavy Lifter HCL-1MM MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Inquisitor ITW-80 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Inquisitor ITW-80 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Inquisitor ITW-85 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Inquisitor ITW-85 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/MuckRaker GMMM-2 MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/MuckRaker GMMM-2 MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/MuckRaker GMMM-2M MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/MuckRaker GMMM-2M MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/MuckRaker GMMM-2M-B MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/MuckRaker GMMM-2M-B MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Opossum OPO-2 SalvageMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Opossum OPO-2 SalvageMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Opossum OPO-3 SalvageMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Opossum OPO-3 SalvageMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Pacifier CCU-36 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Pacifier CCU-36 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Pacifier CCU-40 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Pacifier CCU-40 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/Pompier GM-4P PoliceMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Pompier GM-4P PoliceMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/St. Florian FLN-366 FireMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/St. Florian FLN-366 FireMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/St. Florian FLN-366-M FireMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/St. Florian FLN-366-M FireMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV-M ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV-M ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Irregulars/StrongArm SC CVI ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/StrongArm SC CVI ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO SW/Flea FLE-16.mtf
+++ b/data/mekfiles/meks/TRO SW/Flea FLE-16.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV HaulerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M HaulerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M HaulerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M-B HaulerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M-B HaulerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M-C HaulerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M-C HaulerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M-W HaulerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XV-M-W HaulerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XXI HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Buster BC XXI HaulerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7 ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7M ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7M ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-8 ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-8 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-8H HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-8H HaulerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-9 ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-9 ConstructionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-9M ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-9M ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-9M-B ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-9M-B ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R 'Herder' IndustrialMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R 'Herder' IndustrialMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R2 'Hunter' IndustrialMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R2 'Hunter' IndustrialMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R3 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R3 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Chaffee BT1 Servicemech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Chaffee BT1 Servicemech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Copper CPK-19 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Copper CPK-19 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Copper CPK-65 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Copper CPK-65 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X1 LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X1 LoggerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X2M LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X2M LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4 LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4 LoggerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4B DemolitionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4B DemolitionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4D DemolitionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4D DemolitionMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4M LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4M LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4X LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4X LoggerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X5M LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X5M LoggerMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X5M-B DemolitionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X5M-B DemolitionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Dig King RCL-1 MiningMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Dig King RCL-1 MiningMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Dig King RCL-1 MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Dig King RCL-1 MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Dig Lord RCL-4 MiningMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Dig Lord RCL-4 MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/ForestryMech ED-X3.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/ForestryMech ED-X3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Grommet D90 MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Grommet D90 MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Harvester Ant KIC-3 Agromech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Harvester Ant KIC-3 Agromech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Harvester Ant KIC-3M AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Harvester Ant KIC-3M AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Harvester Ant KIC-3M-B AgroMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Harvester Ant KIC-3M-B AgroMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Harvester HVR-99 Agromech .mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Harvester HVR-99 Agromech .mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Heavy Lifter HCL-1 CargoMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Heavy Lifter HCL-1 CargoMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Jabberwocky MilitiaMech JAW-67.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Jabberwocky MilitiaMech JAW-67.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Lumberjack LM5M.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Lumberjack LM5M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Marco MR-6.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Marco MR-6.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Marco MR-7.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Marco MR-7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Peacekeeper PK-6 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Peacekeeper PK-6 SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Peacemaker PM6 PoliceMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Peacemaker PM6 PoliceMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Pompier GM-3A Firemech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Pompier GM-3A Firemech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Pompier GM-3CD FireMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Pompier GM-3CD FireMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Pompier GM-3HT FireMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Pompier GM-3HT FireMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XI-M LoaderMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XI-M LoaderMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XI-M-B LoaderMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XI-M-B LoaderMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XV HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XV HaulerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XVI HaulerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Powerman SC XVI HaulerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/ScavengerMech SC-V SalvageMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/ScavengerMech SC-V SalvageMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/ScavengerMech SC-V-M MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/ScavengerMech SC-V-M MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Shugosha LAW-QM1 Q-Mech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Shugosha LAW-QM1 Q-Mech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Shugosha LAW-QM2 Q-Mech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Shugosha LAW-QM2 Q-Mech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Shugosha LAW-QM3 Q-Mech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Shugosha LAW-QM3 Q-Mech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Shugosha PTN-LAW LoaderMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Shugosha PTN-LAW LoaderMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70 CargoMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70 CargoMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70 MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70 MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70T CargoMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Uni ATAE-70T CargoMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/TRO Vehicle Annex/Vampyr SC-V-1 SalvageMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Vampyr SC-V-1 SalvageMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Commando COM-1AK.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Commando COM-1AK.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Copper CPK-65KM SecurityMech.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Copper CPK-65KM SecurityMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Crosscut ED-X4K LoggerMech.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Crosscut ED-X4K LoggerMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KC.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KL.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KL.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KR.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KT.mtf
+++ b/data/mekfiles/meks/ToS/ToS Kaumberg/Phoenix PX-1KT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/ToS/ToS Valencia/Reconquista.mtf
+++ b/data/mekfiles/meks/ToS/ToS Valencia/Reconquista.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Total Chaos/Atlas II AS7-D-H (Devlin).mtf
+++ b/data/mekfiles/meks/Total Chaos/Atlas II AS7-D-H (Devlin).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Total Chaos/Awesome AWS-10KM (Cameron).mtf
+++ b/data/mekfiles/meks/Total Chaos/Awesome AWS-10KM (Cameron).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Archer ARC-5CS.mtf
+++ b/data/mekfiles/meks/Tukayyid/Archer ARC-5CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Black Knight BL-9-KNT.mtf
+++ b/data/mekfiles/meks/Tukayyid/Black Knight BL-9-KNT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Gladiator (Executioner) TC.mtf
+++ b/data/mekfiles/meks/Tukayyid/Gladiator (Executioner) TC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Loki (Hellbringer) M.mtf
+++ b/data/mekfiles/meks/Tukayyid/Loki (Hellbringer) M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Mad Cat (Timber Wolf) TC.mtf
+++ b/data/mekfiles/meks/Tukayyid/Mad Cat (Timber Wolf) TC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Marauder MAD-5CS.mtf
+++ b/data/mekfiles/meks/Tukayyid/Marauder MAD-5CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Phoenix Hawk PXH-1bC.mtf
+++ b/data/mekfiles/meks/Tukayyid/Phoenix Hawk PXH-1bC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Puma (Adder) TC.mtf
+++ b/data/mekfiles/meks/Tukayyid/Puma (Adder) TC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Rifleman RFL-5CS.mtf
+++ b/data/mekfiles/meks/Tukayyid/Rifleman RFL-5CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Ryoken (Stormcrow) Attwater.mtf
+++ b/data/mekfiles/meks/Tukayyid/Ryoken (Stormcrow) Attwater.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Ryoken (Stormcrow) TC.mtf
+++ b/data/mekfiles/meks/Tukayyid/Ryoken (Stormcrow) TC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Shadow Cat TC.mtf
+++ b/data/mekfiles/meks/Tukayyid/Shadow Cat TC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Shadow Hawk SHD-2Ht.mtf
+++ b/data/mekfiles/meks/Tukayyid/Shadow Hawk SHD-2Ht.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Vulture (Mad Dog) S.mtf
+++ b/data/mekfiles/meks/Tukayyid/Vulture (Mad Dog) S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Tukayyid/Warhammer WHM-7CS.mtf
+++ b/data/mekfiles/meks/Tukayyid/Warhammer WHM-7CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Death to Mercenaries/Annihilator ANH-1E.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Death to Mercenaries/Annihilator ANH-1E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Death to Mercenaries/Victor Li.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Death to Mercenaries/Victor Li.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Galtor/Atlas AS7-WGS Samsonov.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Galtor/Atlas AS7-WGS Samsonov.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Galtor/Dragon DRG-2Y Yoriyoshi.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Galtor/Dragon DRG-2Y Yoriyoshi.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Galtor/Marauder MAD-SD Douglass.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Galtor/Marauder MAD-SD Douglass.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Galtor/Thunderbolt TDR-5S-T Tallman.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Galtor/Thunderbolt TDR-5S-T Tallman.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Glengary/Zeus (Leonidas).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Glengary/Zeus (Leonidas).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Luzerne/Cauldron-Born (Ebon Jaguar) (Samantha).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Luzerne/Cauldron-Born (Ebon Jaguar) (Samantha).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Luzerne/Grasshopper (Reynolds).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Luzerne/Grasshopper (Reynolds).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Misery/Atlas AS7-D (Danielle).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Misery/Atlas AS7-D (Danielle).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Misery/Ostroc OSR-2C Michi.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Misery/Ostroc OSR-2C Michi.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Misery/Stalker STK-3F Jagawen.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Misery/Stalker STK-3F Jagawen.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP New Dallas/Rampage RMP-4G (Benboudaoud).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP New Dallas/Rampage RMP-4G (Benboudaoud).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP New Dallas/Victor VTR-9B (Kataga).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP New Dallas/Victor VTR-9B (Kataga).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Awesome AWS-8Q (Buck).mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Awesome AWS-8Q (Buck).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-5.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR1.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR2.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR3.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR4.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR5.mtf
+++ b/data/mekfiles/meks/Turning Points/HTP Tortuga/Brigand LDT-XPR5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Atreus/Albatross ALB-5W Dantalion.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Atreus/Albatross ALB-5W Dantalion.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Atreus/Emperor EMP-6ME Mercury Elite.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Atreus/Emperor EMP-6ME Mercury Elite.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Dieron/Dasher (Fire Moth) Aletha.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Dieron/Dasher (Fire Moth) Aletha.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Dieron/Kodiak Cale.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Dieron/Kodiak Cale.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Hespersus/Galahad GLH-3D Laodices.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Hespersus/Galahad GLH-3D Laodices.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Luthien/Black Hawk-KU BHKU-O Albert.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Luthien/Black Hawk-KU BHKU-O Albert.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Luthien/Thresher Edward.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Luthien/Thresher Edward.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP New Avalon/Griffin GRF-1E2 Sparky 2.0.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP New Avalon/Griffin GRF-1E2 Sparky 2.0.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP New Avalon/Grim Reaper GRM-R-PR62A.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP New Avalon/Grim Reaper GRM-R-PR62A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Sian/Cataphract CTF-5MOC Naomi.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Sian/Cataphract CTF-5MOC Naomi.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Sian/Jinggau JN-G8BX Rush.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Sian/Jinggau JN-G8BX Rush.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Sian/Seraph C-SRP-O Ravana.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Sian/Seraph C-SRP-O Ravana.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Tharkad/Dragon Fire DGR-6FC2 (Gregory).mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Tharkad/Dragon Fire DGR-6FC2 (Gregory).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/JTP Tharkad/Fafnir FNR-4A Peter.mtf
+++ b/data/mekfiles/meks/Turning Points/JTP Tharkad/Fafnir FNR-4A Peter.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Capellan Crusades/Centurion CN9-YLW3 'Yen Lo Wang'.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Capellan Crusades/Centurion CN9-YLW3 'Yen Lo Wang'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Capellan Crusades/Orion IIC 'Burton'.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Capellan Crusades/Orion IIC 'Burton'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Capellan Crusades/Tian-Zong TNZ-N3 'Jasminda'.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Capellan Crusades/Tian-Zong TNZ-N3 'Jasminda'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Falcon Incursion/BattleMaster BLR-3M (Rogers).mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Falcon Incursion/BattleMaster BLR-3M (Rogers).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Falcon Incursion/Nightstar NSR-9J Brubaker.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Falcon Incursion/Nightstar NSR-9J Brubaker.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Fronc Reaches/Marauder MAD-7D (Von Staskov).mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Fronc Reaches/Marauder MAD-7D (Von Staskov).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Fronc Reaches/Marshal MHL-6FR.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Fronc Reaches/Marshal MHL-6FR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Fronc Reaches/Phoenix Hawk PXH-3D (Jiemin).mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Fronc Reaches/Phoenix Hawk PXH-3D (Jiemin).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Cazador.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Cazador.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Rhino.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Rhino.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Snow Fox (Omni) A.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Snow Fox (Omni) A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Snow Fox (Omni) B.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Snow Fox (Omni) B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Snow Fox (Omni) Prime.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Snow Fox (Omni) Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Surtur SUR-T1.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Surtur SUR-T1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Tolva.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Hanseatic Crusade/Tolva.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Red Corsair/BattleMaster BLR-1G Red Corsair.mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Red Corsair/BattleMaster BLR-1G Red Corsair.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP Red Corsair/Man O' War (Gargoyle) (Conal).mtf
+++ b/data/mekfiles/meks/Turning Points/OTP Red Corsair/Man O' War (Gargoyle) (Conal).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP WidowMaker Absorption/Atlas II AS7-D-H (Kerensky).mtf
+++ b/data/mekfiles/meks/Turning Points/OTP WidowMaker Absorption/Atlas II AS7-D-H (Kerensky).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/OTP WidowMaker Absorption/Highlander HGN-732 (Jorgensson).mtf
+++ b/data/mekfiles/meks/Turning Points/OTP WidowMaker Absorption/Highlander HGN-732 (Jorgensson).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Arcturus/Vanquisher VQR-7V (Pravuil).mtf
+++ b/data/mekfiles/meks/Turning Points/TP Arcturus/Vanquisher VQR-7V (Pravuil).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Epsilon Eridani/Dragoon AEM-05C.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Epsilon Eridani/Dragoon AEM-05C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Epsilon Eridani/Lament LMT-2R (Manes).mtf
+++ b/data/mekfiles/meks/Turning Points/TP Epsilon Eridani/Lament LMT-2R (Manes).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Foster/Night Chanter A.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Foster/Night Chanter A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Foster/Night Chanter Prime.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Foster/Night Chanter Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Foster/Spirit Walker A.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Foster/Spirit Walker A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Foster/Spirit Walker Prime.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Foster/Spirit Walker Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Irian/Inquisitor II ITW-200.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Irian/Inquisitor II ITW-200.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Irian/Marauder II MAD-6S.mtf
+++ b/data/mekfiles/meks/Turning Points/TP Irian/Marauder II MAD-6S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Vega 3039/Jenner JR7-F (Smith).mtf
+++ b/data/mekfiles/meks/Turning Points/TP Vega 3039/Jenner JR7-F (Smith).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Vega 3039/Vulcan VL-2T (Timms).mtf
+++ b/data/mekfiles/meks/Turning Points/TP Vega 3039/Vulcan VL-2T (Timms).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Turning Points/TP Vega 3039/Warhammer WHM-6K (Olesko).mtf
+++ b/data/mekfiles/meks/Turning Points/TP Vega 3039/Warhammer WHM-6K (Olesko).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Urbanfest/UrbanKnight UM-DKX.mtf
+++ b/data/mekfiles/meks/Urbanfest/UrbanKnight UM-DKX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Urbanfest/Urbanmaster UM-S60.mtf
+++ b/data/mekfiles/meks/Urbanfest/Urbanmaster UM-S60.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Bull Shark BSK-M3.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Bull Shark BSK-M3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Bull Shark BSK-MAZ.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Bull Shark BSK-MAZ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-5R.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-5R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-5T.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-5T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-6R.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-6R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-7A.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-7A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-7R.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-BR Broadside.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-BR Broadside.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-RA Ravager.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Corsair COR-RA Ravager.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-1A.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-1B.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-1C.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-2A.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-2A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-3A.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-3A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-BLT Bolt.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-BLT Bolt.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-PH Powerhouse.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-PH Powerhouse.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-R Reaver.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Roughneck RGH-R Reaver.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider A.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Ambush.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Ambush.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider B.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider C.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider D.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Manul.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Manul.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Prime.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Vanguard.mtf
+++ b/data/mekfiles/meks/Videogame (Apocryphal)/Sun Spider Vanguard.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WWEs/Talon TLN-5VNO.mtf
+++ b/data/mekfiles/meks/WWEs/Talon TLN-5VNO.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus A.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus B.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus C.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus D.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus E.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus Prime.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Cephalus U.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Cephalus U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Dragonfly (Viper) Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Dragonfly (Viper) Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Koshi (Mist Lynx) Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Koshi (Mist Lynx) Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Mad Cat (Timber Wolf) Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Mad Cat (Timber Wolf) Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon (Jaguar).mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon (Jaguar).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon A.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon B.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon C.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon D.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon E.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon F.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon G.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon G.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon Prime.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Osteon U.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Osteon U.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) A-Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) A-Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) B-Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) B-Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) C-Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) C-Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) D-Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) D-Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) E.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) F.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) US.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) US.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) UW.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) UW.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Pariah (Septicemia) Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Ryoken (Stormcrow) Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Ryoken (Stormcrow) Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Savage Coyote Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Savage Coyote Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Thor (Summoner) Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Thor (Summoner) Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/WoR Supplemental/Turkina Z.mtf
+++ b/data/mekfiles/meks/WoR Supplemental/Turkina Z.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Archangel C-ANG-O Berith.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Archangel C-ANG-O Berith.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/BattleMaster BLR-4S Calvin II.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/BattleMaster BLR-4S Calvin II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/BattleMaster BLR-4S Calvin.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/BattleMaster BLR-4S Calvin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Deva C-DVA-O Achilleus.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Deva C-DVA-O Achilleus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Gallowglas GAL-4GLSA.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Gallowglas GAL-4GLSA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Griffin GRF-6S Francine II.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Griffin GRF-6S Francine II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Griffin GRF-6S Francine.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Griffin GRF-6S Francine.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Grigori C-GRG-O Rufus.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Grigori C-GRG-O Rufus.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Lightray LGH-6W.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Lightray LGH-6W.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Malak C-MK-O Mi.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Malak C-MK-O Mi.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Preta C-PRT-O Kendali.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Preta C-PRT-O Kendali.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Seraph C-SRP-O Havalah.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Seraph C-SRP-O Havalah.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Uziel UZL-2S Jacob II.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Uziel UZL-2S Jacob II.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Uziel UZL-2S Jacob.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Uziel UZL-2S Jacob.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Wolfhound WLF-4WA.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Wolfhound WLF-4WA.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/Wolf and Blake/Zeus X ZEU-9WD Stacy.mtf
+++ b/data/mekfiles/meks/Wolf and Blake/Zeus X ZEU-9WD Stacy.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Boondocks/Merlin MLN-SX.mtf
+++ b/data/mekfiles/meks/XTRs/Boondocks/Merlin MLN-SX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Boondocks/Spindrift Aquatic SecurityMech SDT-1.mtf
+++ b/data/mekfiles/meks/XTRs/Boondocks/Spindrift Aquatic SecurityMech SDT-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Boondocks/Whitworth WTH-5S.mtf
+++ b/data/mekfiles/meks/XTRs/Boondocks/Whitworth WTH-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Boondoggles/Liberator LIB-4T.mtf
+++ b/data/mekfiles/meks/XTRs/Boondoggles/Liberator LIB-4T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Boondoggles/Ostscout IIC.mtf
+++ b/data/mekfiles/meks/XTRs/Boondoggles/Ostscout IIC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Aquagladius AQS-5 MAM.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Aquagladius AQS-5 MAM.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Carbine CON-9M-D ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Carbine CON-9M-D ConstructionMech MOD.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Crosscut IIC SolahmaMech.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Crosscut IIC SolahmaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Daedalus DAD-DX.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Daedalus DAD-DX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Gauss-Buster.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Gauss-Buster.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Omni-Marauder A.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Omni-Marauder A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Omni-Marauder Prime.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Omni-Marauder Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Phoenix Hawk PXH-99.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Phoenix Hawk PXH-99.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Porcupine PRC-3N.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Porcupine PRC-3N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Scourge SCG-WX1.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Scourge SCG-WX1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Uni ATAE-70 ArtilleryMech.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Uni ATAE-70 ArtilleryMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Valkyrie VLK-QD5.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Valkyrie VLK-QD5.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Volkh VKH-68.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Volkh VKH-68.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Caveat Emptor/Wasp WSP-3X.mtf
+++ b/data/mekfiles/meks/XTRs/Caveat Emptor/Wasp WSP-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Clans/Cougar-XR.mtf
+++ b/data/mekfiles/meks/XTRs/Clans/Cougar-XR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Clans/Ha Otoko-HR.mtf
+++ b/data/mekfiles/meks/XTRs/Clans/Ha Otoko-HR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Clans/Kraken-XR.mtf
+++ b/data/mekfiles/meks/XTRs/Clans/Kraken-XR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Clans/Ursus PR.mtf
+++ b/data/mekfiles/meks/XTRs/Clans/Ursus PR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/ComStar/Beowulf BEO-X-7a.mtf
+++ b/data/mekfiles/meks/XTRs/ComStar/Beowulf BEO-X-7a.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/ComStar/Celerity CLR-02-X-D.mtf
+++ b/data/mekfiles/meks/XTRs/ComStar/Celerity CLR-02-X-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/ComStar/Exterminator EXT-6CS.mtf
+++ b/data/mekfiles/meks/XTRs/ComStar/Exterminator EXT-6CS.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/ComStar/Grim Reaper GRM-R (Einar).mtf
+++ b/data/mekfiles/meks/XTRs/ComStar/Grim Reaper GRM-R (Einar).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/ComStar/Highlander HGN-641-X-2.mtf
+++ b/data/mekfiles/meks/XTRs/ComStar/Highlander HGN-641-X-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/ComStar/Tessen TSN-X-4.mtf
+++ b/data/mekfiles/meks/XTRs/ComStar/Tessen TSN-X-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Corporations/Arbiter ARB-001.mtf
+++ b/data/mekfiles/meks/XTRs/Corporations/Arbiter ARB-001.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Corporations/Charger CGR-1X1.mtf
+++ b/data/mekfiles/meks/XTRs/Corporations/Charger CGR-1X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Corporations/Firestarter FS9-X81.mtf
+++ b/data/mekfiles/meks/XTRs/Corporations/Firestarter FS9-X81.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Corporations/Hunchback HBK-7X-4.mtf
+++ b/data/mekfiles/meks/XTRs/Corporations/Hunchback HBK-7X-4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Corporations/Quickdraw QKD-8X.mtf
+++ b/data/mekfiles/meks/XTRs/Corporations/Quickdraw QKD-8X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Davion/Devastator DVS-X10 MUSE EARTH.mtf
+++ b/data/mekfiles/meks/XTRs/Davion/Devastator DVS-X10 MUSE EARTH.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Davion/Enforcer III ENF-7X MUSE COMPACT.mtf
+++ b/data/mekfiles/meks/XTRs/Davion/Enforcer III ENF-7X MUSE COMPACT.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Davion/Legionnaire LGN-2X1 MUSE FIRE.mtf
+++ b/data/mekfiles/meks/XTRs/Davion/Legionnaire LGN-2X1 MUSE FIRE.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Davion/Pendragon PDG-1X MUSE RED.mtf
+++ b/data/mekfiles/meks/XTRs/Davion/Pendragon PDG-1X MUSE RED.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Davion/Rifleman RFL-X3 MUSE WIND.mtf
+++ b/data/mekfiles/meks/XTRs/Davion/Rifleman RFL-X3 MUSE WIND.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gladiators/Crosscut ED-XX Ichabod.mtf
+++ b/data/mekfiles/meks/XTRs/Gladiators/Crosscut ED-XX Ichabod.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gladiators/Juggernaut JG-R9TX1 Leapin' Lil.mtf
+++ b/data/mekfiles/meks/XTRs/Gladiators/Juggernaut JG-R9TX1 Leapin' Lil.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gladiators/Spatha SP2-X Warlord.mtf
+++ b/data/mekfiles/meks/XTRs/Gladiators/Spatha SP2-X Warlord.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gladiators/Valiant VAL-NT-JX Hot Knife.mtf
+++ b/data/mekfiles/meks/XTRs/Gladiators/Valiant VAL-NT-JX Hot Knife.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gladiators/Warhammer WHM-X7 The Lich.mtf
+++ b/data/mekfiles/meks/XTRs/Gladiators/Warhammer WHM-X7 The Lich.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gladiators/Wraith TR2-X Alexander.mtf
+++ b/data/mekfiles/meks/XTRs/Gladiators/Wraith TR2-X Alexander.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gunslingers/Exterminator EXT-4DX Caine.mtf
+++ b/data/mekfiles/meks/XTRs/Gunslingers/Exterminator EXT-4DX Caine.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gunslingers/Mongoose MON-66GX Gunslinger.mtf
+++ b/data/mekfiles/meks/XTRs/Gunslingers/Mongoose MON-66GX Gunslinger.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gunslingers/Rifleman III RF2-A.mtf
+++ b/data/mekfiles/meks/XTRs/Gunslingers/Rifleman III RF2-A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gunslingers/Thug THG-11ECX (Jose).mtf
+++ b/data/mekfiles/meks/XTRs/Gunslingers/Thug THG-11ECX (Jose).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Gunslingers/Wyvern WVE-5UX City.mtf
+++ b/data/mekfiles/meks/XTRs/Gunslingers/Wyvern WVE-5UX City.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Kurita/Banzai BNZ-X.mtf
+++ b/data/mekfiles/meks/XTRs/Kurita/Banzai BNZ-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Kurita/Hatamoto-Kaeru HTM-35X.mtf
+++ b/data/mekfiles/meks/XTRs/Kurita/Hatamoto-Kaeru HTM-35X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Kurita/Jenner JR10-X.mtf
+++ b/data/mekfiles/meks/XTRs/Kurita/Jenner JR10-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Kurita/No-Dachi NDA-3X.mtf
+++ b/data/mekfiles/meks/XTRs/Kurita/No-Dachi NDA-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Kurita/Wolf Trap (Tora) WFT-2X 'Bear Trap'.mtf
+++ b/data/mekfiles/meks/XTRs/Kurita/Wolf Trap (Tora) WFT-2X 'Bear Trap'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Liao/Dola DOL-1A.mtf
+++ b/data/mekfiles/meks/XTRs/Liao/Dola DOL-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Liao/Pillager PLG-4x Anvil.mtf
+++ b/data/mekfiles/meks/XTRs/Liao/Pillager PLG-4x Anvil.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Liao/Raven X RVN-3X.mtf
+++ b/data/mekfiles/meks/XTRs/Liao/Raven X RVN-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Liao/Vindicator VND-3LD (Dao).mtf
+++ b/data/mekfiles/meks/XTRs/Liao/Vindicator VND-3LD (Dao).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Marik/Awesome AWS-11M.mtf
+++ b/data/mekfiles/meks/XTRs/Marik/Awesome AWS-11M.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Marik/Hermes II HER-7S.mtf
+++ b/data/mekfiles/meks/XTRs/Marik/Hermes II HER-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Marik/Jackal JA-KL-1579.mtf
+++ b/data/mekfiles/meks/XTRs/Marik/Jackal JA-KL-1579.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Marik/Orion ON3-MX.mtf
+++ b/data/mekfiles/meks/XTRs/Marik/Orion ON3-MX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Marik/Pandarus LFA-1X.mtf
+++ b/data/mekfiles/meks/XTRs/Marik/Pandarus LFA-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Marik/Sarissa MN1-D.mtf
+++ b/data/mekfiles/meks/XTRs/Marik/Sarissa MN1-D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Mercenaries/Annihilator ANH-2AX.mtf
+++ b/data/mekfiles/meks/XTRs/Mercenaries/Annihilator ANH-2AX.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Mercenaries/Grasshopper GHR-7X.mtf
+++ b/data/mekfiles/meks/XTRs/Mercenaries/Grasshopper GHR-7X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Mercenaries/Hoplite HOP-4X.mtf
+++ b/data/mekfiles/meks/XTRs/Mercenaries/Hoplite HOP-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Mercenaries/Wolfhound WLF-2X.mtf
+++ b/data/mekfiles/meks/XTRs/Mercenaries/Wolfhound WLF-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Most Wanted/Black Knight BL-X-KNT 'Red Reaper'.mtf
+++ b/data/mekfiles/meks/XTRs/Most Wanted/Black Knight BL-X-KNT 'Red Reaper'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Most Wanted/Fireball ALM-XF.mtf
+++ b/data/mekfiles/meks/XTRs/Most Wanted/Fireball ALM-XF.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Most Wanted/Huron Warrior HUR-WO-RX4.mtf
+++ b/data/mekfiles/meks/XTRs/Most Wanted/Huron Warrior HUR-WO-RX4.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Most Wanted/Mauler MAL-4X 'Todesbote'.mtf
+++ b/data/mekfiles/meks/XTRs/Most Wanted/Mauler MAL-4X 'Todesbote'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Most Wanted/Pompier GM-FL FireMech.mtf
+++ b/data/mekfiles/meks/XTRs/Most Wanted/Pompier GM-FL FireMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Periphery/Anubis ABS-3MC.mtf
+++ b/data/mekfiles/meks/XTRs/Periphery/Anubis ABS-3MC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Periphery/Atlas AS-700 Jurn.mtf
+++ b/data/mekfiles/meks/XTRs/Periphery/Atlas AS-700 Jurn.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Periphery/Dig Lord RCL-Z1 Armed MiningMech.mtf
+++ b/data/mekfiles/meks/XTRs/Periphery/Dig Lord RCL-Z1 Armed MiningMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Periphery/Trebuchet TBT-XK7.mtf
+++ b/data/mekfiles/meks/XTRs/Periphery/Trebuchet TBT-XK7.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Phantoms/Chameleon Q-'Mech CLN-7VQ.mtf
+++ b/data/mekfiles/meks/XTRs/Phantoms/Chameleon Q-'Mech CLN-7VQ.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Phantoms/Grand Titan Vengeance T-IT-N14R.mtf
+++ b/data/mekfiles/meks/XTRs/Phantoms/Grand Titan Vengeance T-IT-N14R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Phantoms/Warlord BLR-2XC.mtf
+++ b/data/mekfiles/meks/XTRs/Phantoms/Warlord BLR-2XC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Phantoms/Wight Dezgra WGT-4NC.mtf
+++ b/data/mekfiles/meks/XTRs/Phantoms/Wight Dezgra WGT-4NC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Pirates/Commando COM-7S2 Freyr.mtf
+++ b/data/mekfiles/meks/XTRs/Pirates/Commando COM-7S2 Freyr.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Pirates/Daimyo DMO-1K2 Al-Shahab.mtf
+++ b/data/mekfiles/meks/XTRs/Pirates/Daimyo DMO-1K2 Al-Shahab.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Pirates/Dervish DV-8D2 Lightbringer.mtf
+++ b/data/mekfiles/meks/XTRs/Pirates/Dervish DV-8D2 Lightbringer.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Pirates/Hellspawn HSN-7D2 Halperin.mtf
+++ b/data/mekfiles/meks/XTRs/Pirates/Hellspawn HSN-7D2 Halperin.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Pirates/Victor VTR-9K2 St. James.mtf
+++ b/data/mekfiles/meks/XTRs/Pirates/Victor VTR-9K2 St. James.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives I/Commando COM-1A.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives I/Commando COM-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives I/Helepolis HEP-1H.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives I/Helepolis HEP-1H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives I/Kyudo KY2-D-01.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives I/Kyudo KY2-D-01.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives I/Mackie MSK-5S.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives I/Mackie MSK-5S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives I/Shadow Hawk SHD-1R.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives I/Shadow Hawk SHD-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives II/Banshee BNC-1E.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives II/Banshee BNC-1E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives II/BattleAxe BKX-1X.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives II/BattleAxe BKX-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives II/Crossbow CRS-X.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives II/Crossbow CRS-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives II/Gladiator GLD-1R.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives II/Gladiator GLD-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives II/Icarus ICR-1X.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives II/Icarus ICR-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives II/Wasp WSP-1.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives II/Wasp WSP-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives III/Bellerophon BEL-1X.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives III/Bellerophon BEL-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives III/Dervish DV-1S.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives III/Dervish DV-1S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives III/Eisenfaust EFT-2.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives III/Eisenfaust EFT-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives III/Firebee FRB-1E(WAM-B).mtf
+++ b/data/mekfiles/meks/XTRs/Primitives III/Firebee FRB-1E(WAM-B).mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives III/Longbow LGB-0C.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives III/Longbow LGB-0C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives III/Thunderbolt TDR-1C.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives III/Thunderbolt TDR-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives IV/Emperor EMP-1A.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives IV/Emperor EMP-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives IV/Griffin GRF-1A.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives IV/Griffin GRF-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives IV/Rifleman RFL-1N.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives IV/Rifleman RFL-1N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives IV/Rifleman RFL-2N.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives IV/Rifleman RFL-2N.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives IV/Toro TR-A-1.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives IV/Toro TR-A-1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives IV/Xanthos XNT-2O.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives IV/Xanthos XNT-2O.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Archer ARC-1A.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Archer ARC-1A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Orion ON1-C.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Orion ON1-C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Orion ON1-H.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Orion ON1-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Phoenix PX-1R.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Phoenix PX-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Trooper TP-1R.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Trooper TP-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Wolverine WVR-1R.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Wolverine WVR-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Wolverine WVR-3R.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Wolverine WVR-3R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Primitives V/Ymir BWP-X1.mtf
+++ b/data/mekfiles/meks/XTRs/Primitives V/Ymir BWP-X1.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/'Battle Tripod' R_H3L-2X.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/'Battle Tripod' R_H3L-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/'Harvester Tripod' R_H3L-3X.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/'Harvester Tripod' R_H3L-3X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/'Scout Tripod' R_H3L-1X.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/'Scout Tripod' R_H3L-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/BattleAxe BKX-RISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/BattleAxe BKX-RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Emperor EMP-6X.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Emperor EMP-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Excalibur EXC-B2-RISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Excalibur EXC-B2-RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Helios HEL-6RISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Helios HEL-6RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Icarus II ICR-2X.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Icarus II ICR-2X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Legionnaire LGN-2K-RISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Legionnaire LGN-2K-RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Mad Cat Mk IV PR RISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Mad Cat Mk IV PR RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Malice MAL-Y-SH-RISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Malice MAL-Y-SH-RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RISC/Templar TLR1-ORISC.mtf
+++ b/data/mekfiles/meks/XTRs/RISC/Templar TLR1-ORISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic I/Beowulf IIC PR.mtf
+++ b/data/mekfiles/meks/XTRs/Republic I/Beowulf IIC PR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic I/Emerald Harrier (Roadrunner) RD-1R.mtf
+++ b/data/mekfiles/meks/XTRs/Republic I/Emerald Harrier (Roadrunner) RD-1R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic I/Enforcer III ENF-7D.mtf
+++ b/data/mekfiles/meks/XTRs/Republic I/Enforcer III ENF-7D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic I/Hatchetman HCT-7R.mtf
+++ b/data/mekfiles/meks/XTRs/Republic I/Hatchetman HCT-7R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic I/Valiant VLT-3E.mtf
+++ b/data/mekfiles/meks/XTRs/Republic I/Valiant VLT-3E.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Awesome AWS-11R.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Awesome AWS-11R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Blade BLD-XR.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Blade BLD-XR.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Hatamoto-Ku HTM-27W2.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Hatamoto-Ku HTM-27W2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Hornet HNT-181.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Hornet HNT-181.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Hornet HNT-182.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Hornet HNT-182.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Hunchback HBK-7S.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Hunchback HBK-7S.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Orca OC-1X.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Orca OC-1X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Penthesilea PEN-3H.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Penthesilea PEN-3H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/Prefect PRF-1C.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/Prefect PRF-1C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic II/UrbanMech UM-R93.mtf
+++ b/data/mekfiles/meks/XTRs/Republic II/UrbanMech UM-R93.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Goshawk II RISC.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Goshawk II RISC.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Lament LMT-2D.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Lament LMT-2D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Lich UABM-2R.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Lich UABM-2R.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Osprey OSP-36.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Osprey OSP-36.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Parash 3.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Parash 3.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP A.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP A.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP B.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP C.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP C.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP D.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP D.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP Prime.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Ryoken III-XP Prime.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Republic III/Triskelion TRK-4V.mtf
+++ b/data/mekfiles/meks/XTRs/Republic III/Triskelion TRK-4V.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RetroTech/Centurion CN9-H.mtf
+++ b/data/mekfiles/meks/XTRs/RetroTech/Centurion CN9-H.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RetroTech/HawkWolf HWK-3F.mtf
+++ b/data/mekfiles/meks/XTRs/RetroTech/HawkWolf HWK-3F.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RetroTech/Pathfinder PFF-2.mtf
+++ b/data/mekfiles/meks/XTRs/RetroTech/Pathfinder PFF-2.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RetroTech/Pathfinder PFF-2T.mtf
+++ b/data/mekfiles/meks/XTRs/RetroTech/Pathfinder PFF-2T.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RetroTech/Patron PTN-2 MilitiaMech.mtf
+++ b/data/mekfiles/meks/XTRs/RetroTech/Patron PTN-2 MilitiaMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/RetroTech/Rook-X NH-1B.mtf
+++ b/data/mekfiles/meks/XTRs/RetroTech/Rook-X NH-1B.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Agrotera AGT-UA _Ariel_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Agrotera AGT-UA _Ariel_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Buccaneer BCN-6PX _Pan_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Buccaneer BCN-6PX _Pan_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Calliope CAL-1MAFSW _Snow White_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Calliope CAL-1MAFSW _Snow White_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Celerity CLR-03OMM _Rajah_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Celerity CLR-03OMM _Rajah_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Clint IIC 2L _Leia_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Clint IIC 2L _Leia_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Ghost GST-10A _Aurora_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Ghost GST-10A _Aurora_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Gunsmith CH11-NGC _Cinderella_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Gunsmith CH11-NGC _Cinderella_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Hitotsume Kozo HKZ-1FM _Mulan_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Hitotsume Kozo HKZ-1FM _Mulan_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Phoenix Hawk PXH-7KJ _Jasmine_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Phoenix Hawk PXH-7KJ _Jasmine_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Tessen TSN-X4R _Rapunzel_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Tessen TSN-X4R _Rapunzel_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Trebuchet TBT-7MM _Merida_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Trebuchet TBT-7MM _Merida_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Vulcan VT-5ML _Aladdin_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Vulcan VT-5ML _Aladdin_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Vulpes VLP-1DX _Beast_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Vulpes VLP-1DX _Beast_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Watchman WTC-4MB 'Belle'.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Watchman WTC-4MB 'Belle'.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Royal Fantasy/Wraith TR2-P _Pocahontas_.mtf
+++ b/data/mekfiles/meks/XTRs/Royal Fantasy/Wraith TR2-P _Pocahontas_.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Steiner/Axman AXM-6X.mtf
+++ b/data/mekfiles/meks/XTRs/Steiner/Axman AXM-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Steiner/Banshee BNC-11X.mtf
+++ b/data/mekfiles/meks/XTRs/Steiner/Banshee BNC-11X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Steiner/Barghest BGS-4X.mtf
+++ b/data/mekfiles/meks/XTRs/Steiner/Barghest BGS-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Steiner/Slagmaiden SLG-X.mtf
+++ b/data/mekfiles/meks/XTRs/Steiner/Slagmaiden SLG-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Steiner/Stealth STH-5X.mtf
+++ b/data/mekfiles/meks/XTRs/Steiner/Stealth STH-5X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Steiner/Stiletto STO-6X.mtf
+++ b/data/mekfiles/meks/XTRs/Steiner/Stiletto STO-6X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Cataphract CTF-0X.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Cataphract CTF-0X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Flea FLE-14.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Flea FLE-14.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Kiso K-3N-KRHQ CommandMech.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Kiso K-3N-KRHQ CommandMech.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Marauder MAD-4X.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Marauder MAD-4X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Super Griffin GRF-2N-X.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Super Griffin GRF-2N-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Super Wasp WSP-2A-X.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Super Wasp WSP-2A-X.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/meks/XTRs/Succession Wars/Zeus ZEU-6Y.mtf
+++ b/data/mekfiles/meks/XTRs/Succession Wars/Zeus ZEU-6Y.mtf
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Centaur 2.blk
+++ b/data/mekfiles/protomeks/3060/Centaur 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Centaur 3.blk
+++ b/data/mekfiles/protomeks/3060/Centaur 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Centaur 4.blk
+++ b/data/mekfiles/protomeks/3060/Centaur 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Centaur.blk
+++ b/data/mekfiles/protomeks/3060/Centaur.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Gorgon 2.blk
+++ b/data/mekfiles/protomeks/3060/Gorgon 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Gorgon 3.blk
+++ b/data/mekfiles/protomeks/3060/Gorgon 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Gorgon 4.blk
+++ b/data/mekfiles/protomeks/3060/Gorgon 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Gorgon.blk
+++ b/data/mekfiles/protomeks/3060/Gorgon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Harpy 2.blk
+++ b/data/mekfiles/protomeks/3060/Harpy 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Harpy 3.blk
+++ b/data/mekfiles/protomeks/3060/Harpy 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Harpy 4.blk
+++ b/data/mekfiles/protomeks/3060/Harpy 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Harpy.blk
+++ b/data/mekfiles/protomeks/3060/Harpy.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Hydra 2.blk
+++ b/data/mekfiles/protomeks/3060/Hydra 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Hydra 3.blk
+++ b/data/mekfiles/protomeks/3060/Hydra 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Hydra 4.blk
+++ b/data/mekfiles/protomeks/3060/Hydra 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Hydra.blk
+++ b/data/mekfiles/protomeks/3060/Hydra.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Minotaur 2.blk
+++ b/data/mekfiles/protomeks/3060/Minotaur 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Minotaur 3.blk
+++ b/data/mekfiles/protomeks/3060/Minotaur 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Minotaur 4.blk
+++ b/data/mekfiles/protomeks/3060/Minotaur 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Minotaur.blk
+++ b/data/mekfiles/protomeks/3060/Minotaur.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Roc 2.blk
+++ b/data/mekfiles/protomeks/3060/Roc 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Roc 3.blk
+++ b/data/mekfiles/protomeks/3060/Roc 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Roc 4.blk
+++ b/data/mekfiles/protomeks/3060/Roc 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Roc.blk
+++ b/data/mekfiles/protomeks/3060/Roc.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Satyr 2.blk
+++ b/data/mekfiles/protomeks/3060/Satyr 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Satyr 3.blk
+++ b/data/mekfiles/protomeks/3060/Satyr 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Satyr 4.blk
+++ b/data/mekfiles/protomeks/3060/Satyr 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Satyr.blk
+++ b/data/mekfiles/protomeks/3060/Satyr.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Siren 2.blk
+++ b/data/mekfiles/protomeks/3060/Siren 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Siren 3.blk
+++ b/data/mekfiles/protomeks/3060/Siren 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Siren 4.blk
+++ b/data/mekfiles/protomeks/3060/Siren 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Siren 5.blk
+++ b/data/mekfiles/protomeks/3060/Siren 5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3060/Siren.blk
+++ b/data/mekfiles/protomeks/3060/Siren.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Basilisk 2.blk
+++ b/data/mekfiles/protomeks/3075/Basilisk 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Basilisk 3.blk
+++ b/data/mekfiles/protomeks/3075/Basilisk 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Basilisk.blk
+++ b/data/mekfiles/protomeks/3075/Basilisk.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Cecerops 2.blk
+++ b/data/mekfiles/protomeks/3075/Cecerops 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Cecerops 3.blk
+++ b/data/mekfiles/protomeks/3075/Cecerops 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Cecerops 4.blk
+++ b/data/mekfiles/protomeks/3075/Cecerops 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Cecerops.blk
+++ b/data/mekfiles/protomeks/3075/Cecerops.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Chrysaor 2.blk
+++ b/data/mekfiles/protomeks/3075/Chrysaor 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Chrysaor.blk
+++ b/data/mekfiles/protomeks/3075/Chrysaor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Delphyne 2.blk
+++ b/data/mekfiles/protomeks/3075/Delphyne 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Delphyne 3.blk
+++ b/data/mekfiles/protomeks/3075/Delphyne 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Delphyne.blk
+++ b/data/mekfiles/protomeks/3075/Delphyne.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Erinyes 2.blk
+++ b/data/mekfiles/protomeks/3075/Erinyes 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Erinyes 3.blk
+++ b/data/mekfiles/protomeks/3075/Erinyes 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Erinyes.blk
+++ b/data/mekfiles/protomeks/3075/Erinyes.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Orc 2.blk
+++ b/data/mekfiles/protomeks/3075/Orc 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Orc 3.blk
+++ b/data/mekfiles/protomeks/3075/Orc 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Orc 4.blk
+++ b/data/mekfiles/protomeks/3075/Orc 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Orc.blk
+++ b/data/mekfiles/protomeks/3075/Orc.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Procyon 2.blk
+++ b/data/mekfiles/protomeks/3075/Procyon 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Procyon 3.blk
+++ b/data/mekfiles/protomeks/3075/Procyon 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Procyon 4.blk
+++ b/data/mekfiles/protomeks/3075/Procyon 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Procyon 5.blk
+++ b/data/mekfiles/protomeks/3075/Procyon 5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Procyon.blk
+++ b/data/mekfiles/protomeks/3075/Procyon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Triton 2.blk
+++ b/data/mekfiles/protomeks/3075/Triton 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Triton 3.blk
+++ b/data/mekfiles/protomeks/3075/Triton 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Triton 4.blk
+++ b/data/mekfiles/protomeks/3075/Triton 4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3075/Triton.blk
+++ b/data/mekfiles/protomeks/3075/Triton.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3145/HippogriffProtomech.blk
+++ b/data/mekfiles/protomeks/3145/HippogriffProtomech.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3145/NTNU/Cecerops 5.blk
+++ b/data/mekfiles/protomeks/3145/NTNU/Cecerops 5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3145/NTNU/Gorgon 5.blk
+++ b/data/mekfiles/protomeks/3145/NTNU/Gorgon 5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3145/NTNU/Gorgon 6.blk
+++ b/data/mekfiles/protomeks/3145/NTNU/Gorgon 6.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3145/NTNU/Roc 5.blk
+++ b/data/mekfiles/protomeks/3145/NTNU/Roc 5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/3145/NTNU/Svartalfa 3.blk
+++ b/data/mekfiles/protomeks/3145/NTNU/Svartalfa 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/ProtoTypes/Minotaur-P2.blk
+++ b/data/mekfiles/protomeks/ProtoTypes/Minotaur-P2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/ProtoTypes/Procyon (Quad).blk
+++ b/data/mekfiles/protomeks/ProtoTypes/Procyon (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/ProtoTypes/Satyr-XP.blk
+++ b/data/mekfiles/protomeks/ProtoTypes/Satyr-XP.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/ProtoTypes/SvartAlfa Ultra LRM.blk
+++ b/data/mekfiles/protomeks/ProtoTypes/SvartAlfa Ultra LRM.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/ProtoTypes/SvartAlfa Ultra.blk
+++ b/data/mekfiles/protomeks/ProtoTypes/SvartAlfa Ultra.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Basilisk ProtoMech (Quad) B.blk
+++ b/data/mekfiles/protomeks/WoR/Basilisk ProtoMech (Quad) B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Basilisk ProtoMech (Quad).blk
+++ b/data/mekfiles/protomeks/WoR/Basilisk ProtoMech (Quad).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Boggart Ultraheavy ProtoMech 2.blk
+++ b/data/mekfiles/protomeks/WoR/Boggart Ultraheavy ProtoMech 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Boggart Ultraheavy ProtoMech.blk
+++ b/data/mekfiles/protomeks/WoR/Boggart Ultraheavy ProtoMech.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Centaur Z.blk
+++ b/data/mekfiles/protomeks/WoR/Centaur Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Hobgoblin Ultraheavy ProtoMech 2.blk
+++ b/data/mekfiles/protomeks/WoR/Hobgoblin Ultraheavy ProtoMech 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Hobgoblin Ultraheavy ProtoMech.blk
+++ b/data/mekfiles/protomeks/WoR/Hobgoblin Ultraheavy ProtoMech.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Minotaur Z.blk
+++ b/data/mekfiles/protomeks/WoR/Minotaur Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Procyon Z.blk
+++ b/data/mekfiles/protomeks/WoR/Procyon Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Roc Z.blk
+++ b/data/mekfiles/protomeks/WoR/Roc Z.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Sprite 2.blk
+++ b/data/mekfiles/protomeks/WoR/Sprite 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Sprite 3.blk
+++ b/data/mekfiles/protomeks/WoR/Sprite 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/WoR/Sprite.blk
+++ b/data/mekfiles/protomeks/WoR/Sprite.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/protomeks/XTR Clans/Minotaur-XP.blk
+++ b/data/mekfiles/protomeks/XTR Clans/Minotaur-XP.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/HBHK/Dragonstar Assault Transport (3060).blk
+++ b/data/mekfiles/smallcraft/HBHK/Dragonstar Assault Transport (3060).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/HBHK/Dragonstar Assault Transport (PT).blk
+++ b/data/mekfiles/smallcraft/HBHK/Dragonstar Assault Transport (PT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/HBHL/Mowang Courier.blk
+++ b/data/mekfiles/smallcraft/HBHL/Mowang Courier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/HBHS/LC-100 Astrolux Star Yacht.blk
+++ b/data/mekfiles/smallcraft/HBHS/LC-100 Astrolux Star Yacht.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/HBMPS/Tigress Close Patrol Craft TIG-15.blk
+++ b/data/mekfiles/smallcraft/HBMPS/Tigress Close Patrol Craft TIG-15.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/Prototypes/TIG-40 Foxhound.blk
+++ b/data/mekfiles/smallcraft/Prototypes/TIG-40 Foxhound.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Ares Assault Craft Mark VII-C.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Ares Assault Craft Mark VII-C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Ares Assault Craft Mark VII.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Ares Assault Craft Mark VII.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Bus S-7AC.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Bus S-7AC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Dropshuttle K-1.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Dropshuttle K-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Dropshuttle K-1C.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Dropshuttle K-1C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Escape Pod.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Escape Pod.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Life Boat.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Life Boat.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Long-Range Shuttlecraft KR-61.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Long-Range Shuttlecraft KR-61.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Long-Range Shuttlecraft KR-61C.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Long-Range Shuttlecraft KR-61C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/NL-42 Battle Taxi.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/NL-42 Battle Taxi.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/S-7A Bus.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/S-7A Bus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Shuttle ST-46.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Shuttle ST-46.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3057r/Shuttle ST-46C.blk
+++ b/data/mekfiles/smallcraft/TRO 3057r/Shuttle ST-46C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3075/Aquarius Escort M1.blk
+++ b/data/mekfiles/smallcraft/TRO 3075/Aquarius Escort M1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3075/Aquarius Escort W1.blk
+++ b/data/mekfiles/smallcraft/TRO 3075/Aquarius Escort W1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3075/Aquarius Escort.blk
+++ b/data/mekfiles/smallcraft/TRO 3075/Aquarius Escort.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3075/Lyonesse Escort M1.blk
+++ b/data/mekfiles/smallcraft/TRO 3075/Lyonesse Escort M1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3075/Lyonesse Escort W1.blk
+++ b/data/mekfiles/smallcraft/TRO 3075/Lyonesse Escort W1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3075/Lyonesse Escort.blk
+++ b/data/mekfiles/smallcraft/TRO 3075/Lyonesse Escort.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3085/Ares Attack Craft Mark IX.blk
+++ b/data/mekfiles/smallcraft/TRO 3085/Ares Attack Craft Mark IX.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3145/Kurita/Oo-Suzumebachi.blk
+++ b/data/mekfiles/smallcraft/TRO 3145/Kurita/Oo-Suzumebachi.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3145/Liao/Zhen Niao.blk
+++ b/data/mekfiles/smallcraft/TRO 3145/Liao/Zhen Niao.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3145/Marik/Caerleon.blk
+++ b/data/mekfiles/smallcraft/TRO 3145/Marik/Caerleon.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3145/Merc/Condottiere Assault Craft.blk
+++ b/data/mekfiles/smallcraft/TRO 3145/Merc/Condottiere Assault Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3145/Merc/NL-45 Gunboat.blk
+++ b/data/mekfiles/smallcraft/TRO 3145/Merc/NL-45 Gunboat.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/TRO 3145/Steiner/Wurger Assault Craft.blk
+++ b/data/mekfiles/smallcraft/TRO 3145/Steiner/Wurger Assault Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Most Wanted/Mowang Courier (Clandestine).blk
+++ b/data/mekfiles/smallcraft/XTRO/Most Wanted/Mowang Courier (Clandestine).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Pirates/S7-P Scarab.blk
+++ b/data/mekfiles/smallcraft/XTRO/Pirates/S7-P Scarab.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Primitives II/Ares Assault Craft Mk.III.blk
+++ b/data/mekfiles/smallcraft/XTRO/Primitives II/Ares Assault Craft Mk.III.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Primitives II/Ares Close Assault Landing Craft Mk.II.blk
+++ b/data/mekfiles/smallcraft/XTRO/Primitives II/Ares Close Assault Landing Craft Mk.II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Primitives II/Ares Landing Craft Mk I.blk
+++ b/data/mekfiles/smallcraft/XTRO/Primitives II/Ares Landing Craft Mk I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Primitives IV/Intrepid Assault Craft (2331).blk
+++ b/data/mekfiles/smallcraft/XTRO/Primitives IV/Intrepid Assault Craft (2331).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/smallcraft/XTRO/Primitives IV/Intrepid Assault Craft (2478).blk
+++ b/data/mekfiles/smallcraft/XTRO/Primitives IV/Intrepid Assault Craft (2478).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/HB HL/Crucible Station.blk
+++ b/data/mekfiles/spacestation/HB HL/Crucible Station.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/HB HL/Hong Lung Interdiction Station.blk
+++ b/data/mekfiles/spacestation/HB HL/Hong Lung Interdiction Station.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/HB MPS/Snowden Mining Station Mk1.blk
+++ b/data/mekfiles/spacestation/HB MPS/Snowden Mining Station Mk1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/HB MPS/Snowden Mining Station.blk
+++ b/data/mekfiles/spacestation/HB MPS/Snowden Mining Station.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/Hist LOT I/M-9 SDS Battle Station 'Pavise'.blk
+++ b/data/mekfiles/spacestation/Hist LOT I/M-9 SDS Battle Station 'Pavise'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/JHS Terra/Drake SDS Control Station.blk
+++ b/data/mekfiles/spacestation/JHS Terra/Drake SDS Control Station.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Alliance Space Station (2713).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Alliance Space Station (2713).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Alliance Space Station (3061).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Alliance Space Station (3061).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Bastion System Defense Station (2584).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Bastion System Defense Station (2584).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Bastion System Defense Station (3058).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Bastion System Defense Station (3058).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Bastion System Defense Station (3091).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Bastion System Defense Station (3091).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/BattleSat System Defense Station (3089).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/BattleSat System Defense Station (3089).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/BattleSat System-Defense Station (3056).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/BattleSat System-Defense Station (3056).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Capitol System Defense Station (3051).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Capitol System Defense Station (3051).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Factory Medium Large (2400).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Factory Medium Large (2400).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Factory Medium Large (2750).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Factory Medium Large (2750).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Factory Small (2300).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Factory Small (2300).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Habitat  Small (2400).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Habitat  Small (2400).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Habitat  Small (2750).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Habitat  Small (2750).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Habitat Large (2500).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Habitat Large (2500).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Habitat Large (2750).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Habitat Large (2750).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Olympus Recharge Station (2663).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Olympus Recharge Station (2663).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Olympus Recharge Station (2942).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Olympus Recharge Station (2942).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Olympus Recharge Station (3072).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Olympus Recharge Station (3072).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Huge (2450).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Huge (2450).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Large (2400).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Large (2400).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Medium (2350).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Medium (2350).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Small (2200).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/Pressurized Yard - Small (2200).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Huge (2350).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Huge (2350).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Large (2300).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Large (2300).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Medium (2250).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Medium (2250).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Small (2100).blk
+++ b/data/mekfiles/spacestation/TRO 3057R/UnPressurized Yard - Small (2100).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/spacestation/ToS Gulf Breeze/Wheeler (2556).blk
+++ b/data/mekfiles/spacestation/ToS Gulf Breeze/Wheeler (2556).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/2750 IS Land/Puma Assault Tank PAT-001.blk
+++ b/data/mekfiles/vehicles/2750 IS Land/Puma Assault Tank PAT-001.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/2750 IS Land/Puma Assault Tank PAT-002.blk
+++ b/data/mekfiles/vehicles/2750 IS Land/Puma Assault Tank PAT-002.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Air Car.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Air Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Ground Car.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Ground Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Heavy Transport B1.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Heavy Transport B1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Hover Scout.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Hover Scout.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Hover Tank.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Jeep.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Jeep.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Jet Sled.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Jet Sled.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/MASH Truck (Small).blk
+++ b/data/mekfiles/vehicles/3025 IS Land/MASH Truck (Small).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Mobile Long Tom Artillery (Unofficial).blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Mobile Long Tom Artillery (Unofficial).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Speeder.blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Speeder.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3025 IS Land/Weapons Carrier A (LL).blk
+++ b/data/mekfiles/vehicles/3025 IS Land/Weapons Carrier A (LL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/AC2 Carrier.blk
+++ b/data/mekfiles/vehicles/3039u/AC2 Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Hover LRM).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Hover LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Hover MG).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Hover MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Hover SRM).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Hover SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Hover Sensors).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Hover Sensors).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Hover).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Hover).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Tracked LRM).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Tracked LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Tracked MG).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Tracked MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Tracked SRM).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Tracked SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Tracked).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Tracked).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Wheeled LRM).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Wheeled LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Wheeled MG).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Wheeled MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Wheeled SRM).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Wheeled SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/APC (Wheeled).blk
+++ b/data/mekfiles/vehicles/3039u/APC (Wheeled).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Axel Heavy Tank Mk 1.blk
+++ b/data/mekfiles/vehicles/3039u/Axel Heavy Tank Mk 1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Axel Heavy Tank Mk 2.blk
+++ b/data/mekfiles/vehicles/3039u/Axel Heavy Tank Mk 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Behemoth Heavy Tank (Armor).blk
+++ b/data/mekfiles/vehicles/3039u/Behemoth Heavy Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Behemoth Heavy Tank (Flamer).blk
+++ b/data/mekfiles/vehicles/3039u/Behemoth Heavy Tank (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Behemoth Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Behemoth Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Bulldog Medium Tank (AC2).blk
+++ b/data/mekfiles/vehicles/3039u/Bulldog Medium Tank (AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Bulldog Medium Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Bulldog Medium Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Bulldog Medium Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Bulldog Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank (Davion).blk
+++ b/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank (Davion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank (Flamer).blk
+++ b/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank (Liao).blk
+++ b/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank (Liao).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Condor Heavy Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Coolant Truck (Hover).blk
+++ b/data/mekfiles/vehicles/3039u/Coolant Truck (Hover).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Coolant Truck (Tracked).blk
+++ b/data/mekfiles/vehicles/3039u/Coolant Truck (Tracked).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Coolant Truck 135-K.blk
+++ b/data/mekfiles/vehicles/3039u/Coolant Truck 135-K.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Demolisher Heavy Tank (Defensive).blk
+++ b/data/mekfiles/vehicles/3039u/Demolisher Heavy Tank (Defensive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Demolisher Heavy Tank (Mk. I).blk
+++ b/data/mekfiles/vehicles/3039u/Demolisher Heavy Tank (Mk. I).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Demolisher Heavy Tank (Mk. II).blk
+++ b/data/mekfiles/vehicles/3039u/Demolisher Heavy Tank (Mk. II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Devastator Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Devastator Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Drillson Heavy Hover Tank (SRM).blk
+++ b/data/mekfiles/vehicles/3039u/Drillson Heavy Hover Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Drillson Heavy Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Drillson Heavy Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Engineering Vehicle (Autocannon).blk
+++ b/data/mekfiles/vehicles/3039u/Engineering Vehicle (Autocannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Engineering Vehicle (Flamer).blk
+++ b/data/mekfiles/vehicles/3039u/Engineering Vehicle (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Engineering Vehicle.blk
+++ b/data/mekfiles/vehicles/3039u/Engineering Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Ferret Light Scout VTOL (Armor) Wild Weasel.blk
+++ b/data/mekfiles/vehicles/3039u/Ferret Light Scout VTOL (Armor) Wild Weasel.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Ferret Light Scout VTOL (Cargo).blk
+++ b/data/mekfiles/vehicles/3039u/Ferret Light Scout VTOL (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Ferret Light Scout VTOL.blk
+++ b/data/mekfiles/vehicles/3039u/Ferret Light Scout VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Goblin Medium Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Goblin Medium Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Goblin Medium Tank (MG).blk
+++ b/data/mekfiles/vehicles/3039u/Goblin Medium Tank (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Goblin Medium Tank (SRM).blk
+++ b/data/mekfiles/vehicles/3039u/Goblin Medium Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Goblin Medium Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Goblin Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Harasser Laser Platform.blk
+++ b/data/mekfiles/vehicles/3039u/Harasser Laser Platform.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Harasser Missile Platform (Flamer).blk
+++ b/data/mekfiles/vehicles/3039u/Harasser Missile Platform (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Harasser Missile Platform (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Harasser Missile Platform (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Harasser Missile Platform (Mini-Peggy).blk
+++ b/data/mekfiles/vehicles/3039u/Harasser Missile Platform (Mini-Peggy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Harasser Missile Platform Leaping Lisa.blk
+++ b/data/mekfiles/vehicles/3039u/Harasser Missile Platform Leaping Lisa.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Harasser Missile Platform.blk
+++ b/data/mekfiles/vehicles/3039u/Harasser Missile Platform.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (AC10).blk
+++ b/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (AC10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (Laser).blk
+++ b/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (SRM).blk
+++ b/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (Scout).blk
+++ b/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun (Scout).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun.blk
+++ b/data/mekfiles/vehicles/3039u/Hetzer Wheeled Assault Gun.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hi-Scout Drone (NapFind).blk
+++ b/data/mekfiles/vehicles/3039u/Hi-Scout Drone (NapFind).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hi-Scout Drone (PathTrak).blk
+++ b/data/mekfiles/vehicles/3039u/Hi-Scout Drone (PathTrak).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hi-Scout Drone Carrier.blk
+++ b/data/mekfiles/vehicles/3039u/Hi-Scout Drone Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hunter Light Support Tank (Ammo).blk
+++ b/data/mekfiles/vehicles/3039u/Hunter Light Support Tank (Ammo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hunter Light Support Tank (LRM10).blk
+++ b/data/mekfiles/vehicles/3039u/Hunter Light Support Tank (LRM10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hunter Light Support Tank (LRM15).blk
+++ b/data/mekfiles/vehicles/3039u/Hunter Light Support Tank (LRM15).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Hunter Light Support Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Hunter Light Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport (Armor).blk
+++ b/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport (Fusion).blk
+++ b/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport (Fusion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport (Trailer).blk
+++ b/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport (Trailer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport.blk
+++ b/data/mekfiles/vehicles/3039u/J-27 Ordnance Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank (Flamer).blk
+++ b/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank (ICE).blk
+++ b/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank (MG).blk
+++ b/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/J. Edgar Light Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/K-27 Ordnance Transport (Killjoy).blk
+++ b/data/mekfiles/vehicles/3039u/K-27 Ordnance Transport (Killjoy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Karnov UR Gunship.blk
+++ b/data/mekfiles/vehicles/3039u/Karnov UR Gunship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Karnov UR Transport (AC).blk
+++ b/data/mekfiles/vehicles/3039u/Karnov UR Transport (AC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Karnov UR Transport (Artillery).blk
+++ b/data/mekfiles/vehicles/3039u/Karnov UR Transport (Artillery).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Karnov UR Transport.blk
+++ b/data/mekfiles/vehicles/3039u/Karnov UR Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/LRM Carrier.blk
+++ b/data/mekfiles/vehicles/3039u/LRM Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Laser Carrier.blk
+++ b/data/mekfiles/vehicles/3039u/Laser Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/MASH Truck (ICE).blk
+++ b/data/mekfiles/vehicles/3039u/MASH Truck (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/MASH Truck.blk
+++ b/data/mekfiles/vehicles/3039u/MASH Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Manticore Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Manticore Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Maxim Heavy Hover Transport (SRM2).blk
+++ b/data/mekfiles/vehicles/3039u/Maxim Heavy Hover Transport (SRM2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Maxim Heavy Hover Transport (SRM4).blk
+++ b/data/mekfiles/vehicles/3039u/Maxim Heavy Hover Transport (SRM4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Maxim Heavy Hover Transport.blk
+++ b/data/mekfiles/vehicles/3039u/Maxim Heavy Hover Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Headquarters (ICE - LL).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Headquarters (ICE - LL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Headquarters (ICE - LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Headquarters (ICE - LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Headquarters (ICE).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Headquarters (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Headquarters (LL).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Headquarters (LL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Headquarters (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Headquarters (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Headquarters.blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Headquarters.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Long Tom (Ammo Carriage).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Long Tom (Ammo Carriage).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Long Tom (Support Carriage).blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Long Tom (Support Carriage).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Mobile Long Tom LT-MOB-25.blk
+++ b/data/mekfiles/vehicles/3039u/Mobile Long Tom LT-MOB-25.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Monitor Naval Vessel.blk
+++ b/data/mekfiles/vehicles/3039u/Monitor Naval Vessel.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Neptune Submarine (LRT).blk
+++ b/data/mekfiles/vehicles/3039u/Neptune Submarine (LRT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Neptune Submarine (SRT).blk
+++ b/data/mekfiles/vehicles/3039u/Neptune Submarine (SRT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Neptune Submarine.blk
+++ b/data/mekfiles/vehicles/3039u/Neptune Submarine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Ontos Heavy Tank (Fusion).blk
+++ b/data/mekfiles/vehicles/3039u/Ontos Heavy Tank (Fusion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Ontos Heavy Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Ontos Heavy Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Ontos Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Ontos Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5 (ICE).blk
+++ b/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5 (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5 (ML).blk
+++ b/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5 (ML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5 (SRM2).blk
+++ b/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5 (SRM2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5.blk
+++ b/data/mekfiles/vehicles/3039u/Packrat LRPV PKR-T5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Partisan Heavy Tank (AC2).blk
+++ b/data/mekfiles/vehicles/3039u/Partisan Heavy Tank (AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Partisan Heavy Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Partisan Heavy Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Partisan Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Partisan Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Patton Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Patton Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank (Missile).blk
+++ b/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank (Missile).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank (Sensors).blk
+++ b/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank (Sensors).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank (Unarmed).blk
+++ b/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank (Unarmed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Pegasus Scout Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pike Support Vehicle (AC5).blk
+++ b/data/mekfiles/vehicles/3039u/Pike Support Vehicle (AC5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pike Support Vehicle (Missile).blk
+++ b/data/mekfiles/vehicles/3039u/Pike Support Vehicle (Missile).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Pike Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3039u/Pike Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Rommel Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Rommel Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/SRM Carrier.blk
+++ b/data/mekfiles/vehicles/3039u/SRM Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Saladin Assault Hover Tank (Armor).blk
+++ b/data/mekfiles/vehicles/3039u/Saladin Assault Hover Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Saladin Assault Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Saladin Assault Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Saracen Medium Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Saracen Medium Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Savannah Master Hovercraft (SL).blk
+++ b/data/mekfiles/vehicles/3039u/Savannah Master Hovercraft (SL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Savannah Master Hovercraft.blk
+++ b/data/mekfiles/vehicles/3039u/Savannah Master Hovercraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Schrek PPC Carrier (Anti-Infantry).blk
+++ b/data/mekfiles/vehicles/3039u/Schrek PPC Carrier (Anti-Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Schrek PPC Carrier.blk
+++ b/data/mekfiles/vehicles/3039u/Schrek PPC Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Scimitar Medium Hover Tank (Missile).blk
+++ b/data/mekfiles/vehicles/3039u/Scimitar Medium Hover Tank (Missile).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Scimitar Medium Hover Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Scimitar Medium Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Scorpion Light Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Scorpion Light Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Scorpion Light Tank (ML).blk
+++ b/data/mekfiles/vehicles/3039u/Scorpion Light Tank (ML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Scorpion Light Tank (SRM).blk
+++ b/data/mekfiles/vehicles/3039u/Scorpion Light Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Scorpion Light Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Scorpion Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Sea Skimmer Hydrofoil (SRM2).blk
+++ b/data/mekfiles/vehicles/3039u/Sea Skimmer Hydrofoil (SRM2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Sea Skimmer Hydrofoil (SRM6).blk
+++ b/data/mekfiles/vehicles/3039u/Sea Skimmer Hydrofoil (SRM6).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Sea Skimmer Hydrofoil.blk
+++ b/data/mekfiles/vehicles/3039u/Sea Skimmer Hydrofoil.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Skulker Wheeled Scout Tank (MG).blk
+++ b/data/mekfiles/vehicles/3039u/Skulker Wheeled Scout Tank (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Skulker Wheeled Scout Tank (SRM).blk
+++ b/data/mekfiles/vehicles/3039u/Skulker Wheeled Scout Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Skulker Wheeled Scout Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Skulker Wheeled Scout Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Striker Light Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3039u/Striker Light Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Striker Light Tank (SRM).blk
+++ b/data/mekfiles/vehicles/3039u/Striker Light Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Striker Light Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Striker Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Swift Wind Scout Car (ICE - Cargo).blk
+++ b/data/mekfiles/vehicles/3039u/Swift Wind Scout Car (ICE - Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Swift Wind Scout Car (ICE - Speed).blk
+++ b/data/mekfiles/vehicles/3039u/Swift Wind Scout Car (ICE - Speed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Swift Wind Scout Car (ICE).blk
+++ b/data/mekfiles/vehicles/3039u/Swift Wind Scout Car (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Swift Wind Scout Car.blk
+++ b/data/mekfiles/vehicles/3039u/Swift Wind Scout Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Vedette Medium Tank (AC2).blk
+++ b/data/mekfiles/vehicles/3039u/Vedette Medium Tank (AC2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Vedette Medium Tank (Liao).blk
+++ b/data/mekfiles/vehicles/3039u/Vedette Medium Tank (Liao).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Vedette Medium Tank.blk
+++ b/data/mekfiles/vehicles/3039u/Vedette Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Von Luckner Heavy Tank VNL-K100.blk
+++ b/data/mekfiles/vehicles/3039u/Von Luckner Heavy Tank VNL-K100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Von Luckner Heavy Tank VNL-K65N.blk
+++ b/data/mekfiles/vehicles/3039u/Von Luckner Heavy Tank VNL-K65N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Von Luckner Heavy Tank VNL-K70.blk
+++ b/data/mekfiles/vehicles/3039u/Von Luckner Heavy Tank VNL-K70.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Warrior H-7 Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3039u/Warrior H-7 Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Warrior H-7A Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3039u/Warrior H-7A Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3039u/Warrior H-7C Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3039u/Warrior H-7C Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Beagle Hover Scout (C3i).blk
+++ b/data/mekfiles/vehicles/3050U/Beagle Hover Scout (C3i).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Beagle Hover Scout (TAG).blk
+++ b/data/mekfiles/vehicles/3050U/Beagle Hover Scout (TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Beagle.blk
+++ b/data/mekfiles/vehicles/3050U/Beagle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Burke Defense Tank (HPPC).blk
+++ b/data/mekfiles/vehicles/3050U/Burke Defense Tank (HPPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Burke Defense Tank.blk
+++ b/data/mekfiles/vehicles/3050U/Burke Defense Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Chaparral (ERML).blk
+++ b/data/mekfiles/vehicles/3050U/Chaparral (ERML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Chaparral (MG).blk
+++ b/data/mekfiles/vehicles/3050U/Chaparral (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Chaparral (SRM).blk
+++ b/data/mekfiles/vehicles/3050U/Chaparral (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Chaparral.blk
+++ b/data/mekfiles/vehicles/3050U/Chaparral.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Cyrano Gunship (ML).blk
+++ b/data/mekfiles/vehicles/3050U/Cyrano Gunship (ML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Cyrano Gunship (Plasma).blk
+++ b/data/mekfiles/vehicles/3050U/Cyrano Gunship (Plasma).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Cyrano Gunship.blk
+++ b/data/mekfiles/vehicles/3050U/Cyrano Gunship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Demon Tank (HGR).blk
+++ b/data/mekfiles/vehicles/3050U/Demon Tank (HGR).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Demon Tank (Horned Demon).blk
+++ b/data/mekfiles/vehicles/3050U/Demon Tank (Horned Demon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Demon Tank.blk
+++ b/data/mekfiles/vehicles/3050U/Demon Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Fury Command Tank (C3M).blk
+++ b/data/mekfiles/vehicles/3050U/Fury Command Tank (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Fury Command Tank (C3S).blk
+++ b/data/mekfiles/vehicles/3050U/Fury Command Tank (C3S).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Fury Command Tank (Fury II).blk
+++ b/data/mekfiles/vehicles/3050U/Fury Command Tank (Fury II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Fury Command Tank.blk
+++ b/data/mekfiles/vehicles/3050U/Fury Command Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Gabriel Reconnaissance Hovercraft (ERSL).blk
+++ b/data/mekfiles/vehicles/3050U/Gabriel Reconnaissance Hovercraft (ERSL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Gabriel Reconnaissance Hovercraft (TDF).blk
+++ b/data/mekfiles/vehicles/3050U/Gabriel Reconnaissance Hovercraft (TDF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Gabriel Reconnaissance Hovercraft.blk
+++ b/data/mekfiles/vehicles/3050U/Gabriel Reconnaissance Hovercraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Kanga Medium Hovertank.blk
+++ b/data/mekfiles/vehicles/3050U/Kanga Medium Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft (ERML).blk
+++ b/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft (ERML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft (ERSL).blk
+++ b/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft (ERSL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft (RL).blk
+++ b/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft (RL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft.blk
+++ b/data/mekfiles/vehicles/3050U/Lightning Attack Hovercraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Magi Infantry Support Vehicle (UCSV).blk
+++ b/data/mekfiles/vehicles/3050U/Magi Infantry Support Vehicle (UCSV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Magi Infantry Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3050U/Magi Infantry Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Marksman Artillery Vehicle (Light PPC).blk
+++ b/data/mekfiles/vehicles/3050U/Marksman Artillery Vehicle (Light PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Marksman Artillery Vehicle.blk
+++ b/data/mekfiles/vehicles/3050U/Marksman Artillery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL (Armor).blk
+++ b/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL (LAC).blk
+++ b/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL (LAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL (Light PPC).blk
+++ b/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL (Light PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL.blk
+++ b/data/mekfiles/vehicles/3050U/Nightshade ECM VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Puma Assault Tank PAT-005.blk
+++ b/data/mekfiles/vehicles/3050U/Puma Assault Tank PAT-005.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Puma Assault Tank PAT-007.blk
+++ b/data/mekfiles/vehicles/3050U/Puma Assault Tank PAT-007.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Puma Assault Tank PAT-008.blk
+++ b/data/mekfiles/vehicles/3050U/Puma Assault Tank PAT-008.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (Flamer).blk
+++ b/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (MG).blk
+++ b/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (ML).blk
+++ b/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (ML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (SL).blk
+++ b/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank (SL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank.blk
+++ b/data/mekfiles/vehicles/3050U/Rhino Fire Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (ERML).blk
+++ b/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (ERML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (Infantry).blk
+++ b/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (LPPC).blk
+++ b/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (LPPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (MG).blk
+++ b/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (SPL).blk
+++ b/data/mekfiles/vehicles/3050U/Ripper Infantry Transport (SPL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Ripper Infantry Transport.blk
+++ b/data/mekfiles/vehicles/3050U/Ripper Infantry Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Rotunda Scout Vehicle.blk
+++ b/data/mekfiles/vehicles/3050U/Rotunda Scout Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Thor Artillery Vehicle (C3i).blk
+++ b/data/mekfiles/vehicles/3050U/Thor Artillery Vehicle (C3i).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Thor Artillery Vehicle (Clan).blk
+++ b/data/mekfiles/vehicles/3050U/Thor Artillery Vehicle (Clan).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Thor Artillery Vehicle.blk
+++ b/data/mekfiles/vehicles/3050U/Thor Artillery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Zephyr Hovertank (C3i).blk
+++ b/data/mekfiles/vehicles/3050U/Zephyr Hovertank (C3i).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Zephyr Hovertank (LRM).blk
+++ b/data/mekfiles/vehicles/3050U/Zephyr Hovertank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3050U/Zephyr Hovertank.blk
+++ b/data/mekfiles/vehicles/3050U/Zephyr Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/AC 2 Carrier (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/AC 2 Carrier (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk III.blk
+++ b/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk III.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk IV.blk
+++ b/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk IV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk VI.blk
+++ b/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk VI.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk VII.blk
+++ b/data/mekfiles/vehicles/3058Uu/Alacorn Heavy Tank Mk VII.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Axel Heavy Tank IIC (XL).blk
+++ b/data/mekfiles/vehicles/3058Uu/Axel Heavy Tank IIC (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Axel Heavy Tank IIC.blk
+++ b/data/mekfiles/vehicles/3058Uu/Axel Heavy Tank IIC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport A.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport B.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport C.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport D.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport E.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport F.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport H.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport H.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport Prime.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger (C) Tracked Transport Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport A.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport B.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport C.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport D.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport E.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport F.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport G.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport Prime.blk
+++ b/data/mekfiles/vehicles/3058Uu/Badger Tracked Transport Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft A.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft B.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft C.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft D.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft E.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft F.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft G.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft H.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft H.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft Prime.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit (C) Hovercraft Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft A.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft B.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft C.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft D.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft E.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft F.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft G.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft H.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft H.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft I.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft Prime.blk
+++ b/data/mekfiles/vehicles/3058Uu/Bandit Hovercraft Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Blizzard Hover Transport (SRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Blizzard Hover Transport (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Blizzard Hover Transport Black Blizzard.blk
+++ b/data/mekfiles/vehicles/3058Uu/Blizzard Hover Transport Black Blizzard.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Blizzard Hover Transport.blk
+++ b/data/mekfiles/vehicles/3058Uu/Blizzard Hover Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank (PPC 2).blk
+++ b/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank (PPC 2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank (PPC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank (PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Brutus Assault Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (Infantry).blk
+++ b/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (LRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (SRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (TAG).blk
+++ b/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter (TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3058Uu/Cavalry Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Centipede Scout Car (SRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Centipede Scout Car (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Centipede Scout Car (TAG).blk
+++ b/data/mekfiles/vehicles/3058Uu/Centipede Scout Car (TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Centipede Scout Car.blk
+++ b/data/mekfiles/vehicles/3058Uu/Centipede Scout Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Challenger X MBT.blk
+++ b/data/mekfiles/vehicles/3058Uu/Challenger X MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Challenger XI MBT.blk
+++ b/data/mekfiles/vehicles/3058Uu/Challenger XI MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Challenger XII MBT.blk
+++ b/data/mekfiles/vehicles/3058Uu/Challenger XII MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Fulcrum Heavy Hovertank II.blk
+++ b/data/mekfiles/vehicles/3058Uu/Fulcrum Heavy Hovertank II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Fulcrum Heavy Hovertank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Fulcrum Heavy Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-100.blk
+++ b/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-102.blk
+++ b/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-102.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-103.blk
+++ b/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-103.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-104.blk
+++ b/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-104.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-200.blk
+++ b/data/mekfiles/vehicles/3058Uu/Galleon Light Tank GAL-200.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Goblin II Infantry Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3058Uu/Goblin II Infantry Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Goblin Infantry Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3058Uu/Goblin Infantry Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Hetzer Wheeled Assault Gun (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/Hetzer Wheeled Assault Gun (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank (3054 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank (3054 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank (ERLL).blk
+++ b/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank (ERLL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank (LPL).blk
+++ b/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank (LPL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank Assault Hunter.blk
+++ b/data/mekfiles/vehicles/3058Uu/Hunter Light Support Tank Assault Hunter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Karnov UR Transport (3055 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Karnov UR Transport (3055 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Karnov UR Transport (BA).blk
+++ b/data/mekfiles/vehicles/3058Uu/Karnov UR Transport (BA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Karnov UR Transport (Periphery).blk
+++ b/data/mekfiles/vehicles/3058Uu/Karnov UR Transport (Periphery).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (Clan).blk
+++ b/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (Clan).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (ML).blk
+++ b/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (ML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (MedEvac).blk
+++ b/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (MedEvac).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (SL).blk
+++ b/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (SL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (SRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Kestrel VTOL (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Kestrel VTOL.blk
+++ b/data/mekfiles/vehicles/3058Uu/Kestrel VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/LRM Carrier (3055 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/LRM Carrier (3055 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/LRM Carrier (WoB).blk
+++ b/data/mekfiles/vehicles/3058Uu/LRM Carrier (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/MRM Carrier.blk
+++ b/data/mekfiles/vehicles/3058Uu/MRM Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (3055 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (3055 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (C3M).blk
+++ b/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (C3S).blk
+++ b/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (C3S).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Manticore Heavy Tank (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (BA).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (BA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (Basic).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (Basic).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (Fusion).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (Fusion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (Intermediate).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (Intermediate).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (MG).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maultier Hover APC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maultier Hover APC.blk
+++ b/data/mekfiles/vehicles/3058Uu/Maultier Hover APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim (I) Heavy Hover Transport (Company Command).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim (I) Heavy Hover Transport (Company Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim (I) Heavy Hover Transport.blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim (I) Heavy Hover Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (3052 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (3052 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (Anti-Personnel).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (Anti-Personnel).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (BA Factory Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (BA Factory Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (BA Field Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (BA Field Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (C3M).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (C3S).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (C3S).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (Clan).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (Clan).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (Fire Support).blk
+++ b/data/mekfiles/vehicles/3058Uu/Maxim Heavy Hover Transport (Fire Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Ontos Heavy Tank (3053 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Ontos Heavy Tank (3053 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Ontos Heavy Tank (Light Gauss).blk
+++ b/data/mekfiles/vehicles/3058Uu/Ontos Heavy Tank (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Padilla Heavy Artillery Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Padilla Heavy Artillery Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Padilla Heavy Artillery Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Padilla Heavy Artillery Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (Company Command).blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (Company Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (Lance Command).blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (Lance Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (Quad RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (Quad RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (XL).blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Air Defense Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Partisan Heavy Tank (C3).blk
+++ b/data/mekfiles/vehicles/3058Uu/Partisan Heavy Tank (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Patton Tank (Ultra).blk
+++ b/data/mekfiles/vehicles/3058Uu/Patton Tank (Ultra).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Pegasus Scout Hover Tank (3058 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Pegasus Scout Hover Tank (3058 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Pegasus Scout Hover Tank (C3).blk
+++ b/data/mekfiles/vehicles/3058Uu/Pegasus Scout Hover Tank (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Pegasus Scout Hover Tank (MRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Pegasus Scout Hover Tank (MRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Peregrine Attack VTOL (Cargo).blk
+++ b/data/mekfiles/vehicles/3058Uu/Peregrine Attack VTOL (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Peregrine Attack VTOL (Kurita).blk
+++ b/data/mekfiles/vehicles/3058Uu/Peregrine Attack VTOL (Kurita).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Peregrine Attack VTOL.blk
+++ b/data/mekfiles/vehicles/3058Uu/Peregrine Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Pilum Heavy Tank (Arrow IV).blk
+++ b/data/mekfiles/vehicles/3058Uu/Pilum Heavy Tank (Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Pilum Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Pilum Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Plainsman Medium Hovertank (SSRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Plainsman Medium Hovertank (SSRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Plainsman Medium Hovertank (Scout).blk
+++ b/data/mekfiles/vehicles/3058Uu/Plainsman Medium Hovertank (Scout).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Plainsman Medium Hovertank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Plainsman Medium Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Po Heavy Tank (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/Po Heavy Tank (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Po Heavy Tank (Light Gauss).blk
+++ b/data/mekfiles/vehicles/3058Uu/Po Heavy Tank (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Po Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Po Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Regulator Hovertank (Arrow IV).blk
+++ b/data/mekfiles/vehicles/3058Uu/Regulator Hovertank (Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Regulator Hovertank (RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Regulator Hovertank (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Regulator Hovertank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Regulator Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Rommel Tank (Gauss).blk
+++ b/data/mekfiles/vehicles/3058Uu/Rommel Tank (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/SRM Carrier (3054 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/SRM Carrier (3054 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/SRM Carrier (C3).blk
+++ b/data/mekfiles/vehicles/3058Uu/SRM Carrier (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/SRM Carrier (WoB).blk
+++ b/data/mekfiles/vehicles/3058Uu/SRM Carrier (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Saladin Assault Hover Tank (Clan Cargo).blk
+++ b/data/mekfiles/vehicles/3058Uu/Saladin Assault Hover Tank (Clan Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Saladin Assault Hover Tank (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/Saladin Assault Hover Tank (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Saladin Assault Hover Tank (Ultra).blk
+++ b/data/mekfiles/vehicles/3058Uu/Saladin Assault Hover Tank (Ultra).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Saracen Medium Hover Tank (MRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Saracen Medium Hover Tank (MRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Scimitar Medium Hover Tank (TAG).blk
+++ b/data/mekfiles/vehicles/3058Uu/Scimitar Medium Hover Tank (TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (C3).blk
+++ b/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (C3i).blk
+++ b/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (C3i).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (Laser).blk
+++ b/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (Troop Transport).blk
+++ b/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter (Troop Transport).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter.blk
+++ b/data/mekfiles/vehicles/3058Uu/Sprint Scout Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Striker Light Tank (3053 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Striker Light Tank (3053 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Striker Light Tank (3061 Upgrade).blk
+++ b/data/mekfiles/vehicles/3058Uu/Striker Light Tank (3061 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Striker Light Tank (Ammo).blk
+++ b/data/mekfiles/vehicles/3058Uu/Striker Light Tank (Ammo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Striker Light Tank (Laser).blk
+++ b/data/mekfiles/vehicles/3058Uu/Striker Light Tank (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Striker Light Tank (Narc).blk
+++ b/data/mekfiles/vehicles/3058Uu/Striker Light Tank (Narc).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank (C3).blk
+++ b/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank (MRM).blk
+++ b/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank (MRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank (Streak).blk
+++ b/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank (Streak).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank TKG-150.blk
+++ b/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank TKG-150.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank TKG-151.blk
+++ b/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank TKG-151.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Tokugawa Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle (RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle (Tracked).blk
+++ b/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle (Tracked).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle.blk
+++ b/data/mekfiles/vehicles/3058Uu/Typhoon Urban Assault Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (LB-X).blk
+++ b/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (Light Gauss).blk
+++ b/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (NETC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (NETC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (Ultra).blk
+++ b/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank (Ultra).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank Doris Delight.blk
+++ b/data/mekfiles/vehicles/3058Uu/Vedette Medium Tank Doris Delight.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Warrior H-10 Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3058Uu/Warrior H-10 Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Warrior H-8 Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3058Uu/Warrior H-8 Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Warrior H-9 Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/3058Uu/Warrior H-9 Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship (Ammo).blk
+++ b/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship (Ammo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship (Arrow IV).blk
+++ b/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship (Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship (RAC).blk
+++ b/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship.blk
+++ b/data/mekfiles/vehicles/3058Uu/Yellow Jacket Gunship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Zhukov Heavy Tank (WoB).blk
+++ b/data/mekfiles/vehicles/3058Uu/Zhukov Heavy Tank (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3058Uu/Zhukov Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3058Uu/Zhukov Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Anhur Transport (BA).blk
+++ b/data/mekfiles/vehicles/3060u/Anhur Transport (BA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Anhur Transport.blk
+++ b/data/mekfiles/vehicles/3060u/Anhur Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ares Medium Tank (Plasma).blk
+++ b/data/mekfiles/vehicles/3060u/Ares Medium Tank (Plasma).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ares Medium Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Ares Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Asshur Artillery Spotter.blk
+++ b/data/mekfiles/vehicles/3060u/Asshur Artillery Spotter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Asshur Fast Reconnaissance Vehicle (PAC).blk
+++ b/data/mekfiles/vehicles/3060u/Asshur Fast Reconnaissance Vehicle (PAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Asshur Fast Reconnaissance Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Asshur Fast Reconnaissance Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Athena Combat Vehicle (HAG).blk
+++ b/data/mekfiles/vehicles/3060u/Athena Combat Vehicle (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Athena Combat Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Athena Combat Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/BattleMech Recovery Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/BattleMech Recovery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Chevalier Light Tank (BAP).blk
+++ b/data/mekfiles/vehicles/3060u/Chevalier Light Tank (BAP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Chevalier Light Tank (MML).blk
+++ b/data/mekfiles/vehicles/3060u/Chevalier Light Tank (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Chevalier Light Tank (Speed).blk
+++ b/data/mekfiles/vehicles/3060u/Chevalier Light Tank (Speed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Chevalier Light Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Chevalier Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Demolisher II Heavy Tank (Thunderbolt).blk
+++ b/data/mekfiles/vehicles/3060u/Demolisher II Heavy Tank (Thunderbolt).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Demolisher II Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Demolisher II Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Donar Assault Helicopter (Close Support).blk
+++ b/data/mekfiles/vehicles/3060u/Donar Assault Helicopter (Close Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Donar Assault Helicopter (Recon).blk
+++ b/data/mekfiles/vehicles/3060u/Donar Assault Helicopter (Recon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Donar Assault Helicopter.blk
+++ b/data/mekfiles/vehicles/3060u/Donar Assault Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank A.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank B.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank C.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank D.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank E.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Epona Pursuit Tank Prime.blk
+++ b/data/mekfiles/vehicles/3060u/Epona Pursuit Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Flatbed Truck (AC).blk
+++ b/data/mekfiles/vehicles/3060u/Flatbed Truck (AC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Flatbed Truck (Armor).blk
+++ b/data/mekfiles/vehicles/3060u/Flatbed Truck (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Flatbed Truck (Mortar).blk
+++ b/data/mekfiles/vehicles/3060u/Flatbed Truck (Mortar).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Flatbed Truck (SRM).blk
+++ b/data/mekfiles/vehicles/3060u/Flatbed Truck (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Flatbed Truck.blk
+++ b/data/mekfiles/vehicles/3060u/Flatbed Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Gladius Medium Hover Tank Mk II.blk
+++ b/data/mekfiles/vehicles/3060u/Gladius Medium Hover Tank Mk II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Gladius Medium Hover Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Gladius Medium Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Hachiman Fire Support Tank (AAA).blk
+++ b/data/mekfiles/vehicles/3060u/Hachiman Fire Support Tank (AAA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Hachiman Fire Support Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Hachiman Fire Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Hawk Moth Gunship (Armor).blk
+++ b/data/mekfiles/vehicles/3060u/Hawk Moth Gunship (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Hawk Moth Gunship (Thunderbolt).blk
+++ b/data/mekfiles/vehicles/3060u/Hawk Moth Gunship (Thunderbolt).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Hawk Moth Gunship.blk
+++ b/data/mekfiles/vehicles/3060u/Hawk Moth Gunship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy BattleMech Recovery Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Heavy BattleMech Recovery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Hover APC (LRM).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Hover APC (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Hover APC (MG).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Hover APC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Hover APC (SRM).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Hover APC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Hover APC (Scout Tank).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Hover APC (Scout Tank).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Hover APC.blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Hover APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy LRM Carrier.blk
+++ b/data/mekfiles/vehicles/3060u/Heavy LRM Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy MML Carrier.blk
+++ b/data/mekfiles/vehicles/3060u/Heavy MML Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Tracked APC (LRM).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Tracked APC (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Tracked APC (MG).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Tracked APC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Tracked APC (SRM).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Tracked APC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Tracked APC.blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Tracked APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (LRM).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (MG).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (SRM).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (WoB).blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Wheeled APC (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Heavy Wheeled APC.blk
+++ b/data/mekfiles/vehicles/3060u/Heavy Wheeled APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Huitzilopochtli Assault Tank 'Huey' (AAA).blk
+++ b/data/mekfiles/vehicles/3060u/Huitzilopochtli Assault Tank 'Huey' (AAA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Huitzilopochtli Assault Tank 'Huey'.blk
+++ b/data/mekfiles/vehicles/3060u/Huitzilopochtli Assault Tank 'Huey'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Indra Infantry Transport (BA).blk
+++ b/data/mekfiles/vehicles/3060u/Indra Infantry Transport (BA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Indra Infantry Transport.blk
+++ b/data/mekfiles/vehicles/3060u/Indra Infantry Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ishtar Heavy Fire Support Tank (Gauss).blk
+++ b/data/mekfiles/vehicles/3060u/Ishtar Heavy Fire Support Tank (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ishtar Heavy Fire Support Tank (Original).blk
+++ b/data/mekfiles/vehicles/3060u/Ishtar Heavy Fire Support Tank (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ishtar Heavy Fire Support Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Ishtar Heavy Fire Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ku Wheeled Assault Tank (IFV).blk
+++ b/data/mekfiles/vehicles/3060u/Ku Wheeled Assault Tank (IFV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Ku Wheeled Assault Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Ku Wheeled Assault Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Light SRM Carrier.blk
+++ b/data/mekfiles/vehicles/3060u/Light SRM Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Light Thunderbolt Carrier.blk
+++ b/data/mekfiles/vehicles/3060u/Light Thunderbolt Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mantis Light Attack VTOL (ECCM).blk
+++ b/data/mekfiles/vehicles/3060u/Mantis Light Attack VTOL (ECCM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mantis Light Attack VTOL.blk
+++ b/data/mekfiles/vehicles/3060u/Mantis Light Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mars Assault Vehicle (ATM).blk
+++ b/data/mekfiles/vehicles/3060u/Mars Assault Vehicle (ATM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mars Assault Vehicle (HAG).blk
+++ b/data/mekfiles/vehicles/3060u/Mars Assault Vehicle (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mars Assault Vehicle (XL).blk
+++ b/data/mekfiles/vehicles/3060u/Mars Assault Vehicle (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mars Assault Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Mars Assault Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mithras Light Tank (ERLL).blk
+++ b/data/mekfiles/vehicles/3060u/Mithras Light Tank (ERLL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Mithras Light Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Mithras Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Myrmidon Medium Tank Type 2.blk
+++ b/data/mekfiles/vehicles/3060u/Myrmidon Medium Tank Type 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Myrmidon Medium Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Myrmidon Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Odin Scout Tank (Spotter).blk
+++ b/data/mekfiles/vehicles/3060u/Odin Scout Tank (Spotter).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Odin Scout Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Odin Scout Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Oro Heavy Tank (HAG).blk
+++ b/data/mekfiles/vehicles/3060u/Oro Heavy Tank (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Oro Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Oro Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Pinto Attack VTOL (WoB).blk
+++ b/data/mekfiles/vehicles/3060u/Pinto Attack VTOL (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Pinto Attack VTOL.blk
+++ b/data/mekfiles/vehicles/3060u/Pinto Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform A.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform B.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform C.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform D.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform E.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform F.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform Prime.blk
+++ b/data/mekfiles/vehicles/3060u/Schiltron Mobile Fire-Support Platform Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Shamash Reconnaissance Vehicle (Flamer).blk
+++ b/data/mekfiles/vehicles/3060u/Shamash Reconnaissance Vehicle (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Shamash Reconnaissance Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Shamash Reconnaissance Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle (ATM).blk
+++ b/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle (ATM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle (Original).blk
+++ b/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle.blk
+++ b/data/mekfiles/vehicles/3060u/Svantovit Infantry Fighting Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Zorya Light Tank (ATM).blk
+++ b/data/mekfiles/vehicles/3060u/Zorya Light Tank (ATM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Zorya Light Tank (Ammo).blk
+++ b/data/mekfiles/vehicles/3060u/Zorya Light Tank (Ammo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3060u/Zorya Light Tank.blk
+++ b/data/mekfiles/vehicles/3060u/Zorya Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Enyo Strike Tank Sholef.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Enyo Strike Tank Sholef.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Heimdall Ground Monitor Tank B.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Heimdall Ground Monitor Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Heimdall Ground Monitor Tank C.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Heimdall Ground Monitor Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Hephaestus Scout Tank D.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Hephaestus Scout Tank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Morrigu Fire Support Vehicle (HAG).blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Morrigu Fire Support Vehicle (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Shoden Assault Vehicle LB-X.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Shoden Assault Vehicle LB-X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Tyr Infantry Support Tank (Kurita).blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/Clan Vehicles/Tyr Infantry Support Tank (Kurita).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank C.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank D.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Fortune Wheeled Assault Vehicle [Thunderbolt].blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Fortune Wheeled Assault Vehicle [Thunderbolt].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Glaive Medium Tank (MFB).blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Glaive Medium Tank (MFB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Glory Heavy Fire Support Vehicle [Arrow IV].blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Glory Heavy Fire Support Vehicle [Arrow IV].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Main Gauche Light Support Tank IFV.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Main Gauche Light Support Tank IFV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank C.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank D.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Minion Advanced Tactical Vehicle Magshot.blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Minion Advanced Tactical Vehicle Magshot.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Morningstar City Command Vehicle [HPG].blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Morningstar City Command Vehicle [HPG].blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Musketeer Hover Tank (3080 Upgrade).blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Musketeer Hover Tank (3080 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Stygian Strike Tank (WOB).blk
+++ b/data/mekfiles/vehicles/3067 Unabridged/IS Vehicles/Stygian Strike Tank (WOB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Enyo Strike Tank.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Enyo Strike Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Heimdall Ground Monitor Tank A.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Heimdall Ground Monitor Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Heimdall Ground Monitor Tank Prime.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Heimdall Ground Monitor Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank A.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank B.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank C.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank Prime.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Morrigu Fire Support Vehicle (Laser).blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Morrigu Fire Support Vehicle (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Morrigu Fire Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Morrigu Fire Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Shoden Assault Vehicle (SSRM).blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Shoden Assault Vehicle (SSRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Shoden Assault Vehicle.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Shoden Assault Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 Clan Land/Tyr Infantry Support Tank.blk
+++ b/data/mekfiles/vehicles/3067/3067 Clan Land/Tyr Infantry Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Ajax Assault Tank A.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Ajax Assault Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Ajax Assault Tank B.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Ajax Assault Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Ajax Assault Tank Prime.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Ajax Assault Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Fortune Wheeled Assault Vehicle.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Fortune Wheeled Assault Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Glaive Medium Tank.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Glaive Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Glory Heavy Fire Support Vehicle (Light Gauss).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Glory Heavy Fire Support Vehicle (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Glory Heavy Fire Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Glory Heavy Fire Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Main Gauche Light Support Tank (C3).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Main Gauche Light Support Tank (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Main Gauche Light Support Tank (XL).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Main Gauche Light Support Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Main Gauche Light Support Tank.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Main Gauche Light Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank A.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank B.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank Prime.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Minion Advanced Tactical Vehicle (TAG).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Minion Advanced Tactical Vehicle (TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Minion Advanced Tactical Vehicle (Targeting Computer).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Minion Advanced Tactical Vehicle (Targeting Computer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Minion Advanced Tactical Vehicle.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Minion Advanced Tactical Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Morningstar City Command Vehicle (Company Command).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Morningstar City Command Vehicle (Company Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Morningstar City Command Vehicle (Laser).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Morningstar City Command Vehicle (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Morningstar City Command Vehicle.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Morningstar City Command Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Musketeer Hover Tank (Armor).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Musketeer Hover Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Musketeer Hover Tank.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Musketeer Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Stygian Strike Tank (Armor).blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Stygian Strike Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3067/3067 IS Land/Stygian Strike Tank.blk
+++ b/data/mekfiles/vehicles/3067/3067 IS Land/Stygian Strike Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Buffel VII Engineering Support Vehicle (Cargo).blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Buffel VII Engineering Support Vehicle (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Buffel VII Engineering Support Vehicle Reverse.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Buffel VII Engineering Support Vehicle Reverse.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Buffel VII Engineering Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Buffel VII Engineering Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Buffel VIII Engineering Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Buffel VIII Engineering Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Dromedary Water Transport.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Dromedary Water Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) DeConAid Trailer.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) DeConAid Trailer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) Oppie O-65.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) Oppie O-65.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) Oppie O-66.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) Oppie O-66.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) Salvage Bed.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/HMRV (Hazardous Materials Recovery Vehicle) Salvage Bed.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (Hoist).blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (Hoist).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (MG).blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (ML).blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (ML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (Q-Vehicle).blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50 (Q-Vehicle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Jifty Transportable Field Repair Unit JI-50.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Merkava Heavy Tank Mk VII.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Merkava Heavy Tank Mk VII.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Paramour Mobile Repair Vehicle (MFB).blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Paramour Mobile Repair Vehicle (MFB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Paramour Mobile Repair Vehicle.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Paramour Mobile Repair Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Prometheus Combat Support Bridgelayer.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Prometheus Combat Support Bridgelayer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075 Support tanks/Transportable Field Repair Unit Nifty.blk
+++ b/data/mekfiles/vehicles/3075 Support tanks/Transportable Field Repair Unit Nifty.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Bellona  Hover Tank (Laser).blk
+++ b/data/mekfiles/vehicles/3075/Bellona  Hover Tank (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Bellona Hover Tank.blk
+++ b/data/mekfiles/vehicles/3075/Bellona Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Cobra Transport VTOL (Command).blk
+++ b/data/mekfiles/vehicles/3075/Cobra Transport VTOL (Command).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Cobra Transport VTOL (MASH.).blk
+++ b/data/mekfiles/vehicles/3075/Cobra Transport VTOL (MASH.).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Cobra Transport VTOL (Original).blk
+++ b/data/mekfiles/vehicles/3075/Cobra Transport VTOL (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Cobra Transport VTOL.blk
+++ b/data/mekfiles/vehicles/3075/Cobra Transport VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Condor Heavy Hover Tank (Upgrade Laser).blk
+++ b/data/mekfiles/vehicles/3075/Condor Heavy Hover Tank (Upgrade Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Condor Heavy Hover Tank (Upgrade).blk
+++ b/data/mekfiles/vehicles/3075/Condor Heavy Hover Tank (Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Crow Scout Helicopter 'Dragonfly'.blk
+++ b/data/mekfiles/vehicles/3075/Crow Scout Helicopter 'Dragonfly'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Crow Scout Helicopter (C3).blk
+++ b/data/mekfiles/vehicles/3075/Crow Scout Helicopter (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Crow Scout Helicopter (Export).blk
+++ b/data/mekfiles/vehicles/3075/Crow Scout Helicopter (Export).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Crow Scout Helicopter.blk
+++ b/data/mekfiles/vehicles/3075/Crow Scout Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Cyrano Gunship (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Cyrano Gunship (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/DI Morgan Assault Tank (Gauss).blk
+++ b/data/mekfiles/vehicles/3075/DI Morgan Assault Tank (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/DI Morgan Assault Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3075/DI Morgan Assault Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/DI Morgan Assault Tank.blk
+++ b/data/mekfiles/vehicles/3075/DI Morgan Assault Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Daimyo HQ 67-K.blk
+++ b/data/mekfiles/vehicles/3075/Daimyo HQ 67-K.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Daimyo HQ 67-K2.blk
+++ b/data/mekfiles/vehicles/3075/Daimyo HQ 67-K2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Daimyo HQ 67-NC.blk
+++ b/data/mekfiles/vehicles/3075/Daimyo HQ 67-NC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Daimyo HQ 67-R.blk
+++ b/data/mekfiles/vehicles/3075/Daimyo HQ 67-R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Danai Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3075/Danai Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Darter Scout Car (BAP).blk
+++ b/data/mekfiles/vehicles/3075/Darter Scout Car (BAP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Darter Scout Car (C3).blk
+++ b/data/mekfiles/vehicles/3075/Darter Scout Car (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Darter Scout Car (ECM).blk
+++ b/data/mekfiles/vehicles/3075/Darter Scout Car (ECM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Darter Scout Car (SRM).blk
+++ b/data/mekfiles/vehicles/3075/Darter Scout Car (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Darter Scout Car (SRM-2).blk
+++ b/data/mekfiles/vehicles/3075/Darter Scout Car (SRM-2).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Darter Scout Car.blk
+++ b/data/mekfiles/vehicles/3075/Darter Scout Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Demon Tank (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Demon Tank (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Fury Command Tank (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Fury Command Tank (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Hiryo Armored Infantry Transport (LPPC).blk
+++ b/data/mekfiles/vehicles/3075/Hiryo Armored Infantry Transport (LPPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Hiryo Armored Infantry Transport (MRM).blk
+++ b/data/mekfiles/vehicles/3075/Hiryo Armored Infantry Transport (MRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Hiryo Armored Infantry Transport.blk
+++ b/data/mekfiles/vehicles/3075/Hiryo Armored Infantry Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Ignis Infantry Support Tank (SRM).blk
+++ b/data/mekfiles/vehicles/3075/Ignis Infantry Support Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Ignis Infantry Support Tank.blk
+++ b/data/mekfiles/vehicles/3075/Ignis Infantry Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/JES I Tactical Missile Carrier.blk
+++ b/data/mekfiles/vehicles/3075/JES I Tactical Missile Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Korvin KRV-3.blk
+++ b/data/mekfiles/vehicles/3075/Korvin KRV-3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Lightning Attack Hovercraft (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Lightning Attack Hovercraft (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/MIT23 MASH Vehicle.blk
+++ b/data/mekfiles/vehicles/3075/MIT23 MASH Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Marsden II MBT II (Primitive).blk
+++ b/data/mekfiles/vehicles/3075/Marsden II MBT II (Primitive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Marsden II MBT II-A (LBX).blk
+++ b/data/mekfiles/vehicles/3075/Marsden II MBT II-A (LBX).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Marsden II MBT II-A.blk
+++ b/data/mekfiles/vehicles/3075/Marsden II MBT II-A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Marsden II MBT.blk
+++ b/data/mekfiles/vehicles/3075/Marsden II MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel (LB-X).blk
+++ b/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel (LRM).blk
+++ b/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel (LRT).blk
+++ b/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel (LRT).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel.blk
+++ b/data/mekfiles/vehicles/3075/Mauna Kea Command Vessel.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Merkava Heavy Tank Mk IX.blk
+++ b/data/mekfiles/vehicles/3075/Merkava Heavy Tank Mk IX.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Merkava Heavy Tank Mk VIII.blk
+++ b/data/mekfiles/vehicles/3075/Merkava Heavy Tank Mk VIII.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Nightshade ECM VTOL (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Nightshade ECM VTOL (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Puma Assault Tank PAT-005b.blk
+++ b/data/mekfiles/vehicles/3075/Puma Assault Tank PAT-005b.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Rhino Fire Support Tank (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Rhino Fire Support Tank (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Ripper Infantry Transport (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Ripper Infantry Transport (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1.blk
+++ b/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1A.blk
+++ b/data/mekfiles/vehicles/3075/SM Tank Destroyer SM1A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/SM Tank Destroyer SM3.blk
+++ b/data/mekfiles/vehicles/3075/SM Tank Destroyer SM3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Sabaku Kaze Heavy Scout Hover Tank.blk
+++ b/data/mekfiles/vehicles/3075/Sabaku Kaze Heavy Scout Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Saxon APC (HQ).blk
+++ b/data/mekfiles/vehicles/3075/Saxon APC (HQ).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Saxon APC (Laser).blk
+++ b/data/mekfiles/vehicles/3075/Saxon APC (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Saxon APC (MASH).blk
+++ b/data/mekfiles/vehicles/3075/Saxon APC (MASH).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Saxon APC.blk
+++ b/data/mekfiles/vehicles/3075/Saxon APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Tamerlane Strike Sled (Flamer).blk
+++ b/data/mekfiles/vehicles/3075/Tamerlane Strike Sled (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Tamerlane Strike Sled (RL).blk
+++ b/data/mekfiles/vehicles/3075/Tamerlane Strike Sled (RL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Tamerlane Strike Sled 2.blk
+++ b/data/mekfiles/vehicles/3075/Tamerlane Strike Sled 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Tamerlane Strike Sled.blk
+++ b/data/mekfiles/vehicles/3075/Tamerlane Strike Sled.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Thumper Artillery Vehicle TAV-1.blk
+++ b/data/mekfiles/vehicles/3075/Thumper Artillery Vehicle TAV-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Thumper Artillery Vehicle TAV-2.blk
+++ b/data/mekfiles/vehicles/3075/Thumper Artillery Vehicle TAV-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Thumper Artillery Vehicle.blk
+++ b/data/mekfiles/vehicles/3075/Thumper Artillery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Turhan Urban Combat Vehicle (C3).blk
+++ b/data/mekfiles/vehicles/3075/Turhan Urban Combat Vehicle (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Turhan Urban Combat Vehicle (Original).blk
+++ b/data/mekfiles/vehicles/3075/Turhan Urban Combat Vehicle (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Turhan Urban Combat Vehicle.blk
+++ b/data/mekfiles/vehicles/3075/Turhan Urban Combat Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3075/Zephyr Hovertank (Royal).blk
+++ b/data/mekfiles/vehicles/3075/Zephyr Hovertank (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Aeron Strike VTOL (BAP).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Aeron Strike VTOL (BAP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Aeron Strike VTOL.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Aeron Strike VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Augustus MBT A3.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Augustus MBT A3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Balac Strike VTOL (LRM).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Balac Strike VTOL (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Balac Strike VTOL (Spotter).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Balac Strike VTOL (Spotter).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Balac Strike VTOL.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Balac Strike VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank A.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank B.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank C.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Comminus.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Comminus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Dominus.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Dominus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Infernus.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Infernus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Invictus.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Invictus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Prime.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Carnivore Assault Tank (HAG).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Carnivore Assault Tank (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Carnivore Assault Tank (Second Line).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Carnivore Assault Tank (Second Line).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Carnivore Assault Tank.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Carnivore Assault Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Chalchiuhtotolin Support Tank (Bombast Laser).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Chalchiuhtotolin Support Tank (Bombast Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Chalchiuhtotolin Support Tank (Chemical Laser).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Chalchiuhtotolin Support Tank (Chemical Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Chalchiuhtotolin Support Tank.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Chalchiuhtotolin Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Demon Medium Tank (Rifle).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Demon Medium Tank (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Demon Medium Tank.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Demon Medium Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Eldingar Hover Sled (Streak).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Eldingar Hover Sled (Streak).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Eldingar Hover Sled.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Eldingar Hover Sled.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Fensalir Combat WiGE (HAG).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Fensalir Combat WiGE (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Fensalir Combat WiGE (Infantry).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Fensalir Combat WiGE (Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Fensalir Combat WiGE.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Fensalir Combat WiGE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Fox Armored Car (Flamer).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Fox Armored Car (Flamer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Fox Armored Car (VSP).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Fox Armored Car (VSP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Fox Armored Car.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Fox Armored Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Giggins APC (Fire Support).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Giggins APC (Fire Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Giggins APC.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Giggins APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Gurteltier MBT (C3M).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Gurteltier MBT (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Gurteltier MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Gurteltier MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/J-37 Ordnance Transport (Original).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/J-37 Ordnance Transport (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/J-37 Ordnance Transport.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/J-37 Ordnance Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/JES II Strategic Missile  Carrier (Ammo).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/JES II Strategic Missile  Carrier (Ammo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/JES II Strategic Missile  Carrier.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/JES II Strategic Missile  Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Joust Medium Tank BE700.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Joust Medium Tank BE700.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Joust Medium Tank BE701.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Joust Medium Tank BE701.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Kinnol MBT (PPC).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Kinnol MBT (PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Kinnol MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Kinnol MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Marksman M1 MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Marksman M1 MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Marksman M1A MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Marksman M1A MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Maxim Mk II Transport (Infantry Support).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Maxim Mk II Transport (Infantry Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Maxim Mk II Transport.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Maxim Mk II Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Moltke M1 MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Moltke M1 MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Moltke M2 MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Moltke M2 MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Moltke M3 MBT.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Moltke M3 MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Padilla Tube Artillery Tank (LTC).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Padilla Tube Artillery Tank (LTC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Padilla Tube Artillery Tank (Thumper).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Padilla Tube Artillery Tank (Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Padilla Tube Artillery Tank.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Padilla Tube Artillery Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Palmoni Assault Infantry Fighting Vehicle.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Palmoni Assault Infantry Fighting Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Pandion Combat WiGE (C3).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Pandion Combat WiGE (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Pandion Combat WiGE (Infantry).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Pandion Combat WiGE (Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Pandion Combat WiGE.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Pandion Combat WiGE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Po II Heavy Tank (Arrow IV).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Po II Heavy Tank (Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Po II Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Po II Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (ECM).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (ECM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (RAF).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (RAF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (Succession Wars).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (Succession Wars).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (Support).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (WoB).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Prowler Multi-Terrain Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV1 (MG).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV1 (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV1.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV2.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV22.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Ranger Armored Fighting Vehicle VV22.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Regulator II Hovertank (RAC).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Regulator II Hovertank (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Regulator II Hovertank (Stealth).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Regulator II Hovertank (Stealth).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Regulator II Hovertank.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Regulator II Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Tonbo Superheavy Transport.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Tonbo Superheavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Trajan Assault Infantry Fighting Vehicle (ICE).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Trajan Assault Infantry Fighting Vehicle (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Trajan Assault Infantry Fighting Vehicle.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Trajan Assault Infantry Fighting Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Transportable Field Repair Unit JI-100.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Transportable Field Repair Unit JI-100.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Trireme Infantry Transport (CS).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Trireme Infantry Transport (CS).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Trireme Infantry Transport.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Trireme Infantry Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Tufana Hovercraft (iNarc).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Tufana Hovercraft (iNarc).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Tufana Hovercraft.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Tufana Hovercraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Winston Combat Vehicle (LAC).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Winston Combat Vehicle (LAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Winston Combat Vehicle.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Winston Combat Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Yasha VTOL (Interdictor).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Yasha VTOL (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Yasha VTOL Spectre.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Yasha VTOL Spectre.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Yasha VTOL.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Yasha VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zephyros Infantry Support Vehicle (Dual Turret).blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zephyros Infantry Support Vehicle (Dual Turret).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zephyros Infantry Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zephyros Infantry Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft A.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft B.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft C.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft D.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft E.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft Prime.blk
+++ b/data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Ajax Assault Tank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Ajax Assault Tank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Beagle (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Beagle (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Brutus Assault Tank (HPPC).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Brutus Assault Tank (HPPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Challenger XIVs MBT.blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Challenger XIVs MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Chaparral (CASE).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Chaparral (CASE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Demolisher II Heavy Tank (MML).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Demolisher II Heavy Tank (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Drillson Heavy Hover Tank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Drillson Heavy Hover Tank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Fortune Wheeled Assault Vehicle (C3M).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Fortune Wheeled Assault Vehicle (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Fulcrum III Heavy Hovertank.blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Fulcrum III Heavy Hovertank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Goblin Infantry Support Vehicle (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Goblin Infantry Support Vehicle (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Hetzer Wheeled Assault Gun (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Hetzer Wheeled Assault Gun (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/JES I Tactical Missile Carrier (3082 Upgrade).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/JES I Tactical Missile Carrier (3082 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Manticore Heavy Tank (HPPC).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Manticore Heavy Tank (HPPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Ontos Heavy Tank (MML).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Ontos Heavy Tank (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Ontos Heavy Tank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Ontos Heavy Tank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Partisan Air Defense Tank (Cell).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Partisan Air Defense Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Partisan Air Defense Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Partisan Air Defense Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Pegasus Scout Hover Tank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Pegasus Scout Hover Tank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Plainsman Medium Hovertank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Plainsman Medium Hovertank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Rommel Tank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Rommel Tank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Savannah Master Hovercraft (Interdictor).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Savannah Master Hovercraft (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Schrek PPC Carrier (Armor).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Schrek PPC Carrier (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Schrek PPC Carrier (C3M).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Schrek PPC Carrier (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Scimitar Medium Hover Tank (C3).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Scimitar Medium Hover Tank (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Scorpion Light Tank (LAC).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Scorpion Light Tank (LAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Shamash Reconnaissance Vehicle (Interdictor).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Shamash Reconnaissance Vehicle (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Skulker Wheeled Scout Tank (C3M).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Skulker Wheeled Scout Tank (C3M).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Sprint Scout Helicopter (Interdictor).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Sprint Scout Helicopter (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Striker Light Tank (Sealed).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Striker Light Tank (Sealed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Vedette Medium Tank (Cell).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Vedette Medium Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Yellow Jacket Gunship (PPC).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Yellow Jacket Gunship (PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Zhukov Heavy Tank (LB-X).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Zhukov Heavy Tank (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/ONN/Zhukov Heavy Tank (Liao).blk
+++ b/data/mekfiles/vehicles/3085u/ONN/Zhukov Heavy Tank (Liao).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Bokkusu Support Trailer.blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Bokkusu Support Trailer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Manta Fast Attack Submarine (Support).blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Manta Fast Attack Submarine (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Manta Fast Attack Submarine.blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Manta Fast Attack Submarine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Moray Heavy Attack Submarine (Original).blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Moray Heavy Attack Submarine (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Moray Heavy Attack Submarine.blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Moray Heavy Attack Submarine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Tenmaku Command Trailer.blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Tenmaku Command Trailer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3085u/Supplemental/Teppo Artillery Vehicle.blk
+++ b/data/mekfiles/vehicles/3085u/Supplemental/Teppo Artillery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Aesir Medium AA Vehicle (HAG).blk
+++ b/data/mekfiles/vehicles/3145/Clans/Aesir Medium AA Vehicle (HAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Aesir Medium AA Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Aesir Medium AA Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Anat APC.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Anat APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Gurzil Support Tank.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Gurzil Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Hadur Fast Support Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Hadur Fast Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Nacon Armored Scout.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Nacon Armored Scout.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Skadi Swift Attack VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Skadi Swift Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Clans/Skanda Light Tank.blk
+++ b/data/mekfiles/vehicles/3145/Clans/Skanda Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Ballista Artillery Trailer.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Ballista Artillery Trailer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Destrier Siege Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Destrier Siege Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Hanse MBT.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Hanse MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Hasek Mechanized Combat Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Hasek Mechanized Combat Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/JI2A1 Attack APC (MML).blk
+++ b/data/mekfiles/vehicles/3145/Davion/JI2A1 Attack APC (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/JI2A1 Attack APC.blk
+++ b/data/mekfiles/vehicles/3145/Davion/JI2A1 Attack APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Kruger Combat Car (Original).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Kruger Combat Car (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Kruger Combat Car.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Kruger Combat Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Marten Scout VTOL (Infantry).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Marten Scout VTOL (Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Marten Scout VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Marten Scout VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Paladin Defense System.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Paladin Defense System.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Sniper Artillery.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Sniper Artillery.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Sortek Assault Craft (Interdictor).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Sortek Assault Craft (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Sortek Assault Craft.blk
+++ b/data/mekfiles/vehicles/3145/Davion/Sortek Assault Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (A).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (A).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (B).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (B).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (C).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (C).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (D).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (D).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (Prime).blk
+++ b/data/mekfiles/vehicles/3145/Davion/Zibler Fast Strike Tank (Prime).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Cizin (Support).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Cizin (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Cizin.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Cizin.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Kamakiri Attack VTOL (Gauss).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Kamakiri Attack VTOL (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Kamakiri Attack VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Kamakiri Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Mamono IFV.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Mamono IFV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Narukami Heavy Tank NK-1C.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Narukami Heavy Tank NK-1C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Narukami Heavy Tank NK-BC3.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Narukami Heavy Tank NK-BC3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/SM2 Heavy Artillery Vehicle (LTC).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/SM2 Heavy Artillery Vehicle (LTC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/SM2 Heavy Artillery Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/SM2 Heavy Artillery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Saladin Mk II HCV (BC3).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Saladin Mk II HCV (BC3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Saladin Mk II HCV.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Saladin Mk II HCV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Saracen Mk II HCV (BC3).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Saracen Mk II HCV (BC3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Saracen Mk II HCV.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Saracen Mk II HCV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Scimitar Mk II HCV (3136 Upgrade).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Scimitar Mk II HCV (3136 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Scimitar Mk II HCV (BC3).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Scimitar Mk II HCV (BC3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Scimitar Mk II HCV.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Scimitar Mk II HCV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Sekhmet Assault Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Sekhmet Assault Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Shillelagh Missile Tank (Original).blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Shillelagh Missile Tank (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Kurita/Shillelagh Missile Tank.blk
+++ b/data/mekfiles/vehicles/3145/Kurita/Shillelagh Missile Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Arrow IV Assault Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Arrow IV Assault Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Behemoth II Heavy Tank (Support).blk
+++ b/data/mekfiles/vehicles/3145/Liao/Behemoth II Heavy Tank (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Behemoth II Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Behemoth II Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Luduan Scout Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Luduan Scout Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Nisos Attack WIGE (Support).blk
+++ b/data/mekfiles/vehicles/3145/Liao/Nisos Attack WIGE (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Nisos Attack WIGE.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Nisos Attack WIGE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Pixiu Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Pixiu Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Predator Tank Destroyer (Original).blk
+++ b/data/mekfiles/vehicles/3145/Liao/Predator Tank Destroyer (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Predator Tank Destroyer.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Predator Tank Destroyer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Sheriff Infantry Support Tank.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Sheriff Infantry Support Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Shun Transport VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Shun Transport VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Liao/Zahn Heavy Transport.blk
+++ b/data/mekfiles/vehicles/3145/Liao/Zahn Heavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Bardiche Heavy Strike Tank (Minesweeper).blk
+++ b/data/mekfiles/vehicles/3145/Marik/Bardiche Heavy Strike Tank (Minesweeper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Bardiche Heavy Strike Tank.blk
+++ b/data/mekfiles/vehicles/3145/Marik/Bardiche Heavy Strike Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Bulwark Assault Vehicle (Original).blk
+++ b/data/mekfiles/vehicles/3145/Marik/Bulwark Assault Vehicle (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Bulwark Assault Vehicle (Standardl).blk
+++ b/data/mekfiles/vehicles/3145/Marik/Bulwark Assault Vehicle (Standardl).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Partisan AA Vehicle (3134 Upgrade).blk
+++ b/data/mekfiles/vehicles/3145/Marik/Partisan AA Vehicle (3134 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Partisan AA Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Marik/Partisan AA Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (A).blk
+++ b/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (A).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (B).blk
+++ b/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (B).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (Coolant Truck).blk
+++ b/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (Coolant Truck).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (Prime).blk
+++ b/data/mekfiles/vehicles/3145/Marik/R10 Mechanized ICV (Prime).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Red Kite Attack VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Marik/Red Kite Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Marik/Thang-Ta APC.blk
+++ b/data/mekfiles/vehicles/3145/Marik/Thang-Ta APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Bishop Transport VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Bishop Transport VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Cardinal Transport (RAF).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Cardinal Transport (RAF).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Cardinal Transport.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Cardinal Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Garrot Superheavy Transport.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Garrot Superheavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Gossamer (XL) VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Gossamer (XL) VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Gossamer VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Gossamer VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Lamprey Transport Helicopter.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Lamprey Transport Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Savior Repair Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Savior Repair Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Testudo Siege Tank Tank.blk
+++ b/data/mekfiles/vehicles/3145/Merc/Testudo Siege Tank Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ambush).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ambush).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Artillery AAA).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Artillery AAA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (LRM).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Mjolnir).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Mjolnir).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Siege).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Siege).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Sniper Cannon).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Sniper Cannon).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Stronghold).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Stronghold).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thumper).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thumper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thunderbolt).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thunderbolt).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ultra).blk
+++ b/data/mekfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ultra).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Balac Strike VTOL (Hybrid).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Balac Strike VTOL (Hybrid).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Bolla Stealth Tank D.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Bolla Stealth Tank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Bulldog Medium Tank (Cell).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Bulldog Medium Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Chalchiuhtotolin Support Tank (XL).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Chalchiuhtotolin Support Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Condor Heavy Hover Tank (Laser Upgrade).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Condor Heavy Hover Tank (Laser Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Demon Medium Tank (Armor).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Demon Medium Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Eldingar Hover Sled (HumHov).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Eldingar Hover Sled (HumHov).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Fox Armored Car (Interdictor).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Fox Armored Car (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Fury Command Tank (Fury III).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Fury Command Tank (Fury III).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Fury Command Tank (Fury IIIm).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Fury Command Tank (Fury IIIm).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Glory Heavy Fire Support Vehicle (3090 Upgrade).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Glory Heavy Fire Support Vehicle (3090 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Harasser Missile Platform (MML).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Harasser Missile Platform (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Harasser Missile Platform (Thunderbolt).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Harasser Missile Platform (Thunderbolt).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Heimdall Ground Monitor Tank D.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Heimdall Ground Monitor Tank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Huitzilopochtli Assault Tank (LRM).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Huitzilopochtli Assault Tank (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Huitzilopochtli Assault Tank (Streak).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Huitzilopochtli Assault Tank (Streak).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/JES II Strategic Missile Carrier (Support).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/JES II Strategic Missile Carrier (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Kinnol MBT (RAC).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Kinnol MBT (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/MIT24 MASH Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/MIT24 MASH Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Manteuffel Attack Tank E.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Manteuffel Attack Tank E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Marksman MBT M1J.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Marksman MBT M1J.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Maxim Mk II Transport (ECM).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Maxim Mk II Transport (ECM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Mobile Long Tom Artillery LT-MOB-95.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Mobile Long Tom Artillery LT-MOB-95.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Mortar Carrier.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Mortar Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Padilla Tube Artillery Tank (AMS).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Padilla Tube Artillery Tank (AMS).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Pilum Heavy Tank (ELRM).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Pilum Heavy Tank (ELRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Po II Heavy Tank (Gauss).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Po II Heavy Tank (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Po II Heavy Tank (Stealth).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Po II Heavy Tank (Stealth).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Prowler Multi-Terrain Vehicle (3140 Upgrade).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Prowler Multi-Terrain Vehicle (3140 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Prowler Multi-Terrain Vehicle (Security).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Prowler Multi-Terrain Vehicle (Security).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Ranger Armored Fighting Vehicle VV1 (Interdictor).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Ranger Armored Fighting Vehicle VV1 (Interdictor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Vedette Medium Tank V9.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Vedette Medium Tank V9.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Winston Combat Vehicle (Support).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Winston Combat Vehicle (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Winston Combat Vehicle (TSEMP).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Winston Combat Vehicle (TSEMP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Winston Combat Vehicle (XXL).blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Winston Combat Vehicle (XXL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/NTNU/Zugvogel Omni Support Aircraft F.blk
+++ b/data/mekfiles/vehicles/3145/NTNU/Zugvogel Omni Support Aircraft F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Crane Heavy Transport.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Crane Heavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Hawk Moth II Gunship (MML).blk
+++ b/data/mekfiles/vehicles/3145/Republic/Hawk Moth II Gunship (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Hawk Moth II Gunship (Sniper).blk
+++ b/data/mekfiles/vehicles/3145/Republic/Hawk Moth II Gunship (Sniper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Hawk Moth II Gunship.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Hawk Moth II Gunship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (C3).blk
+++ b/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (C3).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (MML).blk
+++ b/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (Speed).blk
+++ b/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (Speed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (Thunderbolt).blk
+++ b/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier (Thunderbolt).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier.blk
+++ b/data/mekfiles/vehicles/3145/Republic/JES III Missile Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/MHI Amphibious APC.blk
+++ b/data/mekfiles/vehicles/3145/Republic/MHI Amphibious APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/MHI Defense AA Tank.blk
+++ b/data/mekfiles/vehicles/3145/Republic/MHI Defense AA Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank (Primary).blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank (Primary).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank A.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank B.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank C.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank D.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank E.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank F.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank G.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank G.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank H.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank H.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank I.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank J.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Scapha Hovertank J.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Shandra Advanced Scout Vehicle (Original).blk
+++ b/data/mekfiles/vehicles/3145/Republic/Shandra Advanced Scout Vehicle (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Republic/Shandra Advanced Scout Vehicle.blk
+++ b/data/mekfiles/vehicles/3145/Republic/Shandra Advanced Scout Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/DI Multipurpose VTOL (Gunship).blk
+++ b/data/mekfiles/vehicles/3145/Steiner/DI Multipurpose VTOL (Gunship).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/DI Multipurpose VTOL.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/DI Multipurpose VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/DI Schmitt Tank (Targeting Computer).blk
+++ b/data/mekfiles/vehicles/3145/Steiner/DI Schmitt Tank (Targeting Computer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/DI Schmitt Tank.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/DI Schmitt Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Gulltoppr OmniMonitor (A).blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Gulltoppr OmniMonitor (A).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Gulltoppr OmniMonitor (B).blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Gulltoppr OmniMonitor (B).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Gulltoppr OmniMonitor (Prime).blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Gulltoppr OmniMonitor (Prime).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Kelswa Assault Tank.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Kelswa Assault Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Manticore II Heavy Tank.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Manticore II Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Schildkrote Line Tank.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Schildkrote Line Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Swallow Attack WIGE (Original).blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Swallow Attack WIGE (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Swallow Attack WIGE.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Swallow Attack WIGE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3145/Steiner/Winterhawk APC.blk
+++ b/data/mekfiles/vehicles/3145/Steiner/Winterhawk APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Bardiche Heavy Strike Tank C.blk
+++ b/data/mekfiles/vehicles/3150/Bardiche Heavy Strike Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Bellona Hover Tank (XL).blk
+++ b/data/mekfiles/vehicles/3150/Bellona Hover Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Devastator II Superheavy Tank .blk
+++ b/data/mekfiles/vehicles/3150/Devastator II Superheavy Tank .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Fensalir Combat WiGE (3132 Upgrade).blk
+++ b/data/mekfiles/vehicles/3150/Fensalir Combat WiGE (3132 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Fensalir Combat WiGE (3137 Upgrade).blk
+++ b/data/mekfiles/vehicles/3150/Fensalir Combat WiGE (3137 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Fensalir Combat WiGE (Stealth).blk
+++ b/data/mekfiles/vehicles/3150/Fensalir Combat WiGE (Stealth).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Galleon Light Tank GAL-105.blk
+++ b/data/mekfiles/vehicles/3150/Galleon Light Tank GAL-105.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Hadur Fast Support Vehicle (LRM).blk
+++ b/data/mekfiles/vehicles/3150/Hadur Fast Support Vehicle (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Hadur Fast Support Vehicle (Reactive).blk
+++ b/data/mekfiles/vehicles/3150/Hadur Fast Support Vehicle (Reactive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Kite Reconnaissance Vehicle (Fusion).blk
+++ b/data/mekfiles/vehicles/3150/Kite Reconnaissance Vehicle (Fusion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Kite Reconnaissance Vehicle.blk
+++ b/data/mekfiles/vehicles/3150/Kite Reconnaissance Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Pandion Combat WiGE (3135 Upgrade).blk
+++ b/data/mekfiles/vehicles/3150/Pandion Combat WiGE (3135 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Pandion Combat WiGE (3140 Upgrade).blk
+++ b/data/mekfiles/vehicles/3150/Pandion Combat WiGE (3140 Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Predator Tank Destroyer (Elite).blk
+++ b/data/mekfiles/vehicles/3150/Predator Tank Destroyer (Elite).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Schildkrote Line Tank (HPPC).blk
+++ b/data/mekfiles/vehicles/3150/Schildkrote Line Tank (HPPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Schildkrote Line Tank (Light Gauss).blk
+++ b/data/mekfiles/vehicles/3150/Schildkrote Line Tank (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Schildkrote Line Tank (Plasma).blk
+++ b/data/mekfiles/vehicles/3150/Schildkrote Line Tank (Plasma).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Sekhmet Assault Vehicle (Streak).blk
+++ b/data/mekfiles/vehicles/3150/Sekhmet Assault Vehicle (Streak).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Shun Transport VTOL (Support).blk
+++ b/data/mekfiles/vehicles/3150/Shun Transport VTOL (Support).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Skanda Light Tank (TSEMP).blk
+++ b/data/mekfiles/vehicles/3150/Skanda Light Tank (TSEMP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/3150/Swallow Attack WiGE (Spotter).blk
+++ b/data/mekfiles/vehicles/3150/Swallow Attack WiGE (Spotter).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Hover/Boreas Cavalry Hovercraft A.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Hover/Boreas Cavalry Hovercraft A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Hover/Boreas Cavalry Hovercraft B.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Hover/Boreas Cavalry Hovercraft B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Hover/Boreas Cavalry Hovercraft Prime.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Hover/Boreas Cavalry Hovercraft Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Hover/Hoodling Sensor Hoverjeep.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Hover/Hoodling Sensor Hoverjeep.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Hover/Hoverpod.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Hover/Hoverpod.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Hover/JI-002 Hoverbike.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Hover/JI-002 Hoverbike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Naval/Harpoon ParaSub.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Naval/Harpoon ParaSub.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Naval/Small Steamer.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Naval/Small Steamer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/VTOL/HTE Micro-Copter.blk
+++ b/data/mekfiles/vehicles/AToW Companion/VTOL/HTE Micro-Copter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Wheeled/Assuan Armored Bike.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Wheeled/Assuan Armored Bike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Wheeled/Beast Riot Car.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Wheeled/Beast Riot Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Wheeled/Death Trike.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Wheeled/Death Trike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Wheeled/Dune Buggy.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Wheeled/Dune Buggy.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Wheeled/Eagre Firefighting ATV.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Wheeled/Eagre Firefighting ATV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/AToW Companion/Wheeled/Tracked Quad.blk
+++ b/data/mekfiles/vehicles/AToW Companion/Wheeled/Tracked Quad.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/DarkAge/Shackleton AESV.blk
+++ b/data/mekfiles/vehicles/DarkAge/Shackleton AESV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Era Digests/Age of War/Estevez AA.blk
+++ b/data/mekfiles/vehicles/Era Digests/Age of War/Estevez AA.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Era Digests/Age of War/Estevez MBT.blk
+++ b/data/mekfiles/vehicles/Era Digests/Age of War/Estevez MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Era Digests/Age of War/Marsden I.blk
+++ b/data/mekfiles/vehicles/Era Digests/Age of War/Marsden I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Era Digests/Dark Age/Praetorian Mobile Strategic Command HQ.blk
+++ b/data/mekfiles/vehicles/Era Digests/Dark Age/Praetorian Mobile Strategic Command HQ.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Era Digests/Dark Age/Tribune Mobile Tactical Command HQ.blk
+++ b/data/mekfiles/vehicles/Era Digests/Dark Age/Tribune Mobile Tactical Command HQ.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/FM DC/Arrow IV Carrier.blk
+++ b/data/mekfiles/vehicles/FM DC/Arrow IV Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Golden Century/Kokou Defense Tank (XL).blk
+++ b/data/mekfiles/vehicles/Golden Century/Kokou Defense Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Golden Century/Kokou Defense Tank.blk
+++ b/data/mekfiles/vehicles/Golden Century/Kokou Defense Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Golden Century/Manticore Heavy Tank EC.blk
+++ b/data/mekfiles/vehicles/Golden Century/Manticore Heavy Tank EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Golden Century/Rhino Fire Support Tank EC.blk
+++ b/data/mekfiles/vehicles/Golden Century/Rhino Fire Support Tank EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Golden Century/Zephyr Hovertank EC.blk
+++ b/data/mekfiles/vehicles/Golden Century/Zephyr Hovertank EC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Apocalypse World Rover.blk
+++ b/data/mekfiles/vehicles/HB HD/Apocalypse World Rover.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Command Post).blk
+++ b/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Command Post).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Kitchen).blk
+++ b/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Kitchen).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle (MASH).blk
+++ b/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle (MASH).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Bunk).blk
+++ b/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Bunk).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Cargo).blk
+++ b/data/mekfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HD/Heavy Combat ATV.blk
+++ b/data/mekfiles/vehicles/HB HD/Heavy Combat ATV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HK/Obuzaabaa Tactical Vehicle.blk
+++ b/data/mekfiles/vehicles/HB HK/Obuzaabaa Tactical Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HK/Sasayaku Control Transport.blk
+++ b/data/mekfiles/vehicles/HB HK/Sasayaku Control Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HL/Apple-Churchill Surveillance VTOL.blk
+++ b/data/mekfiles/vehicles/HB HL/Apple-Churchill Surveillance VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HL/C-85 Sprinter Delivery Vehicle.blk
+++ b/data/mekfiles/vehicles/HB HL/C-85 Sprinter Delivery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Hector Road Train Tractor.blk
+++ b/data/mekfiles/vehicles/HB HM/Hector Road Train Tractor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Liquid).blk
+++ b/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Liquid).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Livestock).blk
+++ b/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Livestock).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Passenger).blk
+++ b/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Passenger).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Refrigerated).blk
+++ b/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module (Refrigerated).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module.blk
+++ b/data/mekfiles/vehicles/HB HM/Hector Road Train Trailer Module.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Ibex RV (Militarized LDGR).blk
+++ b/data/mekfiles/vehicles/HB HM/Ibex RV (Militarized LDGR).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Ibex RV (Militarized MG).blk
+++ b/data/mekfiles/vehicles/HB HM/Ibex RV (Militarized MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/HB HM/Ibex RV.blk
+++ b/data/mekfiles/vehicles/HB HM/Ibex RV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Ballista Self Propelled Artillery Tank.blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Ballista Self Propelled Artillery Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Pollux ADA Heavy Tank.blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Pollux ADA Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Vali Artillery Vehicle.blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Vali Artillery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Vector (Attack).blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Vector (Attack).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Vector EW.blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Vector EW.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Vector Scout.blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Vector Scout.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Vector Transport.blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Vector Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Weapon Carrier Tracked (AC20).blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Weapon Carrier Tracked (AC20).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Weapon Carrier Tracked (LB-10X).blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Weapon Carrier Tracked (LB-10X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist LOT II/Weapon Carrier Tracked (Ultra5).blk
+++ b/data/mekfiles/vehicles/Hist LOT II/Weapon Carrier Tracked (Ultra5).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist Reunification War/Gallant Urban Assault Tank.blk
+++ b/data/mekfiles/vehicles/Hist Reunification War/Gallant Urban Assault Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist Reunification War/Hipparch Cavalry Tank.blk
+++ b/data/mekfiles/vehicles/Hist Reunification War/Hipparch Cavalry Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist Reunification War/Tiger Medium Tank T-12.blk
+++ b/data/mekfiles/vehicles/Hist Reunification War/Tiger Medium Tank T-12.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Hist Reunification War/Wayland Mobile Base.blk
+++ b/data/mekfiles/vehicles/Hist Reunification War/Wayland Mobile Base.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/House Arano/Sleipnir APC SRM.blk
+++ b/data/mekfiles/vehicles/House Arano/Sleipnir APC SRM.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/House Arano/Sleipnir APC.blk
+++ b/data/mekfiles/vehicles/House Arano/Sleipnir APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/House Arano/Vargr APC LRM.blk
+++ b/data/mekfiles/vehicles/House Arano/Vargr APC LRM.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/House Arano/Vargr APC.blk
+++ b/data/mekfiles/vehicles/House Arano/Vargr APC.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Brunel Dump Truck AC20.blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Brunel Dump Truck AC20.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Brunel Dump Truck LRM.blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Brunel Dump Truck LRM.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Burke Defense Tank (Royal).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Burke Defense Tank (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Flatbed Truck (LRM).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Flatbed Truck (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Flatbed Truck (RL).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Flatbed Truck (RL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Galleon Light Tank GAL-200 (RL).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Galleon Light Tank GAL-200 (RL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Kanga Medium Hovertank (AC).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Kanga Medium Hovertank (AC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Marksman Artillery Vehicle (AC).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Marksman Artillery Vehicle (AC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Rotunda Scout Vehicle (LRM).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Rotunda Scout Vehicle (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Rotunda Scout Vehicle (RL).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Rotunda Scout Vehicle (RL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Rotunda Scout Vehicle (SRM).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Rotunda Scout Vehicle (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Thor Artillery Vehicle (AC).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Thor Artillery Vehicle (AC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Von Luckner Heavy Tank (Royal).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Von Luckner Heavy Tank (Royal).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Operation Klondike/Von Luckner Heavy Tank (Star League).blk
+++ b/data/mekfiles/vehicles/Operation Klondike/Von Luckner Heavy Tank (Star League).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Aithon Assault Transport.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Aithon Assault Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Bandit Mk II.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Bandit Mk II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Cavalry (Infiltrator).blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Cavalry (Infiltrator).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Challenger MBT XV.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Challenger MBT XV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Enyo Strike Tank ER Pulse.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Enyo Strike Tank ER Pulse.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Fulcrum Heavy Hover Tank Hybrid.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Fulcrum Heavy Hover Tank Hybrid.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Garuda Heavy VTOL.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Garuda Heavy VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Heavy NLRM Carrier.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Heavy NLRM Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Hephaestus (AP) Jump Tank.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Hephaestus (AP) Jump Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Hephaestus Jump Tank.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Hephaestus Jump Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Hiryo Armored Infantry Transport BloodHound.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Hiryo Armored Infantry Transport BloodHound.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Hunter Light Support Tank (Amphibious).blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Hunter Light Support Tank (Amphibious).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Kalki Cruise Missile Launcher.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Kalki Cruise Missile Launcher.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Lexan Surveillance VTOL.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Lexan Surveillance VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Myrmidon Medium Tank (Anti-Infantry).blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Myrmidon Medium Tank (Anti-Infantry).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Nishikigoi Support Aircraft Koi.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Nishikigoi Support Aircraft Koi.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Nuberu Anti Aircraft Tank 2 Numantia.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Nuberu Anti Aircraft Tank 2 Numantia.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Nuberu Anti Aircraft Tank.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Nuberu Anti Aircraft Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Ontos Heavy Tank Heat.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Ontos Heavy Tank Heat.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Pegasus Scout Hover Tank X-Pulse.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Pegasus Scout Hover Tank X-Pulse.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Phalanx Support Tank (Production).blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Phalanx Support Tank (Production).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Phalanx Support Tank(Prototype).blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Phalanx Support Tank(Prototype).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Po Heavy Tank HV.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Po Heavy Tank HV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Rommel Tank (Howitzer) Production.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Rommel Tank (Howitzer) Production.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Scorpion Light Tank (Minesweeper).blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Scorpion Light Tank (Minesweeper).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Sea Skimmer Hydrofoil ELRM.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Sea Skimmer Hydrofoil ELRM.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Skulker Wheeled Scout Tank MK II.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Skulker Wheeled Scout Tank MK II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Sokar Urban Combat Unit.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Sokar Urban Combat Unit.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Thumper Artillery Vehicle Angel.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Thumper Artillery Vehicle Angel.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Vedette Medium Tank V7.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Vedette Medium Tank V7.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Vidar Heavy Defense Tank.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Vidar Heavy Defense Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/ProtoTypes/Warrior S-9 Stealth Helicopter.blk
+++ b/data/mekfiles/vehicles/ProtoTypes/Warrior S-9 Stealth Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (Chemical).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (Chemical).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (ERLL).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (ERLL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (LB-X).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (Plasma).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Bulldog Medium Tank (Plasma).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Arrow IV).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Arrow IV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Cell).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Clan).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Clan).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Gauss).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (MRM).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (MRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Reinforced).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Demolisher Heavy Tank (Reinforced).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Pegasus Scout Hover Tank (Upgrade).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 25/Pegasus Scout Hover Tank (Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (Fusion).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (Fusion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (LAC).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (LAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (Laser).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (Ultra).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank (Ultra).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Condor Heavy Hover Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Maxim Heavy Hover Transport (Escort).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 26/Maxim Heavy Hover Transport (Escort).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Buzzard Hover Tank.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Buzzard Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Falcon Hover Tank.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Falcon Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-106.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-106.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-106M.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-106M.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-200R.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-200R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-201.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-201.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-300.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Galleon Light Tank GAL-300.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Hawk Hover Tank (LTV-4).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Hawk Hover Tank (LTV-4).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank A.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank B.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank Prime.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank R.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Kamisori Light Tank R.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Patton Tank (Taurian).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Patton Tank (Taurian).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Patton Tank (XL).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 27/Patton Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Ammunition Carriage).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Ammunition Carriage).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Ammunition Loader Carriage).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Ammunition Loader Carriage).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Drone Command Carriage).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Drone Command Carriage).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Support Carriage).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/LT-MOB-25F (Support Carriage).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Mobile Long Tom Artillery LT-MOB-25F.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Mobile Long Tom Artillery LT-MOB-25F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Skulker Wheeled Scout Tank C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Skulker Wheeled Scout Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Assault).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Assault).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Cell).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Heavy Gauss).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Heavy Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (SRM).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Steiner).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Steiner).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Support) 'Gilmore'.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (Support) 'Gilmore'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (WoB).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/SturmFeur Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Warrior Attack Helicopter H-7F.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Warrior Attack Helicopter H-7F.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Whirlwind Scout Hover Tank (AAA).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Whirlwind Scout Hover Tank (AAA).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Whirlwind Scout Hover Tank (IFV).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Whirlwind Scout Hover Tank (IFV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Whirlwind Scout Hover Tank.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 28/Whirlwind Scout Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Browning Mobile HQ (Half Track).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Browning Mobile HQ (Half Track).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Browning Mobile HQ.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Browning Mobile HQ.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Command Van (ICE).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Command Van (ICE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Command Van (Q-Vehicle).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Command Van (Q-Vehicle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Command Van.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Command Van.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT A.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT B.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT D.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT Prime.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Eurus MBT Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Hetzer Wheeled Assault Gun (Cell).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Hetzer Wheeled Assault Gun (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Hetzer Wheeled Assault Gun C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Hetzer Wheeled Assault Gun C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Ontos Heavy Tank (Chemical Laser).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 29/Ontos Heavy Tank (Chemical Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/LRM Carrier C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/LRM Carrier C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL A.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL B.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL D.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL D.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL E.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL E.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL Prime.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Onuris Attack VTOL Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (Clan).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (Clan).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (LB-X).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (Plasma).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (Plasma).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (RAC) 'Assault Pike'.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/Pike Support Vehicle (RAC) 'Assault Pike'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/SRM Carrier C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 30/SRM Carrier C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Davion).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Davion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Kurita Upgrade).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Kurita Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Kurita).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Kurita).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Liao).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Liao).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Refit).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Behemoth Heavy Tank (Refit).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Harrier Heavy Hover Tank (PPC).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Harrier Heavy Hover Tank (PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Harrier Heavy Hover Tank (Re-Laser).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Harrier Heavy Hover Tank (Re-Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Harrier Heavy Hover Tank.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Harrier Heavy Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/MASH Truck (AMS).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/MASH Truck (AMS).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Manticore Heavy Tank (XL).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Manticore Heavy Tank (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Savannah Master Hovercraft (Reflective).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Savannah Master Hovercraft (Reflective).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Skimmer.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 31/Skimmer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank  C 2.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank  C 2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank  C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank  C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank (ERLL).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank (ERLL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank (MML).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank (MML).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank (Streak).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Drillson Heavy Hover Tank (Streak).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (Chemical).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (Chemical).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (Kurita).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (Kurita).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (LAC).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (LAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (Light PPC).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (Light PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (TAG).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (TAG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (X-Pulse).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/J. Edgar Light Hover Tank (X-Pulse).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek AC Carrier (Lothian).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek AC Carrier (Lothian).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek AC Carrier.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek AC Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek Gauss Carrier.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek Gauss Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek PPC Carrier (LB-X).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek PPC Carrier (LB-X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek PPC Carrier (XL).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Schrek PPC Carrier (XL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Vedette Medium Tank (Armor).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Vedette Medium Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K65W.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K65W.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K75N.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K75N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K85N.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K85N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K90.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 32/Von Luckner Heavy Tank VNL-K90.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Desert Scorpion Light Tank.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Desert Scorpion Light Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Goblin III Infantry Support Vehicle.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Goblin III Infantry Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (Heavy Ferro).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (Heavy Ferro).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (LFE).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (LFE).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (Marian}.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (Marian}.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (Speed).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (Speed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (iNarc).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Harasser Missile Platform (iNarc).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Hunter Light Support Tank (Cell).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Hunter Light Support Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Karnov UR Transport (BA Stealth).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Karnov UR Transport (BA Stealth).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (Cell).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (ELRM).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (ELRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (Light Gauss).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (Light Gauss).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (Refit).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Partisan Heavy Tank (Refit).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/SM Tank Destroyer SM1B.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/SM Tank Destroyer SM1B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Armor).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Armor).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Hardened).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Hardened).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (MRM).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (MRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (RAC).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (RAC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Rifle).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Rifle).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Thunderbolt).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Thunderbolt).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Ultra).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank (Ultra).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank C.blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Scorpion Light Tank C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Striker Light Tank (Stealth).blk
+++ b/data/mekfiles/vehicles/Rec Guides ilClan/Vol 33/Striker Light Tank (Stealth).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Shrapnel/Vol 21/Giant Guardian.blk
+++ b/data/mekfiles/vehicles/Shrapnel/Vol 21/Giant Guardian.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Shrapnel/Vol 21/Main Guardian.blk
+++ b/data/mekfiles/vehicles/Shrapnel/Vol 21/Main Guardian.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Shrapnel/Vol 21/Swift Guardian Tank.blk
+++ b/data/mekfiles/vehicles/Shrapnel/Vol 21/Swift Guardian Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Shrapnel/Vol 5/SM5 Field Commander Prime.blk
+++ b/data/mekfiles/vehicles/Shrapnel/Vol 5/SM5 Field Commander Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Somerset Strikers/Packrat LRPV PKR-T5 (TOC).blk
+++ b/data/mekfiles/vehicles/Somerset Strikers/Packrat LRPV PKR-T5 (TOC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TOS/Granada/Auxiliary Defense Tank ADT-1.blk
+++ b/data/mekfiles/vehicles/TOS/Granada/Auxiliary Defense Tank ADT-1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TOS/Granada/Auxiliary Defense Tank ADT-2.blk
+++ b/data/mekfiles/vehicles/TOS/Granada/Auxiliary Defense Tank ADT-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TOS/Tortuga/Debbie 'The Warcrime Wagon'.blk
+++ b/data/mekfiles/vehicles/TOS/Tortuga/Debbie 'The Warcrime Wagon'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TOS/Tortuga/Outrider.blk
+++ b/data/mekfiles/vehicles/TOS/Tortuga/Outrider.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Hoverbike (Laser).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Hoverbike (Laser).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Hoverbike (MG).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Hoverbike (MG).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Hoverbike.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Hoverbike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Minigun Cycle (SRM).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Minigun Cycle (SRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Minigun Cycle.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Minigun Cycle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Monocycle.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Monocycle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Scout ATV.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Scout ATV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/TrackBike.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/TrackBike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Smalls/Trike.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Smalls/Trike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Prime Mover (Original).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Prime Mover (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Prime Mover (Succession Wars).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Prime Mover (Succession Wars).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Prime Mover.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Prime Mover.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Gunship WiGE.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Gunship WiGE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Maritime Patrol WiGE (LB-10X).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Maritime Patrol WiGE (LB-10X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Maritime Patrol WiGE (LB-2X).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Maritime Patrol WiGE (LB-2X).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Maritime Patrol WiGE.blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Sturmvogel Maritime Patrol WiGE.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Wheeled Scout (Camera).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Wheeled Scout (Camera).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Wheeled Scout (Sensors).blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Wheeled Scout (Sensors).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Wheeled Scout .blk
+++ b/data/mekfiles/vehicles/TRO Irregulars/Vehicles/Wheeled Scout .blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Bayamo Hoverbike.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Bayamo Hoverbike.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Buffalo BFFL Hovertruck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Buffalo BFFL Hovertruck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Champion Hoversports CS535 Hover Car.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Champion Hoversports CS535 Hover Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Champion Hoversports Crimson Streak Hover Racer.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Champion Hoversports Crimson Streak Hover Racer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Deusenberg VIP Luxury Hovercar (One).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Deusenberg VIP Luxury Hovercar (One).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Deusenberg VIP Luxury Hovercar (Original).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Deusenberg VIP Luxury Hovercar (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Dillinger Police Vehicle.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Dillinger Police Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Freedom 900 Hover Jeep.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Freedom 900 Hover Jeep.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Ina-du Swamp Skimmer.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Ina-du Swamp Skimmer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Lewis Skimmer Bus.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Lewis Skimmer Bus.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Routemaster Hover Shuttle.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Routemaster Hover Shuttle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Slipper Hovercar LX-Series.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Hover/Slipper Hovercar LX-Series.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Baleena Passenger Submarine.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Baleena Passenger Submarine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Jonah Submarine.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Jonah Submarine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Seahorse Cargo Sub.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Submarine)/Seahorse Cargo Sub.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Atlantia Luxury Yacht.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Atlantia Luxury Yacht.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Silverback Coastal Cutter.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Silverback Coastal Cutter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Silverfin Coastal Cutter.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Silverfin Coastal Cutter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Whitestreak Jetski.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Whitestreak Jetski.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Whitestreak Speedboat.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Naval (Surface)/Whitestreak Speedboat.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Rail/Adelante Passenger-Cargo Train.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Rail/Adelante Passenger-Cargo Train.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Rail/TGV Omni Railcar Primary Configuration.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Rail/TGV Omni Railcar Primary Configuration.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Cellco Ranger UPU-3000.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Cellco Ranger UPU-3000.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Corx Mobile Tunnel Miner.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Corx Mobile Tunnel Miner.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Croyle Systems Cortez Series N.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Croyle Systems Cortez Series N.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Trailer.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Trailer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Tug.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Tug.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Tractor) Series 3.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Tractor) Series 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Trailer) Series 3.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Trailer) Series 3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Bulldozer).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Bulldozer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Cargo).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Crane).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Crane).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Harvester).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Hesiod Utility Vehicle (Harvester).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-10 'Backhoe'.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-10 'Backhoe'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-11 'Rock Cutter'.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-11 'Rock Cutter'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-12 'Chainsaw'.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-12 'Chainsaw'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-14 'Dual Bulldozer'.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Kallon UL-series Construction Vehicle UL-14 'Dual Bulldozer'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Limpet Half-Track.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Limpet Half-Track.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Luciano White Wolverine.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Luciano White Wolverine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Magellan Series Four.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Magellan Series Four.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Raptor.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Raptor.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Rock Rover Half-Track (RRV).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Rock Rover Half-Track (RRV).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Rock Rover Half-Track RRV (Speed).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Rock Rover Half-Track RRV (Speed).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Rumbler-HT.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Rumbler-HT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Saturn Harvester.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Saturn Harvester.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (MASH).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (MASH).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (Mobile Canteen).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck (Mobile Canteen).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Tracked/Sherpa Armored Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Blackstone Baronet Passenger VTOL.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Blackstone Baronet Passenger VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Blackstone Pegasus Passenger VTOL.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Blackstone Pegasus Passenger VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Cascatelle Firefighting VTOL.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Cascatelle Firefighting VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Luxury VTOL Series VI.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Luxury VTOL Series VI.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Personal VTOL Series II.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Lexan Oceanic Personal VTOL Series II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Peacekeeper SWAT Carrier.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Peacekeeper SWAT Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Pion-Laurier Lama-Deux.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Pion-Laurier Lama-Deux.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/SOAR VTOL.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/SOAR VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Sky Eye News Helicopter.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Sky Eye News Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C1.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C2.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/St. Christopher Cargo Transport C2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Swiftran RTC-215M.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/Swiftran RTC-215M.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Aston-Martin Fiver Roadster.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Aston-Martin Fiver Roadster.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Aston-Martin Fiver Traveler.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Aston-Martin Fiver Traveler.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bailey Armored Car.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bailey Armored Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bombduster.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bombduster.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Brunel Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Brunel Dump Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bulldog Medium Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Bulldog Medium Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Burro Heavy Support Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Burro Heavy Support Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Burro II Super Heavy Cargo Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Burro II Super Heavy Cargo Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Ceres-Bikes Flashbang.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Ceres-Bikes Flashbang.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Durandel-British 'Blue Nova' Convertible.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Durandel-British 'Blue Nova' Convertible.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Knox Armored Car.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Knox Armored Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Lesseps Dump Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Mao-Heng Charioteer (Original).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Mao-Heng Charioteer (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Motuo Che Shang No.2.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Motuo Che Shang No.2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Pit Bull Medium Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Pit Bull Medium Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Prairie Schooner Land Train.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Prairie Schooner Land Train.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Prairie Schooner Module.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Prairie Schooner Module.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Saturnus V Grande Circuit Racer.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Saturnus V Grande Circuit Racer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Saurer-Bucher Fire Engine TLF-LL6500.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Saurer-Bucher Fire Engine TLF-LL6500.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Simca Ambulance.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Simca Ambulance.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Skoda 'Growler' Service Utility Truck.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/Wheeled/Skoda 'Growler' Service Utility Truck.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Coanda Personal Sports Craft.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Coanda Personal Sports Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Cormorant Medium Cargo Craft (Cargo).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Cormorant Medium Cargo Craft (Cargo).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Cormorant Medium Cargo Craft.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Cormorant Medium Cargo Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Fulmar Patrol Craft (Original).blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Fulmar Patrol Craft (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Fulmar Patrol Craft.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Fulmar Patrol Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Koi Heavy Transport.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Koi Heavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Quicksilver Personal Sports Craft.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Quicksilver Personal Sports Craft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Ryu Heavy Transport.blk
+++ b/data/mekfiles/vehicles/TRO Vehicle Annex/WiGE/Ryu Heavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/HTP Galtor/Koryu Submarine (Civilian).blk
+++ b/data/mekfiles/vehicles/Turning Points/HTP Galtor/Koryu Submarine (Civilian).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/HTP Galtor/Koryu Submarine (Military).blk
+++ b/data/mekfiles/vehicles/Turning Points/HTP Galtor/Koryu Submarine (Military).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/HTP Galtor/Neptune Submarine (Hunter-Killer).blk
+++ b/data/mekfiles/vehicles/Turning Points/HTP Galtor/Neptune Submarine (Hunter-Killer).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/HTP Glengary/Heavy Weapons Carrier (PPC).blk
+++ b/data/mekfiles/vehicles/Turning Points/HTP Glengary/Heavy Weapons Carrier (PPC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/JTP Atreus/Tokugawa Heavy Tank SD2.blk
+++ b/data/mekfiles/vehicles/Turning Points/JTP Atreus/Tokugawa Heavy Tank SD2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/TP Epsilon Eridani/Pollux II ADA Heavy Tank.blk
+++ b/data/mekfiles/vehicles/Turning Points/TP Epsilon Eridani/Pollux II ADA Heavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/TP Helm/Vedette Medium Tank (AC_10).blk
+++ b/data/mekfiles/vehicles/Turning Points/TP Helm/Vedette Medium Tank (AC_10).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/TP Helm/Weapons Troop Carrier (LRM).blk
+++ b/data/mekfiles/vehicles/Turning Points/TP Helm/Weapons Troop Carrier (LRM).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Turning Points/TP Vega 3039/Flatbed Railcar.blk
+++ b/data/mekfiles/vehicles/Turning Points/TP Vega 3039/Flatbed Railcar.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/Urbanfest/Condor HoverBall.blk
+++ b/data/mekfiles/vehicles/Urbanfest/Condor HoverBall.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Boondocks/Goblin Medium Tank X.blk
+++ b/data/mekfiles/vehicles/XTRs/Boondocks/Goblin Medium Tank X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Boondocks/Heavy LRM Carrier (EN Variant).blk
+++ b/data/mekfiles/vehicles/XTRs/Boondocks/Heavy LRM Carrier (EN Variant).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Boondocks/Hetzer Wheeled Assault Gun (Jadgpanzer II).blk
+++ b/data/mekfiles/vehicles/XTRs/Boondocks/Hetzer Wheeled Assault Gun (Jadgpanzer II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Boondocks/Lexan Surveillance Helo (Prototype).blk
+++ b/data/mekfiles/vehicles/XTRs/Boondocks/Lexan Surveillance Helo (Prototype).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Boondocks/Nishikigoi Support Aircraft.blk
+++ b/data/mekfiles/vehicles/XTRs/Boondocks/Nishikigoi Support Aircraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Boondocks/Sea Hunter Maritime Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Boondocks/Sea Hunter Maritime Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Clans/Athena Combat Vehicle XR.blk
+++ b/data/mekfiles/vehicles/XTRs/Clans/Athena Combat Vehicle XR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Clans/Enyo Strike Tank XR.blk
+++ b/data/mekfiles/vehicles/XTRs/Clans/Enyo Strike Tank XR.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Comstar/Demon Tank CX-2.blk
+++ b/data/mekfiles/vehicles/XTRs/Comstar/Demon Tank CX-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Comstar/Lightning Attack Hovercraft CX-3.blk
+++ b/data/mekfiles/vehicles/XTRs/Comstar/Lightning Attack Hovercraft CX-3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Corporations/Maxim Flanker.blk
+++ b/data/mekfiles/vehicles/XTRs/Corporations/Maxim Flanker.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Corporations/Partisan Hull Defense.blk
+++ b/data/mekfiles/vehicles/XTRs/Corporations/Partisan Hull Defense.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Corporations/Sea Skimmer Hydrofoil Sniper.blk
+++ b/data/mekfiles/vehicles/XTRs/Corporations/Sea Skimmer Hydrofoil Sniper.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Corporations/Skulker Wheeled Scout Tank X-5.blk
+++ b/data/mekfiles/vehicles/XTRs/Corporations/Skulker Wheeled Scout Tank X-5.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Corporations/SturmFeur Kalki Cruise Missile Launcher.blk
+++ b/data/mekfiles/vehicles/XTRs/Corporations/SturmFeur Kalki Cruise Missile Launcher.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Davion/Cavalry Attack Helicopter Cadence Rain.blk
+++ b/data/mekfiles/vehicles/XTRs/Davion/Cavalry Attack Helicopter Cadence Rain.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Davion/Challenger MBT XVc.blk
+++ b/data/mekfiles/vehicles/XTRs/Davion/Challenger MBT XVc.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Davion/Fulcrum Heavy Hovertank X.blk
+++ b/data/mekfiles/vehicles/XTRs/Davion/Fulcrum Heavy Hovertank X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gladiators/Bandit Warthog.blk
+++ b/data/mekfiles/vehicles/XTRs/Gladiators/Bandit Warthog.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gladiators/Manticore The Ballista.blk
+++ b/data/mekfiles/vehicles/XTRs/Gladiators/Manticore The Ballista.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gladiators/Minion Advanced Tactical Vehicle Silver Bullet.blk
+++ b/data/mekfiles/vehicles/XTRs/Gladiators/Minion Advanced Tactical Vehicle Silver Bullet.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gunslingers/Beagle Hover Scout (LRRP).blk
+++ b/data/mekfiles/vehicles/XTRs/Gunslingers/Beagle Hover Scout (LRRP).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gunslingers/Burke II Superheavy Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Gunslingers/Burke II Superheavy Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gunslingers/Cyrano Gunship (Fury).blk
+++ b/data/mekfiles/vehicles/XTRs/Gunslingers/Cyrano Gunship (Fury).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Gunslingers/Rhino Fire Support Tank (Hagar).blk
+++ b/data/mekfiles/vehicles/XTRs/Gunslingers/Rhino Fire Support Tank (Hagar).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Kurita/Hiryo Armored Infantry Transport Hound.blk
+++ b/data/mekfiles/vehicles/XTRs/Kurita/Hiryo Armored Infantry Transport Hound.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Kurita/Pegasus Scout Hover Tank X.blk
+++ b/data/mekfiles/vehicles/XTRs/Kurita/Pegasus Scout Hover Tank X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Kurita/Tokugawa Heavy Tank Yumi.blk
+++ b/data/mekfiles/vehicles/XTRs/Kurita/Tokugawa Heavy Tank Yumi.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Liao/Po Heavy Tank HV Prototype.blk
+++ b/data/mekfiles/vehicles/XTRs/Liao/Po Heavy Tank HV Prototype.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Liao/Regulator Hovertank Alan.blk
+++ b/data/mekfiles/vehicles/XTRs/Liao/Regulator Hovertank Alan.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Liao/Scorpion Light Tank Minesweeper.blk
+++ b/data/mekfiles/vehicles/XTRs/Liao/Scorpion Light Tank Minesweeper.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Marik/Galleon Light Tank Maxwell.blk
+++ b/data/mekfiles/vehicles/XTRs/Marik/Galleon Light Tank Maxwell.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Marik/Thumper Artillery Vehicle Maxwell.blk
+++ b/data/mekfiles/vehicles/XTRs/Marik/Thumper Artillery Vehicle Maxwell.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Mercs/Kanga-X Jump Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Mercs/Kanga-X Jump Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Mercs/Schrek IIX PPC Carrier.blk
+++ b/data/mekfiles/vehicles/XTRs/Mercs/Schrek IIX PPC Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Mercs/Vedette Medium Tank V-G7X.blk
+++ b/data/mekfiles/vehicles/XTRs/Mercs/Vedette Medium Tank V-G7X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Mercs/Warrior HX-9 Attack Helicopter.blk
+++ b/data/mekfiles/vehicles/XTRs/Mercs/Warrior HX-9 Attack Helicopter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Most Wanted/Fensalir Combat WiGE (XXL).blk
+++ b/data/mekfiles/vehicles/XTRs/Most Wanted/Fensalir Combat WiGE (XXL).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Most Wanted/Harasser Missile Platform (Fuel Cell).blk
+++ b/data/mekfiles/vehicles/XTRs/Most Wanted/Harasser Missile Platform (Fuel Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Most Wanted/Hawk Moth Verwandlung.blk
+++ b/data/mekfiles/vehicles/XTRs/Most Wanted/Hawk Moth Verwandlung.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Most Wanted/Karnov UR Transport (Heavy Stealth).blk
+++ b/data/mekfiles/vehicles/XTRs/Most Wanted/Karnov UR Transport (Heavy Stealth).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Most Wanted/Von Luckner Heavy Tank VNL-X71 (Yakuza).blk
+++ b/data/mekfiles/vehicles/XTRs/Most Wanted/Von Luckner Heavy Tank VNL-X71 (Yakuza).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Danai Support Vehicle Arrow.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Danai Support Vehicle Arrow.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #1.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #1.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #2.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #3.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #3.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #4.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #4.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Train.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Train.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Patton Tank SB.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Patton Tank SB.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Periphery/Saladin Assault Hover Tank Ifrit.blk
+++ b/data/mekfiles/vehicles/XTRs/Periphery/Saladin Assault Hover Tank Ifrit.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Phantoms/Ferret Light Scout VTOL (Fermi).blk
+++ b/data/mekfiles/vehicles/XTRs/Phantoms/Ferret Light Scout VTOL (Fermi).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Phantoms/Hi-Scout Drone Carrier (Cunnington).blk
+++ b/data/mekfiles/vehicles/XTRs/Phantoms/Hi-Scout Drone Carrier (Cunnington).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Phantoms/Packrat Gespenst.blk
+++ b/data/mekfiles/vehicles/XTRs/Phantoms/Packrat Gespenst.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Phantoms/SM Tank Destroyer SM1 Telos.blk
+++ b/data/mekfiles/vehicles/XTRs/Phantoms/SM Tank Destroyer SM1 Telos.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Pirates/Anhur P-Stealth.blk
+++ b/data/mekfiles/vehicles/XTRs/Pirates/Anhur P-Stealth.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Pirates/Myrmidon Medium Tank P (Tate).blk
+++ b/data/mekfiles/vehicles/XTRs/Pirates/Myrmidon Medium Tank P (Tate).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Pirates/Ontos Heavy Tank X.blk
+++ b/data/mekfiles/vehicles/XTRs/Pirates/Ontos Heavy Tank X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Pirates/Striker Light Tank Wet.blk
+++ b/data/mekfiles/vehicles/XTRs/Pirates/Striker Light Tank Wet.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives II/AC2 Carrier Primitive.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives II/AC2 Carrier Primitive.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives II/LRM Carrier Primitive.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives II/LRM Carrier Primitive.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives II/Mosquito Light Fighter.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives II/Mosquito Light Fighter.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives II/Randolph Support Vehicle.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives II/Randolph Support Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives II/SRM Carrier Primitive.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives II/SRM Carrier Primitive.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives II/Strike Falcon Attack VTOL.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives II/Strike Falcon Attack VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives III/Alacorn Heavy Tank Mk I.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives III/Alacorn Heavy Tank Mk I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives III/Alacorn Heavy Tank Mk II.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives III/Alacorn Heavy Tank Mk II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives III/Caravan Heavy Transport.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives III/Caravan Heavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives III/Carter MERV.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives III/Carter MERV.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives III/Korvin Tank KRV-2.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives III/Korvin Tank KRV-2.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives IV/Chi-Ha Infantry Combat Vehicle (Original).blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives IV/Chi-Ha Infantry Combat Vehicle (Original).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives IV/Chi-Ha Infantry Combat Vehicle.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives IV/Chi-Ha Infantry Combat Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives IV/Cobra VTOL Transport (Fusion).blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives IV/Cobra VTOL Transport (Fusion).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives IV/Cobra VTOL Transport.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives IV/Cobra VTOL Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives IV/Sturmblitz Assault Gun.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives IV/Sturmblitz Assault Gun.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives V/Apostle Self-Propelled Artillery.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives V/Apostle Self-Propelled Artillery.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives V/Asher Hover Scout.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives V/Asher Hover Scout.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives V/Dunning Mobile Tactical Command Post.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives V/Dunning Mobile Tactical Command Post.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives V/RR-3 Recovery Vehicle.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives V/RR-3 Recovery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives V/Reaper Self-Propelled Artillery.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives V/Reaper Self-Propelled Artillery.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives V/UTR-588 Recovery Vehicle.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives V/UTR-588 Recovery Vehicle.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives/Armored Personnel Carrier (Hover Primitive).blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives/Armored Personnel Carrier (Hover Primitive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives/Armored Personnel Carrier (Tracked Primitive).blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives/Armored Personnel Carrier (Tracked Primitive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives/Armored Personnel Carrier (Wheeled Primitive).blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives/Armored Personnel Carrier (Wheeled Primitive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives/Merkava Heavy Tank MK VI.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives/Merkava Heavy Tank MK VI.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives/Sand Devil Hover Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives/Sand Devil Hover Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Primitives/Stoat Scout Car.blk
+++ b/data/mekfiles/vehicles/XTRs/Primitives/Stoat Scout Car.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RISC/J-27 Ordnance Transport (RISC).blk
+++ b/data/mekfiles/vehicles/XTRs/RISC/J-27 Ordnance Transport (RISC).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RISC/J-27 Trailer (RISC) (Decoy).blk
+++ b/data/mekfiles/vehicles/XTRs/RISC/J-27 Trailer (RISC) (Decoy).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RISC/J-27 Trailer (RISC) (Homing).blk
+++ b/data/mekfiles/vehicles/XTRs/RISC/J-27 Trailer (RISC) (Homing).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Condor Multi-Purpose Tank (Reactive).blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Condor Multi-Purpose Tank (Reactive).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Condor Multi-Purpose Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Condor Multi-Purpose Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Diggs Drone Control Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Diggs Drone Control Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Hexareme HQ Hovercraft.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Hexareme HQ Hovercraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Quaestor Mobile Tactical Command HQ.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Quaestor Mobile Tactical Command HQ.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Strix Stealth VTOL.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Strix Stealth VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) A.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) A.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) B.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) B.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) C.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) C.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) Prime.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic I/Zephyr Hovertank (Omnidrone) Prime.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Republic III/Padilla Anti-Missile Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/Republic III/Padilla Anti-Missile Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RetroTech/Barouche Hovercraft.blk
+++ b/data/mekfiles/vehicles/XTRs/RetroTech/Barouche Hovercraft.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RetroTech/HW1 Hwacha.blk
+++ b/data/mekfiles/vehicles/XTRs/RetroTech/HW1 Hwacha.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RetroTech/Humming Bird Rescue VTOL.blk
+++ b/data/mekfiles/vehicles/XTRs/RetroTech/Humming Bird Rescue VTOL.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RetroTech/Nike Tank.blk
+++ b/data/mekfiles/vehicles/XTRs/RetroTech/Nike Tank.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/RetroTech/White Tip Submarine.blk
+++ b/data/mekfiles/vehicles/XTRs/RetroTech/White Tip Submarine.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Steiner/Centipede Scout Car Commando.blk
+++ b/data/mekfiles/vehicles/XTRs/Steiner/Centipede Scout Car Commando.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Steiner/Demolisher II Heavy Tank II -X.blk
+++ b/data/mekfiles/vehicles/XTRs/Steiner/Demolisher II Heavy Tank II -X.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Steiner/Rommel Tank (Howitzer) Prototype.blk
+++ b/data/mekfiles/vehicles/XTRs/Steiner/Rommel Tank (Howitzer) Prototype.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Succession Wars/Buffalo Drone Bomb.blk
+++ b/data/mekfiles/vehicles/XTRs/Succession Wars/Buffalo Drone Bomb.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Succession Wars/Condor Heavy Hover Tank (Fission).blk
+++ b/data/mekfiles/vehicles/XTRs/Succession Wars/Condor Heavy Hover Tank (Fission).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Succession Wars/J. Edgar Light Hover Tank (Cell).blk
+++ b/data/mekfiles/vehicles/XTRs/Succession Wars/J. Edgar Light Hover Tank (Cell).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Succession Wars/Kestrel VTOL Scout.blk
+++ b/data/mekfiles/vehicles/XTRs/Succession Wars/Kestrel VTOL Scout.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/vehicles/XTRs/Succession Wars/Soarece Superheavy MBT.blk
+++ b/data/mekfiles/vehicles/XTRs/Succession Wars/Soarece Superheavy MBT.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Aegis Heavy Cruiser (2843).blk
+++ b/data/mekfiles/warship/3057/Clan/Aegis Heavy Cruiser (2843).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Black Lion II Battlecruiser (2843).blk
+++ b/data/mekfiles/warship/3057/Clan/Black Lion II Battlecruiser (2843).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Cameron Battlecruiser (2851).blk
+++ b/data/mekfiles/warship/3057/Clan/Cameron Battlecruiser (2851).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Carrack Transport (Merchant 2985).blk
+++ b/data/mekfiles/warship/3057/Clan/Carrack Transport (Merchant 2985).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Congress Frigate (2914).blk
+++ b/data/mekfiles/warship/3057/Clan/Congress Frigate (2914).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Essex II Destroyer (2962).blk
+++ b/data/mekfiles/warship/3057/Clan/Essex II Destroyer (2962).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Fredasa (Corvette-Raider) (2962).blk
+++ b/data/mekfiles/warship/3057/Clan/Fredasa (Corvette-Raider) (2962).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Liberator Cruiser (3024).blk
+++ b/data/mekfiles/warship/3057/Clan/Liberator Cruiser (3024).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Lola III Destroyer (2841).blk
+++ b/data/mekfiles/warship/3057/Clan/Lola III Destroyer (2841).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/McKenna Battleship (2851).blk
+++ b/data/mekfiles/warship/3057/Clan/McKenna Battleship (2851).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Nightlord Battleship (2932).blk
+++ b/data/mekfiles/warship/3057/Clan/Nightlord Battleship (2932).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Potemkin Troop Cruiser (2875).blk
+++ b/data/mekfiles/warship/3057/Clan/Potemkin Troop Cruiser (2875).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Sovetskii Soyuz Heavy Cruiser (2845).blk
+++ b/data/mekfiles/warship/3057/Clan/Sovetskii Soyuz Heavy Cruiser (2845).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Sovetskii Soyuz Heavy Cruiser (Dire Wolf) (2845).blk
+++ b/data/mekfiles/warship/3057/Clan/Sovetskii Soyuz Heavy Cruiser (Dire Wolf) (2845).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Texas Battleship (2835).blk
+++ b/data/mekfiles/warship/3057/Clan/Texas Battleship (2835).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Vincent Corvette Mk42.blk
+++ b/data/mekfiles/warship/3057/Clan/Vincent Corvette Mk42.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Volga Transport (2836).blk
+++ b/data/mekfiles/warship/3057/Clan/Volga Transport (2836).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/Whirlwind Destroyer (2901).blk
+++ b/data/mekfiles/warship/3057/Clan/Whirlwind Destroyer (2901).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/Clan/York Destroyer-Carrier (2947).blk
+++ b/data/mekfiles/warship/3057/Clan/York Destroyer-Carrier (2947).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Aegis Heavy Cruiser (2372).blk
+++ b/data/mekfiles/warship/3057/IS/Aegis Heavy Cruiser (2372).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Aegis Heavy Cruiser (2582).blk
+++ b/data/mekfiles/warship/3057/IS/Aegis Heavy Cruiser (2582).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Atreus Battleship (2552).blk
+++ b/data/mekfiles/warship/3057/IS/Atreus Battleship (2552).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Avatar Heavy Cruiser (2531).blk
+++ b/data/mekfiles/warship/3057/IS/Avatar Heavy Cruiser (2531).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Baron Destroyer (2520).blk
+++ b/data/mekfiles/warship/3057/IS/Baron Destroyer (2520).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Black Lion II Battlecruiser (2691).blk
+++ b/data/mekfiles/warship/3057/IS/Black Lion II Battlecruiser (2691).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Bonaventure Corvette (2317).blk
+++ b/data/mekfiles/warship/3057/IS/Bonaventure Corvette (2317).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Cameron Battlecruiser (2688).blk
+++ b/data/mekfiles/warship/3057/IS/Cameron Battlecruiser (2688).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Carrack Transport (2600).blk
+++ b/data/mekfiles/warship/3057/IS/Carrack Transport (2600).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Carson Destroyer (2632).blk
+++ b/data/mekfiles/warship/3057/IS/Carson Destroyer (2632).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Congress Frigate (2542).blk
+++ b/data/mekfiles/warship/3057/IS/Congress Frigate (2542).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Dart Light Cruiser (2305).blk
+++ b/data/mekfiles/warship/3057/IS/Dart Light Cruiser (2305).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Davion Destroyer Block I.blk
+++ b/data/mekfiles/warship/3057/IS/Davion Destroyer Block I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Davion Destroyer Block II.blk
+++ b/data/mekfiles/warship/3057/IS/Davion Destroyer Block II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Essex II Destroyer (2711).blk
+++ b/data/mekfiles/warship/3057/IS/Essex II Destroyer (2711).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Farragut Battleship (2448).blk
+++ b/data/mekfiles/warship/3057/IS/Farragut Battleship (2448).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Fox Corvette (3057).blk
+++ b/data/mekfiles/warship/3057/IS/Fox Corvette (3057).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Impavido Destroyer (3058).blk
+++ b/data/mekfiles/warship/3057/IS/Impavido Destroyer (3058).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Kimagure Pursuit Cruiser (2582).blk
+++ b/data/mekfiles/warship/3057/IS/Kimagure Pursuit Cruiser (2582).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Kirishima Cruiser (3061).blk
+++ b/data/mekfiles/warship/3057/IS/Kirishima Cruiser (3061).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Kyushu Frigate (3057).blk
+++ b/data/mekfiles/warship/3057/IS/Kyushu Frigate (3057).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Lola I Destroyer (2345).blk
+++ b/data/mekfiles/warship/3057/IS/Lola I Destroyer (2345).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Lola II Destroyer (2622).blk
+++ b/data/mekfiles/warship/3057/IS/Lola II Destroyer (2622).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Lola III Destroyer (2662).blk
+++ b/data/mekfiles/warship/3057/IS/Lola III Destroyer (2662).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Luxor Heavy Cruiser (2727).blk
+++ b/data/mekfiles/warship/3057/IS/Luxor Heavy Cruiser (2727).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Mako Corvette (2692).blk
+++ b/data/mekfiles/warship/3057/IS/Mako Corvette (2692).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/McKenna Battleship (2652).blk
+++ b/data/mekfiles/warship/3057/IS/McKenna Battleship (2652).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Monsoon Battleship (2368).blk
+++ b/data/mekfiles/warship/3057/IS/Monsoon Battleship (2368).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Monsoon Battleship (2574).blk
+++ b/data/mekfiles/warship/3057/IS/Monsoon Battleship (2574).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Monsoon Battleship (LF) (2574).blk
+++ b/data/mekfiles/warship/3057/IS/Monsoon Battleship (LF) (2574).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Naga Destroyer (2645).blk
+++ b/data/mekfiles/warship/3057/IS/Naga Destroyer (2645).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Nightwing Surveillance (2447).blk
+++ b/data/mekfiles/warship/3057/IS/Nightwing Surveillance (2447).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Pinto Corvette (2502).blk
+++ b/data/mekfiles/warship/3057/IS/Pinto Corvette (2502).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Potemkin Troop Cruiser (2611).blk
+++ b/data/mekfiles/warship/3057/IS/Potemkin Troop Cruiser (2611).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Quixote Frigate (2350).blk
+++ b/data/mekfiles/warship/3057/IS/Quixote Frigate (2350).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Riga Frigate (2440).blk
+++ b/data/mekfiles/warship/3057/IS/Riga Frigate (2440).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Sovetskii Soyuz Heavy Cruiser (2742).blk
+++ b/data/mekfiles/warship/3057/IS/Sovetskii Soyuz Heavy Cruiser (2742).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Suffren Destroyer (3062).blk
+++ b/data/mekfiles/warship/3057/IS/Suffren Destroyer (3062).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Sylvester Transport (2499).blk
+++ b/data/mekfiles/warship/3057/IS/Sylvester Transport (2499).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Texas Battleship (2618).blk
+++ b/data/mekfiles/warship/3057/IS/Texas Battleship (2618).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Tracker Surveillance (2407).blk
+++ b/data/mekfiles/warship/3057/IS/Tracker Surveillance (2407).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Vigilant Corvette (2320).blk
+++ b/data/mekfiles/warship/3057/IS/Vigilant Corvette (2320).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Vincent Corvette Mk39.blk
+++ b/data/mekfiles/warship/3057/IS/Vincent Corvette Mk39.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Volga Transport (2709).blk
+++ b/data/mekfiles/warship/3057/IS/Volga Transport (2709).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Wagon Wheel Frigate (2570).blk
+++ b/data/mekfiles/warship/3057/IS/Wagon Wheel Frigate (2570).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Whirlwind Destroyer (2606).blk
+++ b/data/mekfiles/warship/3057/IS/Whirlwind Destroyer (2606).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3057/IS/Winchester Cruiser (2364).blk
+++ b/data/mekfiles/warship/3057/IS/Winchester Cruiser (2364).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Clan/Carrack Transport (Clan).blk
+++ b/data/mekfiles/warship/3067/Clan/Carrack Transport (Clan).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Clan/Conqueror Battlecruiser Carrier.blk
+++ b/data/mekfiles/warship/3067/Clan/Conqueror Battlecruiser Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Clan/Leviathan Heavy Transport.blk
+++ b/data/mekfiles/warship/3067/Clan/Leviathan Heavy Transport.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Clan/Leviathan II Battleship.blk
+++ b/data/mekfiles/warship/3067/Clan/Leviathan II Battleship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Comstar/Dante Frigate.blk
+++ b/data/mekfiles/warship/3067/Comstar/Dante Frigate.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Davion/Avalon Cruiser.blk
+++ b/data/mekfiles/warship/3067/Davion/Avalon Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Kurita/Inazuma Corvette.blk
+++ b/data/mekfiles/warship/3067/Kurita/Inazuma Corvette.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Kurita/Tatsumaki Destroyer.blk
+++ b/data/mekfiles/warship/3067/Kurita/Tatsumaki Destroyer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Liao/Feng Huang Cruiser (Upgrade).blk
+++ b/data/mekfiles/warship/3067/Liao/Feng Huang Cruiser (Upgrade).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Liao/Feng Huang Cruiser.blk
+++ b/data/mekfiles/warship/3067/Liao/Feng Huang Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Marik/Agamemnon Heavy Cruiser.blk
+++ b/data/mekfiles/warship/3067/Marik/Agamemnon Heavy Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Marik/Eagle Frigate.blk
+++ b/data/mekfiles/warship/3067/Marik/Eagle Frigate.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Marik/Thera Carrier.blk
+++ b/data/mekfiles/warship/3067/Marik/Thera Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Marik/Zechetinu Corvette.blk
+++ b/data/mekfiles/warship/3067/Marik/Zechetinu Corvette.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Marik/Zechetinu II Corvette.blk
+++ b/data/mekfiles/warship/3067/Marik/Zechetinu II Corvette.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3067/Steiner/Mjolnir Battlecruiser.blk
+++ b/data/mekfiles/warship/3067/Steiner/Mjolnir Battlecruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Du Shi Wang Battleship.blk
+++ b/data/mekfiles/warship/3075/Du Shi Wang Battleship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Robinson Transport (Block I).blk
+++ b/data/mekfiles/warship/3075/Robinson Transport (Block I).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Robinson Transport (Block II).blk
+++ b/data/mekfiles/warship/3075/Robinson Transport (Block II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Samarkand Carrier (Block I).blk
+++ b/data/mekfiles/warship/3075/Samarkand Carrier (Block I).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Samarkand Carrier (Block II).blk
+++ b/data/mekfiles/warship/3075/Samarkand Carrier (Block II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Tharkad Battlecruiser (2690).blk
+++ b/data/mekfiles/warship/3075/Tharkad Battlecruiser (2690).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3075/Tharkad Battlecruiser (WoB).blk
+++ b/data/mekfiles/warship/3075/Tharkad Battlecruiser (WoB).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/3085S/Newgrange III Yardship.blk
+++ b/data/mekfiles/warship/3085S/Newgrange III Yardship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/ED Golden Centrury/Quicksilver Mongoose Battleship.blk
+++ b/data/mekfiles/warship/ED Golden Centrury/Quicksilver Mongoose Battleship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Capellan/Black Lion I Battlecruiser.blk
+++ b/data/mekfiles/warship/FR 2765/Capellan/Black Lion I Battlecruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Capellan/Soyal Heavy Cruiser.blk
+++ b/data/mekfiles/warship/FR 2765/Capellan/Soyal Heavy Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Davion/Congress D Frigate.blk
+++ b/data/mekfiles/warship/FR 2765/Davion/Congress D Frigate.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Davion/Defender Battlecruiser.blk
+++ b/data/mekfiles/warship/FR 2765/Davion/Defender Battlecruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Draconis Combine/Cruiser.blk
+++ b/data/mekfiles/warship/FR 2765/Draconis Combine/Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Draconis Combine/Narukami Destroyer (Block I).blk
+++ b/data/mekfiles/warship/FR 2765/Draconis Combine/Narukami Destroyer (Block I).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Draconis Combine/Narukami Destroyer (Block II).blk
+++ b/data/mekfiles/warship/FR 2765/Draconis Combine/Narukami Destroyer (Block II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/FWL/League Destroyer (Block I).blk
+++ b/data/mekfiles/warship/FR 2765/FWL/League Destroyer (Block I).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/FWL/League Destroyer (Block II).blk
+++ b/data/mekfiles/warship/FR 2765/FWL/League Destroyer (Block II).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Periphery/Athena Cruiser.blk
+++ b/data/mekfiles/warship/FR 2765/Periphery/Athena Cruiser.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Periphery/Essex I Destroyer.blk
+++ b/data/mekfiles/warship/FR 2765/Periphery/Essex I Destroyer.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Periphery/Riga II Destroyer-Carrier (2747).blk
+++ b/data/mekfiles/warship/FR 2765/Periphery/Riga II Destroyer-Carrier (2747).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Steiner/Commonwealth Light Cruiser Block I.blk
+++ b/data/mekfiles/warship/FR 2765/Steiner/Commonwealth Light Cruiser Block I.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/FR 2765/Steiner/Commonwealth Light Cruiser Block II.blk
+++ b/data/mekfiles/warship/FR 2765/Steiner/Commonwealth Light Cruiser Block II.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Golden Century/Corone Corvette.blk
+++ b/data/mekfiles/warship/Golden Century/Corone Corvette.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Golden Century/Molniya Corvette (2951).blk
+++ b/data/mekfiles/warship/Golden Century/Molniya Corvette (2951).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Golden Century/Peregrine Corvette.blk
+++ b/data/mekfiles/warship/Golden Century/Peregrine Corvette.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Hist LOT I/Capital Drone M-5 'Caspar'.blk
+++ b/data/mekfiles/warship/Hist LOT I/Capital Drone M-5 'Caspar'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Hist LOT I/Capital Drone M-5C 'Caspar'.blk
+++ b/data/mekfiles/warship/Hist LOT I/Capital Drone M-5C 'Caspar'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Hist LOT II/Stefan Amaris Battleship.blk
+++ b/data/mekfiles/warship/Hist LOT II/Stefan Amaris Battleship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Hist Reunification War/Concordat Frigate (2506).blk
+++ b/data/mekfiles/warship/Hist Reunification War/Concordat Frigate (2506).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Hist Reunification War/Dreadnought Battleship (2330).blk
+++ b/data/mekfiles/warship/Hist Reunification War/Dreadnought Battleship (2330).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/Hist Reunification War/New Syrtis Carrier (2557).blk
+++ b/data/mekfiles/warship/Hist Reunification War/New Syrtis Carrier (2557).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/IE3/Bug Eye Surveillance Ship.blk
+++ b/data/mekfiles/warship/IE3/Bug Eye Surveillance Ship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/IE3/Faslane Yard Ship.blk
+++ b/data/mekfiles/warship/IE3/Faslane Yard Ship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/JHS 3076/Newgrange III Yardship 'Eyrines'.blk
+++ b/data/mekfiles/warship/JHS 3076/Newgrange III Yardship 'Eyrines'.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/JHS Terra/Naga Destroyer (Caspar II Control Ship).blk
+++ b/data/mekfiles/warship/JHS Terra/Naga Destroyer (Caspar II Control Ship).blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/ToS Valencia/Conestoga Transport Jumpship.blk
+++ b/data/mekfiles/warship/ToS Valencia/Conestoga Transport Jumpship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/XTR/Boondoogles/Enterprise Super Carrier.blk
+++ b/data/mekfiles/warship/XTR/Boondoogles/Enterprise Super Carrier.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/XTR/Gunslingers/Kimagure Pursuit Cruiser Surprise.blk
+++ b/data/mekfiles/warship/XTR/Gunslingers/Kimagure Pursuit Cruiser Surprise.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers

--- a/data/mekfiles/warship/XTR/Republic III/Leviathan III Battleship.blk
+++ b/data/mekfiles/warship/XTR/Republic III/Leviathan III Battleship.blk
@@ -1,4 +1,4 @@
-# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
 # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
 #
 # NOTICE: The MegaMek organization is a non-profit group of volunteers


### PR DESCRIPTION
Commit e01f517a21 (full resave with UUID and updated format) rewrote every unit file with a header stamped 2026 only. That flattened the 2025-2026 ranges set deliberately in a6f64e7b57, dropping 2025 from 10,884 files whose content dates from 2025.

This restores the range on exactly those files. The set is the intersection of files carrying the range immediately before the resave with files carrying a bare 2026 now, so the 672 files genuinely created in 2026 keep their single year. Nothing else in the files is touched: every change is one header line.

The resaver itself is fixed separately in megamek, otherwise the next full resave flattens these again.