### PR TITLE
Add Princess evaluation scenarios for the AI match harness

### DIFF
--- a/data/scenarios/Evaluation/PrincessEval_ForcedWithdrawal.mms
+++ b/data/scenarios/Evaluation/PrincessEval_ForcedWithdrawal.mms
@@ -1,0 +1,106 @@
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+MMSVersion: 2
+name: Princess Evaluation - Forced Withdrawal
+description: >
+  Headless bot-vs-bot benchmark scenario for AIMatchRunner. Two identical mixed lances with default
+  Princess behavior and Forced Withdrawal enabled fight until one side is destroyed or withdraws.
+  Intended to measure whether crippled units actually retreat to their withdrawal edge (and keep
+  defending themselves) rather than loitering in the engagement zone. The first faction is the
+  unit-less watcher slot claimed by the headless runner; the two bot factions mirror each other so
+  before/after comparisons only measure code changes, not force imbalance.
+
+map: Map Set 2/16x17 BattleTech.board
+
+factions:
+- name: Observer
+  # Unit-less watcher slot; ScenarioGameRunner claims the first faction with a headless client.
+
+- name: North Lance
+  deploy: N
+  bot:
+    # DEFAULT preset values written out; scenarios cannot reference named presets
+    selfpreservation: 5
+    fallshame: 5
+    hyperaggression: 5
+    herdmentality: 5
+    bravery: 5
+    forcedwithdraw: true
+    withdrawto: NORTH
+    flee: false
+  units:
+  - fullname: Archer ARC-2R
+    crew:
+      name: Eval Pilot N1
+      gunnery: 3
+      piloting: 4
+  - fullname: Marauder MAD-3R
+    crew:
+      name: Eval Pilot N2
+      gunnery: 3
+      piloting: 4
+  - fullname: Wolverine WVR-6R
+    crew:
+      name: Eval Pilot N3
+      gunnery: 3
+      piloting: 4
+  - fullname: Hunchback HBK-4G
+    crew:
+      name: Eval Pilot N4
+      gunnery: 3
+      piloting: 4
+
+- name: South Lance
+  deploy: S
+  bot:
+    selfpreservation: 5
+    fallshame: 5
+    hyperaggression: 5
+    herdmentality: 5
+    bravery: 5
+    forcedwithdraw: true
+    withdrawto: SOUTH
+    flee: false
+  units:
+  - fullname: Archer ARC-2R
+    crew:
+      name: Eval Pilot S1
+      gunnery: 3
+      piloting: 4
+  - fullname: Marauder MAD-3R
+    crew:
+      name: Eval Pilot S2
+      gunnery: 3
+      piloting: 4
+  - fullname: Wolverine WVR-6R
+    crew:
+      name: Eval Pilot S3
+      gunnery: 3
+      piloting: 4
+  - fullname: Hunchback HBK-4G
+    crew:
+      name: Eval Pilot S4
+      gunnery: 3
+      piloting: 4
+
+end:
+- trigger:
+    type: battlefieldcontrol
+- trigger:
+    type: roundend
+    round: 15

--- a/data/scenarios/Evaluation/PrincessEval_Herding.mms
+++ b/data/scenarios/Evaluation/PrincessEval_Herding.mms
@@ -1,0 +1,147 @@
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+MMSVersion: 2
+name: Princess Evaluation - Herding
+description: >
+  Headless bot-vs-bot benchmark scenario for AIMatchRunner. Two identical slow, heavy companies with
+  default Princess behavior advance toward each other across an open grasslands map. This is the
+  configuration where herding-driven piecemeal attacks show up: watch for units trickling into contact
+  one at a time instead of committing as a body. The long east-west approach gives the closing dynamic
+  several rounds to express itself. The first faction is the unit-less watcher slot claimed by the
+  headless runner; the two bot factions mirror each other so before/after comparisons only measure
+  code changes.
+
+map: Grasslands BattleMats/32x17 Grasslands A BattleMat.board
+
+factions:
+- name: Observer
+  # Unit-less watcher slot; ScenarioGameRunner claims the first faction with a headless client.
+
+- name: West Company
+  deploy: W
+  bot:
+    # DEFAULT preset values written out; scenarios cannot reference named presets
+    selfpreservation: 5
+    fallshame: 5
+    hyperaggression: 5
+    herdmentality: 5
+    bravery: 5
+    forcedwithdraw: true
+    withdrawto: WEST
+    flee: false
+  units:
+  - fullname: Atlas AS7-D
+    crew:
+      name: Eval Pilot W1
+      gunnery: 4
+      piloting: 5
+  - fullname: Banshee BNC-3E
+    crew:
+      name: Eval Pilot W2
+      gunnery: 4
+      piloting: 5
+  - fullname: Stalker STK-3F
+    crew:
+      name: Eval Pilot W3
+      gunnery: 4
+      piloting: 5
+  - fullname: Awesome AWS-8Q
+    crew:
+      name: Eval Pilot W4
+      gunnery: 4
+      piloting: 5
+  - fullname: BattleMaster BLR-1G
+    crew:
+      name: Eval Pilot W5
+      gunnery: 4
+      piloting: 5
+  - fullname: Zeus ZEU-6S
+    crew:
+      name: Eval Pilot W6
+      gunnery: 4
+      piloting: 5
+  - fullname: Warhammer WHM-6R
+    crew:
+      name: Eval Pilot W7
+      gunnery: 4
+      piloting: 5
+  - fullname: Marauder MAD-3R
+    crew:
+      name: Eval Pilot W8
+      gunnery: 4
+      piloting: 5
+
+- name: East Company
+  deploy: "E"
+  bot:
+    selfpreservation: 5
+    fallshame: 5
+    hyperaggression: 5
+    herdmentality: 5
+    bravery: 5
+    forcedwithdraw: true
+    withdrawto: EAST
+    flee: false
+  units:
+  - fullname: Atlas AS7-D
+    crew:
+      name: Eval Pilot E1
+      gunnery: 4
+      piloting: 5
+  - fullname: Banshee BNC-3E
+    crew:
+      name: Eval Pilot E2
+      gunnery: 4
+      piloting: 5
+  - fullname: Stalker STK-3F
+    crew:
+      name: Eval Pilot E3
+      gunnery: 4
+      piloting: 5
+  - fullname: Awesome AWS-8Q
+    crew:
+      name: Eval Pilot E4
+      gunnery: 4
+      piloting: 5
+  - fullname: BattleMaster BLR-1G
+    crew:
+      name: Eval Pilot E5
+      gunnery: 4
+      piloting: 5
+  - fullname: Zeus ZEU-6S
+    crew:
+      name: Eval Pilot E6
+      gunnery: 4
+      piloting: 5
+  - fullname: Warhammer WHM-6R
+    crew:
+      name: Eval Pilot E7
+      gunnery: 4
+      piloting: 5
+  - fullname: Marauder MAD-3R
+    crew:
+      name: Eval Pilot E8
+      gunnery: 4
+      piloting: 5
+
+end:
+- trigger:
+    type: battlefieldcontrol
+- trigger:
+    type: roundend
+    round: 20

--- a/data/scenarios/Evaluation/PrincessEval_KickHeight.mms
+++ b/data/scenarios/Evaluation/PrincessEval_KickHeight.mms
@@ -1,0 +1,106 @@
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+MMSVersion: 2
+name: Princess Evaluation - Kick Height
+description: >
+  Headless bot-vs-bot benchmark scenario for AIMatchRunner. Two identical brawler lances with default
+  Princess behavior fight on rolling hills, where level changes make hit-table selection matter for
+  physical attacks. Intended to measure how often units end their move adjacent to and one level below
+  an enemy (exposing their head to kicks resolved on the punch table) and how many head and pilot hits
+  physical attacks inflict. The first faction is the unit-less watcher slot claimed by the headless
+  runner; the two bot factions mirror each other so before/after comparisons only measure code changes.
+
+map: Map Set 3/16x17 Rolling Hills 1.board
+
+factions:
+- name: Observer
+  # Unit-less watcher slot; ScenarioGameRunner claims the first faction with a headless client.
+
+- name: Hill Lance
+  deploy: N
+  bot:
+    # DEFAULT preset values written out; scenarios cannot reference named presets
+    selfpreservation: 5
+    fallshame: 5
+    hyperaggression: 5
+    herdmentality: 5
+    bravery: 5
+    forcedwithdraw: true
+    withdrawto: NORTH
+    flee: false
+  units:
+  - fullname: Atlas AS7-D
+    crew:
+      name: Eval Pilot N1
+      gunnery: 3
+      piloting: 4
+  - fullname: BattleMaster BLR-1G
+    crew:
+      name: Eval Pilot N2
+      gunnery: 3
+      piloting: 4
+  - fullname: Hunchback HBK-4G
+    crew:
+      name: Eval Pilot N3
+      gunnery: 3
+      piloting: 4
+  - fullname: Centurion CN9-A
+    crew:
+      name: Eval Pilot N4
+      gunnery: 3
+      piloting: 4
+
+- name: Valley Lance
+  deploy: S
+  bot:
+    selfpreservation: 5
+    fallshame: 5
+    hyperaggression: 5
+    herdmentality: 5
+    bravery: 5
+    forcedwithdraw: true
+    withdrawto: SOUTH
+    flee: false
+  units:
+  - fullname: Atlas AS7-D
+    crew:
+      name: Eval Pilot S1
+      gunnery: 3
+      piloting: 4
+  - fullname: BattleMaster BLR-1G
+    crew:
+      name: Eval Pilot S2
+      gunnery: 3
+      piloting: 4
+  - fullname: Hunchback HBK-4G
+    crew:
+      name: Eval Pilot S3
+      gunnery: 3
+      piloting: 4
+  - fullname: Centurion CN9-A
+    crew:
+      name: Eval Pilot S4
+      gunnery: 3
+      piloting: 4
+
+end:
+- trigger:
+    type: battlefieldcontrol
+- trigger:
+    type: roundend
+    round: 15


### PR DESCRIPTION
## Summary

Adds three benchmark scenarios for the headless AI match harness (companion to megamek PR MegaMek/megamek#8629). Each is a mirror match built for `AIMatchRunner` batches: identical Princess forces on both sides, so before/after comparisons of a bot change measure only the code, not force imbalance. They are the measurement scenarios for an upcoming series of Princess behavior fixes.

## Changes Made

- **Watcher slot**: each scenario's first faction is a unit-less `Observer` - the headless runner claims the first faction with a watcher client, the rest become bots.
- **Explicit behavior**: both bot factions carry the DEFAULT preset written out numerically (scenarios cannot reference named presets), with `forcedwithdraw` on and the withdrawal edge set to each side's own deployment edge.
- **Deterministic end**: every scenario has `battlefieldcontrol` plus a round-cap `end:` trigger.

## Files Changed

- `data/scenarios/Evaluation/PrincessEval_ForcedWithdrawal.mms` - NEW: 4v4 mixed lances, Map Set 2 "16x17 BattleTech", cap 15. Measures whether crippled units actually withdraw.
- `data/scenarios/Evaluation/PrincessEval_KickHeight.mms` - NEW: 4v4 brawlers, Map Set 3 "16x17 Rolling Hills 1", cap 15. Measures elevation-aware physical-attack behavior.
- `data/scenarios/Evaluation/PrincessEval_Herding.mms` - NEW: 8v8 slow heavies/assaults, 32x17 Grasslands A, east-west approach, cap 20. Measures herding-driven piecemeal commitment.

## Testing

- All three load and run headlessly via `gradlew aiMatch` against megamek PR MegaMek/megamek#8629 (single-game and 2-game parallel batches; standings and BV verified against the gamelog).
- Mirror symmetry checked: both sides report identical starting BV in the results CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
