### PR TITLE
Updated Gradle Actions to Make Staging Data Less Painful

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,13 @@ repositories {
     mavenCentral()
 }
 
+// mm-data only produces the zipped artifacts (unit files, RATs, planetary systems)
+// that the consuming projects (MegaMek, MegaMekLab, MekHQ) substitute for the loose
+// source files. The consumers' own `stageDataFiles` tasks now copy the remaining
+// loose data directly out of `mm-data/data`, so there is no intermediate staging
+// copy here. Removing that copy avoids moving ~900 MB of image/board data twice per
+// build; see each consumer's build.gradle for the split, incremental sync tasks.
+
 tasks.register<Zip>("unitFilesZip") {
     description = "Creates zip archives of all the unit file folders (excluding loose .txt and .xml files)."
     group = "build"
@@ -82,132 +89,4 @@ tasks.register<Zip>("connectorSystemZip") {
     from("data/universe/planetary_systems/connector_systems/")
     destinationDirectory.set(File(stagingFolder, "universe/planetary_systems"))
     archiveFileName.set("connector_systems.zip")
-}
-
-tasks.register<Copy>("stageMMFiles") {
-    description = "Stages files for MM"
-    group = "build"
-
-    dependsOn("ratZip")
-    dependsOn("unitFilesZip")
-
-    from("data") {
-        include("boards/**/*.*")
-        include("css/**/*.*")
-        include("fonts/**/*.*")
-        include("forcegenerator/**/*.*")
-        include("images/camo/**/*.*")
-        include("images/fluff/**/*.*")
-        include("images/hexes/**/*.*")
-        include("images/misc/**/*.*")
-        include("images/portraits/**/*.*")
-        include("images/temp/**/*.*")
-        include("images/units/**/*.*")
-        include("images/universe/**/*.*")
-        include("images/widgets/**/*.*")
-        include("mapgen/**/*.*")
-        include("mapsetup/**/*.*")
-        include("mekfiles/*.txt")
-        include("mekfiles/*.xml")
-        exclude("mekfiles/*.cache")
-        include("names/**/*.*")
-        include("scenarios/**/*.*")
-        include("sounds/**/*.*")
-        include("sourcebooks/*.*")
-        include("universe/eras.xml")
-        include("universe/ranks.xml")
-        include("universe/commands/**/*.*")
-        include("universe/factions/**/*.*")
-    }
-
-    from(stagingFolder) {
-        include("mekfiles/**/*.*")
-        include("rat/**/*.*")
-        exclude("mekfiles/*.cache")
-    }
-
-    into("${stagingFolder}/mm")
-}
-
-tasks.register<Copy>("stageMMLFiles") {
-    description = "Stages files for MML"
-    group = "build"
-
-    mustRunAfter("ratZip")
-    mustRunAfter("unitFilesZip")
-    dependsOn("ratZip")
-    dependsOn("unitFilesZip")
-
-    from("data") {
-        include("fonts/**/*.*")
-        include("forcegenerator/**/*.*")
-        include("images/fluff/**/*.*")
-        include("images/misc/**/*.*")
-        include("images/recordsheets/**/*.*")
-        include("images/units/**/*.*")
-        include("images/universe/**/*.*")
-        include("images/widgets/**/*.*")
-        include("mekfiles/*.txt")
-        include("mekfiles/*.xml")
-        exclude("mekfiles/*.cache")
-        include("names/**/*.*")
-        include("sourcebooks/*.*")
-        include("universe/commands/**/*.*")
-        include("universe/factions/**/*.*")
-        include("universe/eras.xml")
-        include("universe/ranks.xml")
-    }
-
-    from(stagingFolder) {
-        include("mekfiles/**/*.*")
-        include("rat/**/*.*")
-        exclude("mekfiles/*.cache")
-    }
-
-    into("${stagingFolder}/mml")
-}
-
-tasks.register<Copy>("stageFiles") {
-    description = "Stages files for All / MekHQ"
-    group = "build"
-
-    mustRunAfter("ratZip")
-    mustRunAfter("unitFilesZip")
-    mustRunAfter("canonSystemZip")
-    mustRunAfter("connectorSystemZip")
-    dependsOn("ratZip")
-    dependsOn("unitFilesZip")
-    dependsOn("canonSystemZip")
-    dependsOn("connectorSystemZip")
-
-    from("data/mekfiles") {
-        include("*.txt")
-        include("*.xml")
-        into("mekfiles")
-    }
-
-    from("data") {
-        exclude("mekfiles")
-        exclude("rat")
-        exclude("universe/planetary_systems/canon_systems")
-        exclude("universe/planetary_systems/connector_systems")
-        include("**/*.*")
-    }
-
-    from(stagingFolder) {
-        include("mekfiles/**/*.*")
-        exclude("mekfiles/*.cache")
-        include("rat/**/*.*")
-        include("universe/**/*.*")
-    }
-
-    // Mirror faction logos into images/force/Units so MekHQ's force-icon code
-    // can resolve them under data/images/force/ without duplicating the files
-    // in the source tree. The original images/universe/factions/ is preserved
-    // by the include("**/*.*") block above.
-    from("data/images/universe/factions") {
-        into("images/force/Units")
-    }
-
-    into("${stagingFolder}/all")
 }


### PR DESCRIPTION
# REQUIRES https://github.com/MegaMek/mekhq/pull/9707
# REQUIRES https://github.com/MegaMek/megameklab/pull/2278
# REQUIRES https://github.com/MegaMek/megamek/pull/8615

# Disclaimer
I'm not Tex and I can't replace Tex. I'm a monkey with a keyboard being fact checked by Claude. It's possible this PR could cause everything to explode and need to be rolled back. I am fully open to this and happy for it to take place. At this venture all I can do is say "works on my machine" and hope it works on yours' too.

# Introduction
Moving to a single data directory was one of our best - and worst - ideas. Not because it was a bad move, it is objectively better than anything we had before. Tex was 100% right in making the switch and we've all benefited from the change.

It was 'bad' because of how painful it made working with data. No so much instantial changes where you change one thing and move on with your life, but iterative changes became a nightmare. Every little change resulted in 7-10 minutes of waiting for data to stage before you could even check if your fix/change worked. This quickly mounts up to hours of lost dev time over any given week.

# How Things Used to Work
Essentially we were building the entire data directory twice.

First we were prepping it for duplication and then we were duplicating it. This meant that we were building and then moving nearly a gig of data _twice_. Any time anything changes - even a single white space - we would need to copy and distribute this data block _twice_.

If you, like me, have a terrible computer the processing takes forever. In my case this was made worse by me having to work off a pen drive due to hdd constraints. 

# How Things Work Now
The immediate change is that rather than viewing the data directory as a single gig-sized whole, we break it up into separate 'boxes'. If something changes within a box - say, the boards directory - then only that box is rebuild.

So, in the example above, if you change a single white space in a directory we only need to restate that directory (or the 'box' it's in for small directories).

We also threw out the middleman step where we previously prepped data for staging and then staged it (the double-handling). Removing that means we are facing **significantly** reduced staging time by a magnitude.

# The Difference
## Before (full build)
<img width="505" height="28" alt="image" src="https://github.com/user-attachments/assets/f02cca89-e4e1-4376-b4b8-01db6e1c2e01" />

## After (full build)
<img width="523" height="28" alt="image" src="https://github.com/user-attachments/assets/70f2e113-cdc4-45f5-bf80-8a20fea12acb" />

## After (partial build, after making a data change)
<img width="505" height="28" alt="image" src="https://github.com/user-attachments/assets/f6b9f569-7350-41cd-9c53-934ddc4f8d40" />