### PR TITLE
Removed space after industrial armor (normalized to all other armors)

### DIFF
--- a/data/mekfiles/meks/3075/DemolitionMech WI-DM.mtf
+++ b/data/mekfiles/meks/3075/DemolitionMech WI-DM.mtf
@@ -41,7 +41,7 @@ heat sinks:1 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:8
 RA armor:8
 LT armor:8

--- a/data/mekfiles/meks/3075/DemolitionMech WI-DM2.mtf
+++ b/data/mekfiles/meks/3075/DemolitionMech WI-DM2.mtf
@@ -39,7 +39,7 @@ heat sinks:1 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:7
 RA armor:7
 LT armor:7

--- a/data/mekfiles/meks/3075/Hyena HYN-4B SalvageMech.mtf
+++ b/data/mekfiles/meks/3075/Hyena HYN-4B SalvageMech.mtf
@@ -39,7 +39,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:7
 RA armor:7
 LT armor:8

--- a/data/mekfiles/meks/3075/Jabberwocky EngineerMech JAW-65A.mtf
+++ b/data/mekfiles/meks/3075/Jabberwocky EngineerMech JAW-65A.mtf
@@ -41,7 +41,7 @@ heat sinks:8 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:3

--- a/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech (Rocket).mtf
+++ b/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech (Rocket).mtf
@@ -41,7 +41,7 @@ heat sinks:3 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:4

--- a/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Carbine CON-1 ConstructionMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:4

--- a/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 ForestryMech.mtf
+++ b/data/mekfiles/meks/Operation Klondike/Crosscut ED-X2 ForestryMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:5

--- a/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H2 MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Centurion CN9-H2 MilitiaMech.mtf
@@ -40,7 +40,7 @@ heat sinks:10 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:10
 RA armor:10
 LT armor:10

--- a/data/mekfiles/meks/TRO Irregulars/DemolitionMech WI-DMM MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/DemolitionMech WI-DMM MOD.mtf
@@ -39,7 +39,7 @@ heat sinks:4 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:8
 RA armor:8
 LT armor:8

--- a/data/mekfiles/meks/TRO Irregulars/Exo HMX-1 Haulermech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Exo HMX-1 Haulermech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:2
 RA armor:2
 LT armor:2

--- a/data/mekfiles/meks/TRO Irregulars/Exo HMX-2 Haulermech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Exo HMX-2 Haulermech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:2
 RA armor:2
 LT armor:2

--- a/data/mekfiles/meks/TRO Irregulars/Firebee WI-WAM MilitiaMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Firebee WI-WAM MilitiaMech.mtf
@@ -41,7 +41,7 @@ heat sinks:3 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:7
 RA armor:7
 LT armor:7

--- a/data/mekfiles/meks/TRO Irregulars/Heavy Lifter HCL-1M CargoMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Heavy Lifter HCL-1M CargoMech MOD.mtf
@@ -39,7 +39,7 @@ heat sinks:11 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 FLL armor:16
 FRL armor:16
 LT armor:21

--- a/data/mekfiles/meks/TRO Irregulars/Pacifier CCU-36 SecurityMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/Pacifier CCU-36 SecurityMech.mtf
@@ -39,7 +39,7 @@ heat sinks:3 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:6
 RA armor:6
 LT armor:7

--- a/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV ConstructionMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:6
 RA armor:6
 LT armor:7

--- a/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV-M ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/StrongArm SC CV-M ConstructionMech MOD.mtf
@@ -41,7 +41,7 @@ heat sinks:1 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:6
 RA armor:6
 LT armor:7

--- a/data/mekfiles/meks/TRO Irregulars/StrongArm SC CVI ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Irregulars/StrongArm SC CVI ConstructionMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:6
 RA armor:6
 LT armor:7

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7 ConstructionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7 ConstructionMech.mtf
@@ -45,7 +45,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:4

--- a/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7M ConstructionMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Carbine CON-7M ConstructionMech MOD.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:4

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R 'Herder' IndustrialMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R 'Herder' IndustrialMech.mtf
@@ -42,7 +42,7 @@ heat sinks:0 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:4
 RA armor:4
 LT armor:4

--- a/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R2 'Hunter' IndustrialMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/CattleMaster CTL-3R2 'Hunter' IndustrialMech.mtf
@@ -40,7 +40,7 @@ heat sinks:1 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:4
 RA armor:4
 LT armor:4

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X1 LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X1 LoggerMech.mtf
@@ -41,7 +41,7 @@ heat sinks:10 Single
 walk mp:5
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:5

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X2M LoggerMech MOD.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X2M LoggerMech MOD.mtf
@@ -41,7 +41,7 @@ heat sinks:1 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:5
 RA armor:5
 LT armor:5

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4 LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4 LoggerMech.mtf
@@ -43,7 +43,7 @@ heat sinks:0 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:5

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4B DemolitionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4B DemolitionMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:5

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4D DemolitionMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4D DemolitionMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:5

--- a/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4X LoggerMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Crosscut ED-X4X LoggerMech.mtf
@@ -41,7 +41,7 @@ heat sinks:0 Single
 walk mp:3
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 LA armor:3
 RA armor:3
 LT armor:5

--- a/data/mekfiles/meks/TRO Vehicle Annex/Heavy Lifter HCL-1 CargoMech.mtf
+++ b/data/mekfiles/meks/TRO Vehicle Annex/Heavy Lifter HCL-1 CargoMech.mtf
@@ -41,7 +41,7 @@ heat sinks:10 Single
 walk mp:4
 jump mp:0
 
-armor:Industrial (Inner Sphere)
+armor:Industrial(Inner Sphere)
 FLL armor:16
 FRL armor:16
 LT armor:21


### PR DESCRIPTION
This PR removes the space in the mtf after `Industrial `.
This way all armors are now normalized to the standard (no space).